### PR TITLE
fix: WindowsTerminal上でIMEを有効化しても半角英数のままになる問題に対するワークアラウンド

### DIFF
--- a/mozc/keymap.txt
+++ b/mozc/keymap.txt
@@ -11,7 +11,7 @@ Composition	Ctrl ,	IMEOff
 Conversion	Ctrl ,	IMEOff
 Prediction	Ctrl .	IMEOn
 DirectInput	Ctrl .	IMEOn
-Precomposition	Ctrl .	IMEOn
+Precomposition	Ctrl .	InputModeHiragana
 Composition	Ctrl .	ConvertToHiragana
 Conversion	Ctrl .	ConvertToHiragana
 Composition	Ctrl b	Backspace


### PR DESCRIPTION
[IME mode changed at startup in Google Japanese Input · microsoft/terminal](https://github.com/microsoft/terminal/issues/14407) という問題が存在しており、
[ターミナルとIMEについてのログ · cumet04/dotfiles](https://github.com/cumet04/dotfiles/issues/17) を参考にひらがな切り替えのショートカットを追加することで誤魔化しを考える。