### PR TITLE
feat: add starship config

### DIFF
--- a/unix/home/user/.config/starship.toml
+++ b/unix/home/user/.config/starship.toml
@@ -1,0 +1,12 @@
+[directory]
+truncation_length = 100
+truncate_to_repo = false
+
+[status]
+disabled = false
+format = '[\[$symbol $common_meaning $signal_name $int\]]($style) '
+
+[time]
+disabled = false
+format = "[$time]($style) "
+time_format = "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
<https://github.com/ncaq/.zsh.d/blob/805e8a2c7a6b21de393e7b65961508319dab3fa1/starship.toml> に置いていたが、
そこまでzshと強く結びついているわけではなく汎用的な設定であり、
デフォルトの位置で十分問題ないので移動。