### PR TITLE
fix!: do not use dnsmasq with NetworkManager

### DIFF
--- a/unix/etc/NetworkManager/NetworkManager.conf
+++ b/unix/etc/NetworkManager/NetworkManager.conf
@@ -1,2 +1,2 @@
 [main]
-dns=dnsmasq
+dns=none

--- a/unix/etc/NetworkManager/dnsmasq.d/dnsmasq.conf
+++ b/unix/etc/NetworkManager/dnsmasq.d/dnsmasq.conf
@@ -1,7 +1,0 @@
-# Cloudflareの公開DNSを指定。
-server=2606:4700:4700::1111
-server=1.1.1.1
-server=2606:4700:4700::1001
-server=1.0.0.1
-# cacheサイズを許される最大値に設定。
-cache-size=10000


### PR DESCRIPTION
NetworkManagerと競合しているのかソケットの作成が不安定になっているのでsystemd側に設定を倒す。
