### PR TITLE
fix: stackのデフォルトcopyright値をデフォルト値にする

### DIFF
--- a/unix/home/user/.stack/config.yaml
+++ b/unix/home/user/.stack/config.yaml
@@ -18,7 +18,6 @@ templates:
   params:
     author-email: ncaq@ncaq.net
     author-name: ncaq
-    copyright: © ncaq
     github-username: ncaq
     scm-init: git
 


### PR DESCRIPTION
デフォルト値は`{{year}} {{author-name}}`の形式になる。
year入れたくないとかせっかく専用に記号が用意されているから使いたいとか考えていたが、
ベルヌ条約的に書かなくて良いどうでも良い情報を頑張ってカスタムする必要はない。
