### PR TITLE
fix: yarnの`--cwd`オプションではなく実際に`cd`で移動する closed #33

### DIFF
--- a/git-hooks/commit-msg
+++ b/git-hooks/commit-msg
@@ -1,3 +1,7 @@
 #!/bin/bash
 set -eu
-yarn --cwd "$(dirname "$0")" commitlint --edit "$(realpath "${1}")"
+
+script_dir=$(dirname "$0")
+commit_editmsg_file="$(realpath "${1}")"
+cd "$script_dir"
+yarn commitlint --edit "$commit_editmsg_file"


### PR DESCRIPTION
yarnをそのプロジェクトで起動した時点でcorepackに副作用を発生させてしまい、
`package.json`に書き込みが発生してしまう。
よってその前に`cd`で移動するように変更。
