### PR TITLE
feat(.profile)!: `PATH`の設定でなるべく分岐しない

### DIFF
--- a/unix/home/user/.profile
+++ b/unix/home/user/.profile
@@ -14,10 +14,6 @@ if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
   source ~/.nix-profile/etc/profile.d/nix.sh
 fi
 
-if [[ -d $GOPATH ]]; then
-  PATH=$GOPATH/bin:$PATH
-fi
-
 if [[ -f ~/.ghcup/env ]]; then
   source ~/.ghcup/env
 fi
@@ -26,38 +22,11 @@ if [[ -f ~/.opam/opam-init/init.sh ]]; then
   source ~/.opam/opam-init/init.sh > /dev/null 2> /dev/null
 fi
 
-if [[ -d ~/.pyenv/ ]]; then
-  PATH=$HOME/.pyenv/shims:$HOME/.pyenv/bin:$PATH
-fi
-
-if [[ -x ~/.rbenv/bin/rbenv ]]; then
-  PATH=$HOME/.rbenv/bin:$PATH
-  eval "$(rbenv init - zsh)"
-fi
-
-if hash ruby 2>/dev/null; then
-  GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
-  export GEM_HOME
-  PATH=$GEM_HOME/bin:$PATH
-fi
-
 if [[ -f ~/.cargo/env ]]; then
   source ~/.cargo/env
 fi
 
-if [[ -d ~/.local/share/coursier/bin ]]; then
-  PATH=$HOME/.local/share/coursier/bin:$PATH
-fi
-
-if hash yarn 2>/dev/null && hash cygpath 2>/dev/null; then
-  # For example, in the case of Windows (like MSYS2), it may be in AppData, so it is necessary to inquire.
-  PATH=$(cygpath "$(yarn --offline global bin)"):$PATH
-else
-  # use linux standard yarn path.
-  PATH=$HOME/.yarn/bin:$PATH
-fi
-
-PATH=$HOME/.local/bin:$PATH
+PATH=~/.local/bin:$GOPATH/bin:~/.pyenv/shims:~/.pyenv/bin:~/.local/share/coursier/bin:~/.yarn/bin:$PATH
 export PATH
 
 # If the execution environment is not WSL, skip subsequent executions.


### PR DESCRIPTION
追加しても害にならないような`PATH`は分岐せず単純に追加してしまう。
多少は高速化されると思う。
Ruby関係に関しては今度Rubyを使うときに現代化する。
zshに依存しているコードを`.profile`に書くのに違和感があった。
MSYS2はWSL2が最近手っ取り早すぎるし、
yarn classicでグローバルにパッケージをインストールしたとしてもprettierぐらいなので、
別にPATH通さなくても良いかと判断した。
