### PR TITLE
fix(git-hooks): commitlintコマンドの実行方法を修正

### DIFF
--- a/git-hooks/commit-msg
+++ b/git-hooks/commit-msg
@@ -3,5 +3,4 @@ set -eu
 
 script_dir=$(dirname "$0")
 commit_editmsg_file="$(realpath "${1}")"
-cd "$script_dir"
-yarn commitlint --edit "$commit_editmsg_file"
+yarn --cwd "$script_dir" commitlint --edit "$commit_editmsg_file"


### PR DESCRIPTION
ディレクトリ移動による依存を排除し、
yarnの`--cwd`オプションを使用してプロセス内部だけワーキングディレクトリを指定するように変更しました。
