### PR TITLE
fix: home-manager default directory to dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use [home-manager](https://github.com/nix-community/home-manager).
 ## Update
 
 ``` zsh
-sudo nixos-rebuild switch --flake .#$(hostname)
+sudo nixos-rebuild switch --flake '.#$(hostname)'
 ```
 
 # Non NixOS System Setup
@@ -23,13 +23,13 @@ sudo nixos-rebuild switch --flake .#$(hostname)
 ## Initial
 
 ``` zsh
-nix run home-manager/master -- init --switch
+nix run home-manager/master -- --flake '.#ncaq' init --switch .
 ```
 
 ## Update
 
 ``` zsh
-home-manager switch --flake '.#ncaq'
+home-manager --flake '.#ncaq' switch
 ./install-legacy
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
               username:
               home-manager.lib.homeManagerConfiguration ({
                 pkgs = nixpkgs.legacyPackages.x86_64-linux;
-                modules = [ ./home ];
+                modules = [ ./home.nix ];
                 extraSpecialArgs = { inherit username; };
               });
           in
@@ -82,7 +82,7 @@
                     inherit inputs;
                     username = "ncaq";
                   };
-                  users.ncaq = import ./home;
+                  users.ncaq = import ./home.nix;
                 };
               }
             ];

--- a/home.nix
+++ b/home.nix
@@ -11,5 +11,5 @@
 
   programs.home-manager.enable = true;
 
-  imports = [ ./link.nix ] ++ import ./package { inherit builtins lib; };
+  imports = [ ./home/link.nix ] ++ import ./home/package { inherit builtins lib; };
 }


### PR DESCRIPTION
`~/.config/home-manager`に使われないディレクトリを生成してしまっていたのを修正。
