### PR TITLE
feat(nixos): enable `nix-ld`

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -22,6 +22,7 @@
 
   programs = {
     dconf.enable = true;
+    nix-ld.enable = true;
     zsh.enable = true;
   };
 


### PR DESCRIPTION
一応`nix-ld`で動いてしまって再現性が弱くなるという副作用があるらしいが、
流石にこれなしでは動かないプログラムが多すぎて、
いちいち全部flakeにするのは面倒すぎるので、
素直に有効にします。
