### PR TITLE
feat(package): add docker-client

### DIFF
--- a/home/package/docker.nix
+++ b/home/package/docker.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    docker-client
+  ];
+}


### PR DESCRIPTION
DockerがWindowsホスト側に入っていてもzshの補完ファイルなどが入らない。
