### PR TITLE
feat(xkeysnail): xkeysnailの導入とuinput設定の追加

### DIFF
--- a/home/package/xkeysnail.nix
+++ b/home/package/xkeysnail.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  home.packages = with pkgs; [
+    xkeysnail
+  ];
+
+  home.activation.cloneXkeysnailConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if [ ! -d "${config.home.homeDirectory}/.xkeysnail" ]; then
+      $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.xkeysnail.git "${config.home.homeDirectory}/.xkeysnail"
+    else
+      echo "Info: ${config.home.homeDirectory}/.xkeysnail already exists, skipping clone"
+    fi
+  '';
+
+  systemd.user.services.xkeysnail = {
+    Unit = {
+      Description = "xkeysnail";
+    };
+    Service = {
+      # デバイスが初期化される前に起動してエラーになることへのワークアラウンド。
+      ExecStartPre = "${pkgs.coreutils}/bin/sleep 1";
+      Restart = "on-failure";
+      ExecStart = "${pkgs.xkeysnail}/bin/xkeysnail --quiet %h/.xkeysnail/config.py";
+      Environment = [
+        "DISPLAY=:0"
+        "PATH=${pkgs.xkeysnail}/bin:${pkgs.python3}/bin"
+      ];
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -18,6 +18,7 @@
     isNormalUser = true;
     extraGroups = [
       "wheel"
+      "input"
     ];
     shell = pkgs.zsh;
   };
@@ -25,6 +26,7 @@
   imports = [
     ./nix-settings.nix
     ./locate.nix
+    ./uinput.nix
     ./unfree.nix
   ];
 }

--- a/nixos/uinput.nix
+++ b/nixos/uinput.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  # 主にxkeysnailが要求します。
+  services.udev.extraRules = ''
+    KERNEL=="uinput", GROUP="input"
+  '';
+}


### PR DESCRIPTION
xkeysnailをhome-managerパッケージとして追加し、設定リポジトリの自動クローンとsystemdサービスを作成。
uinputデバイスのパーミッション設定とinputグループへのユーザー追加も行い、xkeysnailの動作に必要な環境を整備。
