### PR TITLE
fix(cache): replace from `iohk.cachix.org` to `cache.iog.io`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,14 +119,14 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.nixos.org/"
+      "https://cache.iog.io"
       "https://nix-community.cachix.org"
-      "https://iohk.cachix.org"
       "https://ncaq-dotfiles.cachix.org"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo="
       "ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws="
     ];
   };

--- a/nixos/nix-settings.nix
+++ b/nixos/nix-settings.nix
@@ -7,13 +7,13 @@
     ];
     substituters = [
       "https://cache.nixos.org/"
+      "https://cache.iog.io"
       "https://nix-community.cachix.org"
-      "https://iohk.cachix.org"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo="
     ];
     cores = 0;
     max-jobs = "auto";


### PR DESCRIPTION
どちらも似たようなものらしいが、
`haskell.nix`の公式が推奨しているのは`cache.iog.io`の方らしい。
