### PR TITLE
feat(flake): add `cachix-push`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,27 @@
               shfmt.enable = true;
             };
           };
+          apps = {
+            cachix-push = {
+              type = "app";
+              program = pkgs.writeShellApplication {
+                name = "cachix-push";
+                runtimeInputs = with pkgs; [
+                  cachix
+                  jq
+                ];
+                text = ''
+                  echo "Push inputs"
+                  nix flake archive --json | jq -r '.path,(.inputs|to_entries[].value.path)' | cachix push ncaq-dotfiles
+                  echo "Push home-manager"
+                  nix build --print-out-paths '.#homeConfigurations.ncaq.activationPackage' | cachix push ncaq-dotfiles
+                  nix build --print-out-paths '.#homeConfigurations.GitHub-Actions.activationPackage' | cachix push ncaq-dotfiles
+                  echo "Push NixOS partical"
+                  nix build --print-out-paths '.#nixosConfigurations.SSD0086.config.system.build.toplevel' | cachix push ncaq-dotfiles
+                '';
+              };
+            };
+          };
           devShells.default = pkgs.mkShell { };
         };
     };


### PR DESCRIPTION
手動でキャッシュをアップロードするためのスクリプト。
`nix run '.#cachix-push'`
のように実行する。
GitHub Actionsが非力なので、
うっかりGHCのビルドなどが入るとタイムアウトしてしまう。
他にもラップトップPCなど今後非力なマシンが増えたときの備えになる。
