### PR TITLE
feat(python): python3をパッケージに追加しpyenvの有効化を削除

### DIFF
--- a/home/package/python.nix
+++ b/home/package/python.nix
@@ -2,7 +2,6 @@
 {
   programs = {
     poetry.enable = true;
-    pyenv.enable = true;
   };
 
   home.packages = with pkgs; [
@@ -10,5 +9,6 @@
     isort
     pipenv
     pyright
+    python3
   ];
 }


### PR DESCRIPTION
たしか否NixOSのhome-manager環境だとpyenvと衝突する。
しかしNixOSの環境だと逆にpython3を指定しないと入らない。
とりあえずpyenv最近使ってないし有効化を解除して明示的にpython3をPATHに入れる。
