### PR TITLE
perf: WSL環境判定とxrdb設定処理の高速化

### DIFF
--- a/home/linked/.profile
+++ b/home/linked/.profile
@@ -1,19 +1,16 @@
-# shellcheck disable=SC1090,SC1091
-
-if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
-  source ~/.nix-profile/etc/profile.d/nix.sh
-elif [ -e /etc/profile.d/nix.sh ]; then
-  source /etc/profile.d/nix.sh
-fi
-
 PATH="$HOME/.local/bin:$PATH"
 export PATH
 
-# If the execution environment is not WSL, skip subsequent executions.
-if [ ! -e "/proc/sys/kernel/osrelease" ] || ! grep -q "WSL" "/proc/sys/kernel/osrelease"; then
+if [ -r /proc/sys/kernel/osrelease ]; then
+  read -r _osrelease < /proc/sys/kernel/osrelease
+  case $_osrelease in
+    *Microsoft*|*WSL*) ;;  # WSL1/WSL2 をカバー
+    *) return ;;
+  esac
+else
   return
 fi
 
-if hash xrdb 2>/dev/null && [[ -f ~/.Xresources ]]; then
-  xrdb -merge ~/.Xresources
+if command -v xrdb >/dev/null 2>&1 && [ -f "$HOME/.Xresources" ]; then
+  xrdb -merge "$HOME/.Xresources"
 fi


### PR DESCRIPTION
おそらく互換性を壊さない範囲で高速化出来たはず。
非NixOS環境でも`.zshenv`とかに環境変数は展開されるので、
多分nix-profileをいちいち読み込まなくても良い。
