### PR TITLE
fix(nixos/locate): locateの除外パターンに"store"を追加

### DIFF
--- a/nixos/locate.nix
+++ b/nixos/locate.nix
@@ -50,6 +50,7 @@
       "node_modules"
       "site-packages"
       "steam-runtime"
+      "store"
       "target"
       "texmf-dist"
       "undo-tree"


### PR DESCRIPTION
`~/.local/state/cabal/store`が多すぎる。
