### PR TITLE
fix!: `x86_64-linux`以外をsystemsリストから削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,6 @@
       ];
 
       systems = [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "x86_64-darwin"
         "x86_64-linux"
       ];
 


### PR DESCRIPTION
`systems`に入れているからと言ってクロスコンパイラのセットアップとかしてないし、
ちゃんとテストされるわけでもない。
ハードコーディングしてる場所が複数ある。
こればっかりは実際に展開してみて動かしてみないとわからない。
必要ないのに警告が出てきて鬱陶しいので削除。
