### PR TITLE
feat: xorgの復旧用セッションを追加

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -17,6 +17,7 @@
     let
       coreImports = [
         ./core/dconf.nix
+        ./core/font.nix
         ./core/locate.nix
         ./core/nix-settings.nix
         ./core/uinput.nix

--- a/nixos/core/font.nix
+++ b/nixos/core/font.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+{
+  # Homeディレクトリが読み込めないような時でも日本語を表示するために、システム領域にもインストールする。
+  fonts.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-cjk-serif
+    noto-fonts-emoji
+  ];
+}

--- a/nixos/linux-native/xserver.nix
+++ b/nixos/linux-native/xserver.nix
@@ -1,22 +1,23 @@
-{ username, ... }:
+# 基本的にビルドした自分のxmonad-launchを使うが、トラブル時の復旧セッションも用意する。
+{ pkgs, username, ... }:
 {
   services = {
     xserver = {
       enable = true;
       displayManager = {
-        lightdm = {
-          enable = true;
-        };
+        lightdm.enable = true;
         session = [
           {
             manage = "desktop";
             name = "hm-xsession";
+            description = "home-manager側で設定した `.xsession` を起動する。";
             start = ''
               exec $HOME/.xsession
             '';
           }
         ];
       };
+      windowManager.icewm.enable = true;
       xkb = {
         layout = "us";
         model = "pc104";
@@ -33,4 +34,8 @@
     };
     libinput.enable = true;
   };
+  environment.systemPackages = with pkgs; [
+    rxvt-unicode
+    xterm
+  ];
 }


### PR DESCRIPTION
nixos/core/font.nixを新規作成し、Notoフォントをシステム領域にインストールすることで日本語表示を強化。
xserver設定にIceWM復旧セッションと端末(rxvt-unicode, xterm)を追加。
