### PR TITLE
fix(nixos): uinput設定を宣言的な形に変更してxkeysnailの動作を修正

### DIFF
--- a/nixos/core/uinput.nix
+++ b/nixos/core/uinput.nix
@@ -1,7 +1,5 @@
 { ... }:
 {
   # 主にxkeysnailが要求します。
-  services.udev.extraRules = ''
-    KERNEL=="uinput", GROUP="input"
-  '';
+  hardware.uinput.enable = true;
 }

--- a/nixos/core/user.nix
+++ b/nixos/core/user.nix
@@ -3,10 +3,11 @@
   users.users.${username} = {
     isNormalUser = true;
     extraGroups = [
-      "wheel"
-      "networkmanager"
       "input"
+      "networkmanager"
       "pipewire"
+      "uinput"
+      "wheel"
     ];
     shell = pkgs.zsh;
   };


### PR DESCRIPTION
既に宣言的な設定が存在したのでそれを使う。
デフォルトだと`/dev/uinput`は`uinput`グルーブに属すようになった。
`/dev/input/`以下のデバイスは`input`グループに属すため、
両方のgroupに所属する。
