### PR TITLE
fix: WSL環境判定に基づきwsl, xkeysnail, xmonadのインストール制御を追加

### DIFF
--- a/home/package/wsl.nix
+++ b/home/package/wsl.nix
@@ -1,5 +1,12 @@
-{ pkgs, ... }:
 {
+  pkgs,
+  lib,
+  isWSL,
+  ...
+}:
+# WSL関係のツールを普通のLinux環境にインストールしても、一見コンフリクトしなさそうに見えるが、
+# 実際使ってみるとGitHub CLIとかが検知して呼び出しを試みてしまう。
+lib.mkIf isWSL {
   home.packages = with pkgs; [
     wslu
   ];

--- a/home/package/xkeysnail.nix
+++ b/home/package/xkeysnail.nix
@@ -2,9 +2,10 @@
   config,
   pkgs,
   lib,
+  isWSL,
   ...
 }:
-{
+lib.mkIf (!isWSL) {
   home.packages = with pkgs; [
     xkeysnail
   ];

--- a/home/package/xmonad.nix
+++ b/home/package/xmonad.nix
@@ -1,5 +1,11 @@
-{ pkgs, dot-xmonad, ... }:
 {
+  pkgs,
+  lib,
+  isWSL,
+  dot-xmonad,
+  ...
+}:
+lib.mkIf (!isWSL) {
   xsession = {
     enable = true;
     windowManager.command = "xmonad-launch";


### PR DESCRIPTION
wsl関連ツールはWSL環境でのみインストールし、
xkeysnailやxmonadは非WSL環境でのみ有効化するように`lib.mkIf`で制御。
これにより環境ごとの不要なパッケージインストールや競合を防止。
