### PR TITLE
fix(kitty): NixOS以外の環境でも設定ファイルだけは有効にする

### DIFF
--- a/home/package/kitty.nix
+++ b/home/package/kitty.nix
@@ -1,8 +1,20 @@
-{ osConfig, ... }:
+{ pkgs, osConfig, ... }:
+let
+  kitty-wrapper = pkgs.writeShellScriptBin "kitty-wrapper" ''
+    if command -v kitty >/dev/null 2>&1; then
+      exec kitty "$@"
+    else
+      echo "kitty not found in system PATH. Please install kitty via your system package manager." >&2
+      exit 1
+    fi
+  '';
+in
 {
   programs.kitty = {
-    # 非NixOS環境だとOpenGLの問題があるため、NixOS環境でのみ有効化する。
-    enable = osConfig != null;
+    enable = true;
+
+    # 非NixOS環境だとOpenGLの問題があるため、システムのパッケージを使う。
+    package = if osConfig == null then kitty-wrapper else pkgs.kitty;
 
     settings = {
       font_size = 12;


### PR DESCRIPTION
NixGLとかの回避策とかは今使っているデバイスだけではなく様々なデバイスで使うことを考えるとあまりにも面倒。
今後そんなに真面目に使わない予定なので、雑な対応で済ませる。
