### PR TITLE
fix: `hostName`の設定がlinux-nativeだけになってしまっていたのを修正

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -19,6 +19,7 @@
         ./core/dconf.nix
         ./core/font.nix
         ./core/locate.nix
+        ./core/networking.nix
         ./core/nix-settings.nix
         ./core/sudo.nix
         ./core/uinput.nix
@@ -26,7 +27,7 @@
       ];
       linuxNativeImports = [
         ./linux-native/audio.nix
-        ./linux-native/network.nix
+        ./linux-native/networkmanager.nix
         ./linux-native/xserver.nix
       ];
     in

--- a/nixos/core/networking.nix
+++ b/nixos/core/networking.nix
@@ -2,6 +2,5 @@
 {
   networking = {
     inherit hostName;
-    networkmanager.enable = true;
   };
 }

--- a/nixos/linux-native/networkmanager.nix
+++ b/nixos/linux-native/networkmanager.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  networking.networkmanager.enable = true;
+}


### PR DESCRIPTION
`hostName`の設定はcoreでWSLでも行うように変更。
networkmanagerの設定はlinux-native側に分離して残す。
