### PR TITLE
style: substitutersおよびtrusted-public-keysの順序を調整

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -177,14 +177,14 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.nixos.org/"
-      "https://cache.iog.io"
       "https://nix-community.cachix.org"
+      "https://cache.iog.io"
       "https://ncaq-dotfiles.cachix.org"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws="
     ];
   };

--- a/nixos/core/nix-settings.nix
+++ b/nixos/core/nix-settings.nix
@@ -7,13 +7,13 @@
     ];
     substituters = [
       "https://cache.nixos.org"
-      "https://cache.iog.io"
       "https://nix-community.cachix.org"
+      "https://cache.iog.io"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
     cores = 0;
     max-jobs = "auto";


### PR DESCRIPTION
どうでも良いといえば本当にどうでも良いのだが、
nixのcommunityの全般サーバのほうがhaskell.nix関係限定より優先されるべきではある。
