### PR TITLE
fix(.profile): check for .Xresources before running xrdb -merge

### DIFF
--- a/home/linked/.profile
+++ b/home/linked/.profile
@@ -10,4 +10,6 @@ case "$(</proc/sys/kernel/osrelease 2>/dev/null)" in
   *) return ;;             # それ以外は .profile を抜ける
 esac
 
-xrdb -merge "$HOME/.Xresources"
+if [ -f "$HOME/.Xresources" ]; then
+  xrdb -merge "$HOME/.Xresources"
+fi


### PR DESCRIPTION
現状WSL2を動かすマシンは4Kディスプレイを使っている環境しか無いので、
これで問題になることはないが、
原理的にこれらは直行した概念のはずなので安全にする。
