### PR TITLE
feat(packages): add openssl

### DIFF
--- a/home/package/general.nix
+++ b/home/package/general.nix
@@ -18,6 +18,7 @@
     lsof
     nautilus
     nkf
+    openssl
     opusTools
     oxipng
     parallel


### PR DESCRIPTION
プロジェクトごとに追加するかは悩ましいところ。
プロジェクトで要求するのであれば当然依存関係に含めるべきだろうけど、
プロジェクトを作らずにサクっと試したいことも多いだろうし、
グローバルなdotfilesに追加する。
