### PR TITLE
fix(gtk): エラー解決方法がよく分からなくなったのでデフォルトにする

### DIFF
--- a/home/package/gtk.nix
+++ b/home/package/gtk.nix
@@ -1,24 +1,12 @@
-{ pkgs, ... }:
+{ ... }:
 {
   gtk = {
     enable = true;
 
-    theme = {
-      name = "Adwaita";
-      package = pkgs.adwaita-icon-theme;
-    };
-
-    iconTheme = {
-      name = "gnome";
-      package = pkgs.adwaita-icon-theme;
-    };
-
-    cursorTheme = {
-      name = "Adwaita";
-      package = pkgs.adwaita-icon-theme;
-    };
-
     gtk3.extraConfig = {
+      gtk-application-prefer-dark-theme = true;
+    };
+    gtk4.extraConfig = {
       gtk-application-prefer-dark-theme = true;
     };
   };


### PR DESCRIPTION
以下のエラーが大量発生していたのでとりあえずデフォルトに戻す。
```
7月 05 17:00:35 bullet .easyeffects-wr[157677]: Theme parser error: gtk.css:5:1-128: Failed to import: ファイル /nix/store/3ylavafjchc3sgisz1f2k16wrqlk95sy-adwaita-icon-theme-48.0/share/themes/Adwaita/gtk-4.0/gtk.css を開くときにエラーが発生しました: No such file or directory
```
別にGUIテーマにそんなにこだわりがあるわけではないのでデフォルトで良い。
ダークテーマさえある程度設定できていれば良い。
