### PR TITLE
fix(disk): tighten permissions on /boot/efi mount options

### DIFF
--- a/nixos/host/creep/disk.nix
+++ b/nixos/host/creep/disk.nix
@@ -6,7 +6,11 @@
     "/boot/efi" = {
       device = "/dev/disk/by-label/SYSTEM";
       fsType = "vfat";
-      options = [ "noatime" ];
+      options = [
+        "noatime"
+        "fmask=0077"
+        "dmask=0077"
+      ];
     };
     "/boot" = {
       device = "/dev/disk/by-label/nixos-boot";


### PR DESCRIPTION
systemd-bootが乱数の初期値をEFIシステムパーティションから読み込むため、
誰でも読み書きできるという警告を出していた。
まあ私は基本的にマシンの共有はしないので問題になることは少なかっただろうけど、
潰しておくに越したことはない。
