### PR TITLE
feat(claude): allow deepwiki mcp

### DIFF
--- a/home/linked/.config/claude/settings.json
+++ b/home/linked/.config/claude/settings.json
@@ -211,7 +211,10 @@
       "Bash(yarn lint:eslint)",
       "Bash(yarn lint:tsc)",
       "Bash(yarn prettier:*)",
-      "WebFetch"
+      "WebFetch",
+      "mcp__deepwiki__ask_question",
+      "mcp__deepwiki__read_wiki_contents",
+      "mcp__deepwiki__read_wiki_structure"
     ],
     "deny": ["Bash(git commit:*)", "Bash(rm:*)"]
   },


### PR DESCRIPTION
publicリポジトリの使い方を聞きまくるだけなので雑に全部許可する。
新しいdeepwiki MCPのメソッドで変なのが生えたら困るので、
あえてワイルドカードとかではなく列挙している。
