### PR TITLE
refactor: NixOSのモジュール形式にする

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -1,9 +1,8 @@
 {
-  lib,
   config,
   username,
   ...
-}@inputs:
+}:
 {
   home.username = username;
   home.homeDirectory = "/home/${config.home.username}";
@@ -11,5 +10,8 @@
 
   programs.home-manager.enable = true;
 
-  imports = [ ./link.nix ] ++ import ./package { inherit builtins lib inputs; };
+  imports = [
+    ./link.nix
+    ./package
+  ];
 }

--- a/home/package/default.nix
+++ b/home/package/default.nix
@@ -1,10 +1,13 @@
 # all re-export.
 { lib, ... }:
-let
-  nixFiles = builtins.readDir ./.;
-  moduleFiles = lib.filterAttrs (
-    name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
-  ) nixFiles;
-  modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
-in
-modules
+{
+  imports =
+    let
+      nixFiles = builtins.readDir ./.;
+      moduleFiles = lib.filterAttrs (
+        name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
+      ) nixFiles;
+      modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
+    in
+    modules;
+}

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,8 +1,4 @@
-{
-  lib,
-  inputs,
-  ...
-}:
+{ ... }:
 {
   system.stateVersion = "25.05";
 
@@ -16,5 +12,5 @@
     zsh.enable = true;
   };
 
-  imports = import ./core { inherit builtins lib inputs; };
+  imports = [ ./core ];
 }

--- a/nixos/core/default.nix
+++ b/nixos/core/default.nix
@@ -1,10 +1,13 @@
 # all re-export.
 { lib, ... }:
-let
-  nixFiles = builtins.readDir ./.;
-  moduleFiles = lib.filterAttrs (
-    name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
-  ) nixFiles;
-  modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
-in
-modules
+{
+  imports =
+    let
+      nixFiles = builtins.readDir ./.;
+      moduleFiles = lib.filterAttrs (
+        name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
+      ) nixFiles;
+      modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
+    in
+    modules;
+}

--- a/nixos/native-linux/default.nix
+++ b/nixos/native-linux/default.nix
@@ -1,10 +1,13 @@
 # all re-export.
 { lib, ... }:
-let
-  nixFiles = builtins.readDir ./.;
-  moduleFiles = lib.filterAttrs (
-    name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
-  ) nixFiles;
-  modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
-in
-modules
+{
+  imports =
+    let
+      nixFiles = builtins.readDir ./.;
+      moduleFiles = lib.filterAttrs (
+        name: type: type == "regular" && lib.hasSuffix ".nix" name && name != "default.nix"
+      ) nixFiles;
+      modules = lib.mapAttrsToList (name: _: ./${name}) moduleFiles;
+    in
+    modules;
+}


### PR DESCRIPTION
いちいち呼び出し側で`import`を実行しなくて良いようにする。
