### PR TITLE
fix(nixos): add native-linux import to creep and vanitas hosts

### DIFF
--- a/nixos/host/creep.nix
+++ b/nixos/host/creep.nix
@@ -1,6 +1,8 @@
 { nixos-hardware, ... }:
 {
   imports = [
+    ../native-linux
+
     nixos-hardware.nixosModules.lenovo-thinkpad-p16s-amd-gen2
 
     ./creep/disk.nix

--- a/nixos/host/vanitas.nix
+++ b/nixos/host/vanitas.nix
@@ -1,7 +1,11 @@
 { ... }:
 {
   # VirtualBoxのゲストOSを想定。
-  imports = [ ./vanitas/disk.nix ];
+  imports = [
+    ../native-linux
+
+    ./vanitas/disk.nix
+  ];
   # 普通の環境はEFIが有効だと思うので予行演習としてVirtualBoxのEFIサポートを有効にしている。
   boot = {
     loader = {


### PR DESCRIPTION
`isWSL`の整理をしてた時にWSLじゃない方の処理を忘れていた。
