### PR TITLE
feat(backlight): AC接続時は画面を暗くするのを無効化する

### DIFF
--- a/nixos/laptop/backlight.nix
+++ b/nixos/laptop/backlight.nix
@@ -1,5 +1,19 @@
 { ... }:
 {
   location.provider = "geoclue2";
-  services.clight.enable = true;
+  services.clight = {
+    enable = true;
+    settings = {
+      dimmer = {
+        # 無操作時に画面を暗くするまでの時間。
+        ac_timeouts = [ ]; # AC電源時: 暗転しない
+        batt_timeouts = [ (5 * 60) ]; # バッテリー時: 5分
+      };
+      dpms = {
+        # 無操作時に画面の電源を切るまでの時間。
+        ac_timeouts = [ (2 * 60 * 60) ]; # AC電源時: 2時間
+        batt_timeouts = [ (10 * 60) ]; # バッテリー時: 10分
+      };
+    };
+  };
 }


### PR DESCRIPTION
今のところ液晶しか管理してないからこれで良い。
OLEDも管理するようになったら、
AC接続時も適切に暗くしたほうが良いのかも。
その場合はxmonad側にあるDPMSの設定も含めて考え直す必要があるだろう。
