### PR TITLE
feat: 別ディスクのWindows起動設定

### DIFF
--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -24,6 +24,20 @@
         enable = true;
         consoleMode = "auto";
         xbootldrMountPoint = "/boot";
+        edk2-uefi-shell.enable = true;
+        # 仕事用Windowsを最上位に表示し、上キーで移動できるようにする。
+        windows = {
+          "work" = {
+            title = "Windows 11 Work";
+            efiDeviceHandle = "HD0b";
+            sortKey = "a_windows_work";
+          };
+          "game" = {
+            title = "Windows 11 Game";
+            efiDeviceHandle = "HD1b";
+            sortKey = "b_windows_game";
+          };
+        };
       };
     };
   };


### PR DESCRIPTION
上の方に置いてデフォルトはNixOS。
saved defaultについてはまだPRが議論中らしいので諦める。
[nixos/systemd-boot: Add rememberLastChoice option. by noar-t · Pull Request #286672 · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/pull/286672)
