### PR TITLE
fix(nix-settings): remove iog cache from global settings

### DIFF
--- a/nixos/core/nix-settings.nix
+++ b/nixos/core/nix-settings.nix
@@ -8,12 +8,10 @@
     substituters = [
       "https://cache.nixos.org"
       "https://nix-community.cachix.org"
-      "https://cache.iog.io"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
     ];
     cores = 0;
     max-jobs = "auto";


### PR DESCRIPTION
`https://cache.iog.io`はあくまでHaskellプロジェクト用のキャッシュなので、
グローバルに乱用するのは適切ではないなと感じたため削除します。
それぞれのプロジェクトで設定するべき。
