### PR TITLE
fix(bullet): systemd-bootからgrubに変更

### DIFF
--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -20,24 +20,26 @@
         efiSysMountPoint = "/efi";
       };
       timeout = 1;
-      systemd-boot = {
+      grub = {
         enable = true;
-        consoleMode = "auto";
-        xbootldrMountPoint = "/boot";
-        edk2-uefi-shell.enable = true;
-        # 仕事用Windowsを最上位に表示し、上キーで移動できるようにする。
-        windows = {
-          "work" = {
-            title = "Windows 11 Work";
-            efiDeviceHandle = "HD0b";
-            sortKey = "a_windows_work";
-          };
-          "game" = {
-            title = "Windows 11 Game";
-            efiDeviceHandle = "HD1b";
-            sortKey = "b_windows_game";
-          };
-        };
+        device = "nodev";
+        efiSupport = true;
+        extraEntries = ''
+          menuentry "Windows Game" {
+            insmod part_gpt
+            insmod fat
+            insmod chain
+            set root='hd0,gpt1'
+            chainloader /efi/Microsoft/Boot/bootmgfw.efi
+          }
+          menuentry "Windows Work" {
+            insmod part_gpt
+            insmod fat
+            insmod chain
+            set root='hd1,gpt1'
+            chainloader /efi/Microsoft/Boot/bootmgfw.efi
+          }
+        '';
       };
     };
   };


### PR DESCRIPTION
close #226
BitLockerの回復キーが毎回要求されないようにする。
一度`boot.loader.systemd-boot.rebootForBitlocker`で解決を試みたが、
これは同じEFIパーティションを利用している場合しか効果がないらしい。
元々はgrubを使っていたので戻ることにあまり抵抗はない。
