### PR TITLE
fix(xdg): use optionalAttrs instead of mkIf for WSL-specific config

### DIFF
--- a/home/package/xdg.nix
+++ b/home/package/xdg.nix
@@ -35,7 +35,7 @@ in
         source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/GoogleDrive/Pictures";
       };
     }
-    // lib.mkIf isWSL {
+    // lib.optionalAttrs isWSL {
       # WindowsのHDD側を参照。
       "Videos" = {
         source = config.lib.file.mkOutOfStoreSymlink "/mnt/d/Videos/";


### PR DESCRIPTION
WSLでない環境で`Pictures`が作られなくなっていた。
`mkIf`を単純なレコード操作に使うのは適切ではない。
