### PR TITLE
feat(bullet): set bootloader default entry to saved state

### DIFF
--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -25,6 +25,7 @@
         device = "nodev";
         efiSupport = true;
         gfxmodeEfi = "1024x768";
+        default = "saved";
         extraEntries = ''
           menuentry "Windows Game" {
             insmod part_gpt


### PR DESCRIPTION
いちいち選ばなくて良いようにする。
