### PR TITLE
fix(bullet): use `search_fs_uuid` for Windows boot entries

### DIFF
--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -28,18 +28,22 @@
         default = "saved";
         extraEntries = ''
           menuentry "Windows Game" {
+            savedefault
             insmod part_gpt
             insmod fat
+            insmod search_fs_uuid
             insmod chain
-            set root='hd0,gpt1'
-            chainloader /efi/Microsoft/Boot/bootmgfw.efi
+            search --fs-uuid --set=root 8E7A-6494
+            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
           }
           menuentry "Windows Work" {
+            savedefault
             insmod part_gpt
             insmod fat
+            insmod search_fs_uuid
             insmod chain
-            set root='hd1,gpt1'
-            chainloader /efi/Microsoft/Boot/bootmgfw.efi
+            search --fs-uuid --set=root CE5B-C127
+            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
           }
         '';
       };


### PR DESCRIPTION
変動するけど仕方ないかと思って番号指定にしていたが、
案の定マザーボードを変更したら変動があり起動しなくなった。
調べ直したらこのようにUUID指定が出来るっぽいのでUUIDで検索して設定します。
ついでに`savedefault`が必要なのにつけていなかったのも修正。
それとLLMの生成で出てきたコードで`EFI`ディレクトリが大文字になっていたので、
調べてみたら`EFI`ディレクトリは動作する時は区別しないけど、
一応データとしては大文字で保存されていることが多いみたいなので、
大文字で指定します。
