### PR TITLE
fix(flake): set isWSL to false in nixosConfigurations options

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,7 @@
                     config.allowUnfree = true;
                   };
                   dpi = 144;
+                  isWSL = false;
                 };
                 modules = [
                   (


### PR DESCRIPTION
`isWSL`の未指定でNixOSではないhome-managerだけ使っている環境のビルドが失敗する問題を修正。 本当は`isWSL`はちゃんと考えないといけないのですが、
現在非NixOSのWSL環境がないので雑に`false`にしておきます。
そもそも非NixOSで運用している環境すらない。
なので後でhome-managerのみの環境が生えてきたらその時に色々考えます。