### PR TITLE
refactor(boot-module): move boot config to per-host boot.nix modules

### DIFF
--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -12,44 +12,9 @@
     nixos-hardware.nixosModules.common-pc
     nixos-hardware.nixosModules.common-pc-ssd
 
+    ./bullet/boot.nix
     ./bullet/disk.nix
     ./bullet/hardware-configuration.nix
   ];
-  boot = {
-    loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
-      grub = {
-        enable = true;
-        device = "nodev";
-        efiSupport = true;
-        gfxmodeEfi = "1024x768";
-        default = "saved";
-        extraEntries = ''
-          menuentry "Windows Game" {
-            savedefault
-            insmod part_gpt
-            insmod fat
-            insmod search_fs_uuid
-            insmod chain
-            search --fs-uuid --set=root 8E7A-6494
-            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
-          }
-          menuentry "Windows Work" {
-            savedefault
-            insmod part_gpt
-            insmod fat
-            insmod search_fs_uuid
-            insmod chain
-            search --fs-uuid --set=root CE5B-C127
-            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
-          }
-        '';
-      };
-    };
-  };
   hardware.nvidia.open = true;
 }

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -1,0 +1,38 @@
+{
+  boot = {
+    loader = {
+      efi = {
+        canTouchEfiVariables = true;
+        efiSysMountPoint = "/efi";
+      };
+      timeout = 1;
+      grub = {
+        enable = true;
+        device = "nodev";
+        efiSupport = true;
+        gfxmodeEfi = "1024x768";
+        default = "saved";
+        extraEntries = ''
+          menuentry "Windows Game" {
+            savedefault
+            insmod part_gpt
+            insmod fat
+            insmod search_fs_uuid
+            insmod chain
+            search --fs-uuid --set=root 8E7A-6494
+            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
+          }
+          menuentry "Windows Work" {
+            savedefault
+            insmod part_gpt
+            insmod fat
+            insmod search_fs_uuid
+            insmod chain
+            search --fs-uuid --set=root CE5B-C127
+            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
+          }
+        '';
+      };
+    };
+  };
+}

--- a/nixos/host/creep.nix
+++ b/nixos/host/creep.nix
@@ -7,29 +7,8 @@
 
     nixos-hardware.nixosModules.lenovo-thinkpad-p16s-amd-gen2
 
+    ./creep/boot.nix
     ./creep/disk.nix
     ./creep/hardware-configuration.nix
   ];
-  boot = {
-    loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
-      systemd-boot = {
-        enable = true;
-        consoleMode = "auto";
-        xbootldrMountPoint = "/boot";
-      };
-    };
-    initrd = {
-      luks.devices = {
-        nixos-root = {
-          device = "/dev/disk/by-label/nixos-root-crypt";
-          allowDiscards = true;
-        };
-      };
-    };
-  };
 }

--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -1,0 +1,24 @@
+{
+  boot = {
+    loader = {
+      efi = {
+        canTouchEfiVariables = true;
+        efiSysMountPoint = "/efi";
+      };
+      timeout = 1;
+      systemd-boot = {
+        enable = true;
+        consoleMode = "auto";
+        xbootldrMountPoint = "/boot";
+      };
+    };
+    initrd = {
+      luks.devices = {
+        nixos-root = {
+          device = "/dev/disk/by-label/nixos-root-crypt";
+          allowDiscards = true;
+        };
+      };
+    };
+  };
+}

--- a/nixos/host/vanitas.nix
+++ b/nixos/host/vanitas.nix
@@ -4,22 +4,8 @@
   imports = [
     ../native-linux
 
+    ./vanitas/boot.nix
     ./vanitas/disk.nix
   ];
-  # 普通の環境はEFIが有効だと思うので予行演習としてVirtualBoxのEFIサポートを有効にしている。
-  boot = {
-    loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
-      systemd-boot = {
-        enable = true;
-        consoleMode = "auto";
-        xbootldrMountPoint = "/boot";
-      };
-    };
-  };
   virtualisation.virtualbox.guest.enable = true;
 }

--- a/nixos/host/vanitas/boot.nix
+++ b/nixos/host/vanitas/boot.nix
@@ -1,0 +1,16 @@
+{
+  boot = {
+    loader = {
+      efi = {
+        canTouchEfiVariables = true;
+        efiSysMountPoint = "/efi";
+      };
+      timeout = 1;
+      systemd-boot = {
+        enable = true;
+        consoleMode = "auto";
+        xbootldrMountPoint = "/boot";
+      };
+    };
+  };
+}


### PR DESCRIPTION
- Extract boot configuration from bullet.nix, creep.nix, and vanitas.nix
- Add nixos/host/{bullet,creep,vanitas}/boot.nix for host-specific boot settings
- Update host modules to import new boot.nix files for improved modularity
