### PR TITLE
feat(disk): add mountpoint to noa

### DIFF
--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -134,6 +134,7 @@
                 passwordFile = "/tmp/secret.password";
                 content = {
                   type = "btrfs";
+                  mountpoint = "/mnt/noa";
                   extraArgs = [
                     "-d raid1"
                     "/dev/mapper/noa0"


### PR DESCRIPTION
利用用途ごとにサブボリュームを作成する方法と、
単純に一つのマウントポイントを用意してディレクトリを分ける方法の2つを検討しました。
パーティションと違ってサブボリュームは容量は柔軟に扱えますが、
一つ一つフォーマットして変更する必要があるので、
ほかを巻き添えにして消してしまうリスクがそれなりにありそうなので、
単純に移植性も高いディレクトリを単純に分ける方法を選びました。
