### PR TITLE
fix(grobi): fallbackとしてモバイルシングルモニタを定義

### DIFF
--- a/home/package/grobi.nix
+++ b/home/package/grobi.nix
@@ -44,6 +44,10 @@
           "echo 'Xft.dpi: 144'|${pkgs.xorg.xrdb}/bin/xrdb -merge"
         ];
       }
+      {
+        name = "eDP-1";
+        configure_single = "eDP-1";
+      }
     ];
   };
 }


### PR DESCRIPTION
ラップトップのシングルモニタで画面が映らない問題を修正
