### PR TITLE
Revert "fix: claude-desktop.nixを削除"

### DIFF
--- a/home/package/claude-desktop.nix
+++ b/home/package/claude-desktop.nix
@@ -1,0 +1,12 @@
+{
+  pkgs,
+  lib,
+  isWSL,
+  claude-desktop,
+  ...
+}:
+lib.mkIf (!isWSL) {
+  home.packages = [
+    claude-desktop.packages.${pkgs.system}.claude-desktop-with-fhs
+  ];
+}


### PR DESCRIPTION
Reverts ncaq/dotfiles#298
解決されたため。
[Update claude-desktop sha256 by eval-exec · Pull Request #64 · k3d3/claude-desktop-linux-flake](https://github.com/k3d3/claude-desktop-linux-flake/pull/64)