### PR TITLE
fix(nixos): tailscaleのビルド失敗を回避するため一部テストをスキップ

### DIFF
--- a/nixos/host/seminar/vpn.nix
+++ b/nixos/host/seminar/vpn.nix
@@ -1,8 +1,18 @@
-{ ... }:
+{ pkgs, lib, ... }:
 {
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "server"; # Exit Nodeとして動作
+    # [tailscale: Build failure with portlist tests on NixOS 25.05 - "seek /proc/net/tcp: illegal seek" · Issue #438765 · NixOS/nixpkgs](https://github.com/nixos/nixpkgs/issues/438765)
+    package = pkgs.tailscale.overrideAttrs (old: {
+      checkFlags = builtins.map (
+        flag:
+        if lib.hasPrefix "-skip=" flag then
+          flag + "|^TestGetList$|^TestIgnoreLocallyBoundPorts$|^TestPoller$"
+        else
+          flag
+      ) old.checkFlags;
+    });
   };
   # Exit Nodeとして動作するために転送を許可。
   boot.kernel.sysctl = {


### PR DESCRIPTION
NixOS 25.05環境において、tailscaleのビルドが "seek /proc/net/tcp: illegal seek" エラーで失敗する問題に対応します。
nixpkgsで問題が修正されるまでの一時的な措置として、`overrideAttrs` を用いて失敗するテストを無効化します。

Refs: https://github.com/nixos/nixpkgs/issues/438765
