### PR TITLE
feat(cache): add Attic nix cache support

### DIFF
--- a/home/package/general.nix
+++ b/home/package/general.nix
@@ -3,6 +3,7 @@
   home.packages = with pkgs; [
     android-tools
     atop
+    attic-client
     bcache-tools
     cachix
     cryptsetup

--- a/nixos/host/seminar/attic.nix
+++ b/nixos/host/seminar/attic.nix
@@ -12,7 +12,7 @@
     settings = {
       listen = "[::]:10000"; # ポート番号は雑に定めました。深く考えていません。
       allowed-hosts = [ "nix-cache.ncaq.net" ];
-      api-endpoint = "https://nix-cache.ncaq.net";
+      api-endpoint = "https://nix-cache.ncaq.net/";
       database.url = "postgresql:///atticd?host=/run/postgresql";
       storage = {
         type = "local";

--- a/nixos/host/seminar/attic.nix
+++ b/nixos/host/seminar/attic.nix
@@ -52,6 +52,6 @@
   # ```
   # トークンを利用してログインする。
   # ```
-  # attic login ncaq https://nix-cache.ncaq.net "$TOKEN"
+  # attic login ncaq https://nix-cache.ncaq.net/ "$TOKEN"
   # ```
 }

--- a/nixos/host/seminar/attic.nix
+++ b/nixos/host/seminar/attic.nix
@@ -7,6 +7,7 @@
     # openssl genrsa -traditional 4096|base64 -w0|sudo tee -a /etc/atticd.env
     # echo '"'|sudo tee -a /etc/atticd.env
     # sudo chown atticd: /etc/atticd.env && sudo chmod 640 /etc/atticd.env
+    # sudo systemctl restart atticd
     # ```
     environmentFile = "/etc/atticd.env";
     settings = {

--- a/nixos/host/seminar/attic.nix
+++ b/nixos/host/seminar/attic.nix
@@ -1,0 +1,58 @@
+{ username, ... }:
+{
+  services.atticd = {
+    enable = true;
+    # ```
+    # echo -n 'ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64="'|sudo tee /etc/atticd.env
+    # openssl genrsa -traditional 4096|base64 -w0|sudo tee -a /etc/atticd.env
+    # echo '"'|sudo tee -a /etc/atticd.env
+    # sudo chown atticd: /etc/atticd.env && sudo chmod 640 /etc/atticd.env
+    # ```
+    environmentFile = "/etc/atticd.env";
+    settings = {
+      listen = "[::]:10000"; # ポート番号は雑に定めました。深く考えていません。
+      allowed-hosts = [ "nix-cache.ncaq.net" ];
+      api-endpoint = "https://nix-cache.ncaq.net";
+      database.url = "postgresql:///atticd?host=/run/postgresql";
+      storage = {
+        type = "local";
+        path = "/mnt/noa/atticd";
+      };
+      # chunkingはNixの設定でデフォルトが定まっているので任せます。
+
+      # compressionはbtrfsがバックエンドであることを考えると、
+      # むしろ明示的に無効にしておいたほうがストレージ効率は良いですが、
+      # ネットワーク通信のことを考えると有効にしておいたほうが良いかもしれません。
+      # デフォルト値に任せます。
+
+      # ガベージコレクションはデフォルトに近い緩めの値を設定しておきます。
+      garbage-collection = {
+        interval = "1 day";
+        default-retention-period = "6 months";
+      };
+    };
+  };
+  users.users.atticd = {
+    isSystemUser = true;
+    group = "atticd";
+  };
+  users.groups.atticd = {
+    members = [ username ];
+  };
+  systemd.tmpfiles.rules = [
+    "d /mnt/noa/atticd 0755 atticd atticd -"
+  ];
+  # 管理トークン発行例。
+  # ```
+  # sudo atticd-atticadm make-token --sub 'seminar' --validity '4y' --pull 'private' --push 'private' --create-cache 'private'
+  # ```
+  # 読み書きトークン発行例。
+  # ```
+  # sudo atticd-atticadm make-token --sub 'bullet' --validity '4y' --pull 'private' --push 'private'
+  # ```
+  # トークンを利用してログインする。
+  # 最初にスペースを入れてシェルの履歴に残らないようにすること。
+  # ```
+  # attic login ncaq https://nix-cache.ncaq.net <token>
+  # ```
+}

--- a/nixos/host/seminar/attic.nix
+++ b/nixos/host/seminar/attic.nix
@@ -44,15 +44,14 @@
   ];
   # 管理トークン発行例。
   # ```
-  # sudo atticd-atticadm make-token --sub 'seminar' --validity '4y' --pull 'private' --push 'private' --create-cache 'private'
+  # TOKEN="$(sudo atticd-atticadm make-token --sub 'seminar' --validity '4y' --pull 'private' --push 'private' --create-cache 'private')"
   # ```
   # 読み書きトークン発行例。
   # ```
-  # sudo atticd-atticadm make-token --sub 'bullet' --validity '4y' --pull 'private' --push 'private'
+  # TOKEN=$(sudo atticd-atticadm make-token --sub 'bullet' --validity '4y' --pull 'private' --push 'private')
   # ```
   # トークンを利用してログインする。
-  # 最初にスペースを入れてシェルの履歴に残らないようにすること。
   # ```
-  # attic login ncaq https://nix-cache.ncaq.net <token>
+  # attic login ncaq https://nix-cache.ncaq.net "$TOKEN"
   # ```
 }

--- a/nixos/host/seminar/cloudflare.nix
+++ b/nixos/host/seminar/cloudflare.nix
@@ -1,4 +1,21 @@
-{ username, ... }:
+{
+  pkgs,
+  username,
+  ...
+}:
+let
+  # workaround script that adds --protocol http2 flag to tunnel command.
+  cloudflaredWrapper = pkgs.writeShellScriptBin "cloudflared" ''
+    # Check if this is a tunnel command
+    if [[ "$1" == "tunnel" ]]; then
+      # Insert --protocol http2 before other tunnel arguments
+      exec ${pkgs.cloudflared}/bin/cloudflared "$@" --protocol http2
+    else
+      # For non-tunnel commands, pass through as-is
+      exec ${pkgs.cloudflared}/bin/cloudflared "$@"
+    fi
+  '';
+in
 {
   # To initialize, run in server:
   # ```
@@ -7,6 +24,7 @@
   # copy credentialsFile from terraform client to server.
   services.cloudflared = {
     enable = true;
+    package = cloudflaredWrapper;
     certificateFile = "/home/${username}/.cloudflared/cert.pem";
     tunnels.seminar = {
       default = "http_status:404";

--- a/nixos/host/seminar/cloudflare.nix
+++ b/nixos/host/seminar/cloudflare.nix
@@ -12,7 +12,7 @@
       default = "http_status:404";
       credentialsFile = "/home/${username}/.cloudflared/tunnel-seminar.json";
       ingress = {
-        "seminar.ncaq.net" = "http://localhost:80";
+        "nix-cache.ncaq.net" = "http://localhost:10000";
       };
     };
   };

--- a/nixos/host/seminar/postgresql.nix
+++ b/nixos/host/seminar/postgresql.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  services.postgresql = {
+    # 雑に使えるサーバグローバルのPostgreSQLサーバを有効にしておきます。
+    enable = true;
+    # PostgreSQLのバージョンによって`dataDir`などが変更されます。
+    # `stateVersion`依存でPostgreSQLのバージョンは定まります。
+    # しかし忘れて全体をアップデートして壊れたりするのが嫌なので明示的に指定しておきます。
+    # JITコンパイラは必要かわかりませんが、単純なクエリには使われないらしくデメリットが薄いそうなので、雑に有効にしておきます。
+    package = pkgs.postgresql_17_jit;
+    # サービス側で追加する方が良いかもしれませんが、
+    # ここでデータベース一覧をまとめるメリットもあるのでこちらでの定義を選択します。
+    ensureDatabases = [ "atticd" ];
+    ensureUsers = [
+      {
+        name = "atticd";
+        ensureDBOwnership = true;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
close #271

現在通信エラーが発生しており利用できない。

```
2025-09-07T10:52:24 on  attic [$] via ❄️  impure (nix-shell-env) took 3s 
ncaq@🌐 seminar:~/dotfiles ❯ attic push private $(which attic)
⚙️ Pushing 22 paths to "private" on "ncaq" (6 already cached, 24 in upstream)...
❌ 3kflp5w1s1jl5qkb6hjxj0wp46zic9si-lowdown-1.3.2-lib: RequestError: General request error: Bad NAR Hash or Size
❌ y4rgi4qlyqx34r4hypic6sfxd3y0hppq-libssh2-1.11.1: RequestError: General request error: Bad NAR Hash or Size
❌ 16hvpw4b3r05girazh4rnwbw0jgjkb4l-xgcc-14.3.0-libgcc: RequestError: General request error: Bad NAR Hash or Size
❌ cfqbabpc7xwg8akbcchqbq3cai6qq2vs-bash-5.2p37: RequestError: General request error: Bad NAR Hash or Size
❌ 4j6p91af1bfgnn31agg1c9ijr0kyg6gi-gcc-14.3.0-libgcc: RequestError: General request error: Bad NAR Hash or Size
❌ nkqpb1fl6kach9rr3xpbnaahp6frkpa4-nghttp2-1.65.0-lib: RequestError: General request error: Bad NAR Hash or Size
❌ adh72qn1r2c4nflkgkv3sdv7aag0p9z5-openssl-3.4.2: RequestError: General request error: Bad NAR Hash or Size
❌ gaaqqkh7pvr85vh2vdclw8z2m4w1lq8q-libsodium-1.0.20: RequestError: General request error: Bad NAR Hash or Size
❌ pkpsla02cnwk0c0951k7rcf4jalah314-krb5-1.21.3-lib: RequestError: General request error: Bad NAR Hash or Size
❌ ws2lrig1jwpyz527vdd4cs4i5mii1c71-libseccomp-2.6.0-lib: error sending request for url (https://nix-cache.ncaq.net/_api/v1/upload-path)
❌ 2gy6zfny7faa36r1jcar3dd1y76w9hsi-publicsuffix-list-0-unstable-2025-03-12: RequestError: General request error: Bad NAR Hash or Size
❌ cbwbz05v2iqhn2d1w118y1rw97cqimjf-busybox-1.36.1: RequestError: General request error: Bad NAR Hash or Size
❌ g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66: RequestError: General request error: Bad NAR Hash or Size
❌ hsvfkb7winxmnlhj7fxh7vy7nc50727k-libcpuid-0.7.1: RequestError: General request error: Bad NAR Hash or Size
❌ 7r0k7ywzmgkscjxgzmgwsng0545h8id6-libunistring-1.3: RequestError: General request error: Bad NAR Hash or Size
❌ ahw6fr4wihcyq1rbx9ivi4qv6zmn10gg-zstd-1.5.7: error sending request for url (https://nix-cache.ncaq.net/_api/v1/upload-path)
❌ 2q1vszdygbs1icp1cd18a4d11zcsc97y-libidn2-2.3.8: RequestError: General request error: Bad NAR Hash or Size
❌ 5x9nmn51cszisf3gr829z2yq8y4hrnra-pcre2-10.44: RequestError: General request error: Bad NAR Hash or Size
❌ 6h1mjkhy5rmg1zqwfqlqqrymi67kkr2q-xz-5.8.1: RequestError: General request error: Bad NAR Hash or Size
❌ 7wfb0gvrjbiss5sk5i95z9b3wv87wkhb-sqlite-3.48.0: RequestError: General request error: Bad NAR Hash or Size
❌ mrbslgynzhg5jfc05x2rlnsykzcxp2v0-boehm-gc-8.2.8: RequestError: General request error: Bad NAR Hash or Size
❌ dj06r96j515npcqi9d8af1d1c60bx2vn-gcc-14.3.0-lib: RequestError: General request error: Bad NAR Hash or Size
Error: RequestError: General request error: Bad NAR Hash or Size
```