### PR TITLE
docs(bcache): make-bcacheコマンド例に--writebackと--discardを追加

### DIFF
--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -84,11 +84,11 @@
       # # diskoはbcacheを直接サポートしていないため、一部は以下のように手動で設定する必要があります。
       # # bcacheデバイスの作成
       # # キャッシュデバイス（SSD）
-      # sudo make-bcache --cache /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935
+      # sudo make-bcache --cache --writeback --discard /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935
       # # バッキングデバイス（HDD）
-      # sudo make-bcache --bdev /dev/disk/by-id/ata-WDC_WD121PURZ-85GUCY0_2AGN938Y
-      # sudo make-bcache --bdev /dev/disk/by-id/ata-WDC_WD80EAAZ-00BXBB0_WD-RD2PKLEH
-      # sudo make-bcache --bdev /dev/disk/by-id/ata-WDC_WD80EAZZ-00BKLB0_WD-CA2HPAUK
+      # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD121PURZ-85GUCY0_2AGN938Y
+      # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAAZ-00BXBB0_WD-RD2PKLEH
+      # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAZZ-00BKLB0_WD-CA2HPAUK
       # # キャッシュセットに接続
       # CACHE_SET_UUID=$(sudo bcache-super-show /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935|grep 'cset.uuid'|awk '{print $2}')
       # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache0/bcache/attach"


### PR DESCRIPTION
後から有効にしていたが、
明示的に初期化コマンドで有効であると示唆します。
