### PR TITLE
feat(nixos/seminar): /mnt/noaのsnapper設定を追加

### DIFF
--- a/nixos/host/seminar/noa-snapper.nix
+++ b/nixos/host/seminar/noa-snapper.nix
@@ -1,0 +1,14 @@
+{ ... }:
+{
+  services.snapper = {
+    configs = {
+      noa = {
+        SUBVOLUME = "/mnt/noa";
+        ALLOW_GROUPS = [ "wheel" ];
+
+        TIMELINE_CREATE = true;
+        TIMELINE_CLEANUP = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
- `/mnt/noa`サブボリューム用のsnapper設定を追加します。
- `wheel`グループにスナップショット管理を許可します。
- タイムラインベースのスナップショット作成とクリーンアップを有効化します。
