### PR TITLE
feat(desktop/dpms): DPMSタイムアウトを更新

### DIFF
--- a/nixos/desktop/dpms.nix
+++ b/nixos/desktop/dpms.nix
@@ -10,8 +10,8 @@
         set -euo pipefail
         # DPMSを有効化
         ${pkgs.xorg.xset}/bin/xset +dpms
-        # DPMS設定 (スタンバイ:30分, サスペンド:45分, オフ:60分)
-        ${pkgs.xorg.xset}/bin/xset dpms 1800 2700 3600
+        # DPMS設定 (スタンバイ:60分, サスペンド:100分, オフ:120分)
+        ${pkgs.xorg.xset}/bin/xset dpms 3600 6000 7200
       '';
       Environment = [
         "DISPLAY=:0"


### PR DESCRIPTION
- standby: 1800秒から3600秒に変更 (30分→60分)
- suspend: 2700秒から6000秒に変更 (45分→100分)
- off: 3600秒から7200秒に変更 (60分→120分)
