### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756649772,
-        "narHash": "sha256-YesaX4RhgNmB0tNBNMgHnW/CV+7o1jrHcpH60Z9KMgg=",
+        "lastModified": 1757808445,
+        "narHash": "sha256-Mbs2oXQa17jPEapXaYECJWxrvVKN8kk1hHpgSacbWDU=",
         "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "bbf9abf395d0ec607a55dd9ddef1efee57883827",
+        "rev": "a7f42f42426130a51b0542a651a2cb29f99ac2b6",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756733629,
-        "narHash": "sha256-dwWGlDhcO5SMIvMSTB4mjQ5Pvo2vtxvpIknhVnSz2I8=",
+        "lastModified": 1757508292,
+        "narHash": "sha256-7lVWL5bC6xBIMWWDal41LlGAG+9u2zUorqo3QCUL4p4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1",
+        "rev": "146f45bee02b8bd88812cfce6ffc0f933788875a",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754804646,
-        "narHash": "sha256-F2VPD1bSAR8FyMTTZOXNhBaed4hHjXR/fWLGiAkXpHo=",
+        "lastModified": 1757651852,
+        "narHash": "sha256-TQxyO4EqOVEX+vPbH9gPVLlmNgU4sz9tzDzUVgo/UhY=",
         "owner": "ncaq",
         "repo": ".xmonad",
-        "rev": "6f0cb3857a890aa086818e7f7659716f4f400c39",
+        "rev": "8bac4eb51d84abda0affb4e010afff4b22fe0d52",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757204834,
-        "narHash": "sha256-FLpW1I62+NsfVy4F5hSs0+Uj/vkJvjgj86WyZgrW2/s=",
+        "lastModified": 1757982288,
+        "narHash": "sha256-qnfIgU4ILEoUdSXNJT1FqI9vClMw+7bzawryci1b7kM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "d22d519e92ee6d0348a659976d009f3419c3de52",
+        "rev": "93b934a7c4309811c07d0184d2502642aacbefeb",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757204824,
-        "narHash": "sha256-dAPQdVpNP+wjqKh+XpvLgDf6QO03UXLsLXtJMetIo8o=",
+        "lastModified": 1757982278,
+        "narHash": "sha256-Dog1K0lrVYqWqs1/nMLMpJYdRaedSpMm9RjUoFJK4rI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bb8327a2c31bc99495e6b3f7bd0f0450c25f4143",
+        "rev": "3eec113f323d3d275ad4e8315e66630d93599488",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1757206330,
-        "narHash": "sha256-gVh7U8kYbIpexIXAHWL01vEtQ+jc5PTY3w6bOfCGQhs=",
+        "lastModified": 1757983887,
+        "narHash": "sha256-Ai7+aYpVCjFPObJvWsOyvC5e3B3xdd4CPI2CWnXAtj0=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7b64b0dfe9e38325bc6cd3a4f057b5215801c872",
+        "rev": "4cf808684da04f619adb63059b4336b450fb2370",
         "type": "github"
       },
       "original": {
@@ -551,11 +551,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756679287,
-        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
+        "lastModified": 1757808926,
+        "narHash": "sha256-K6PEI5PYY94TVMH0mX3MbZNYFme7oNRKml/85BpRRAo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
+        "rev": "f21d9167782c086a33ad53e2311854a8f13c281e",
         "type": "github"
       },
       "original": {
@@ -600,11 +600,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757103352,
-        "narHash": "sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH+q462Sn8lrmWmk=",
+        "lastModified": 1757943327,
+        "narHash": "sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11b2a10c7be726321bb854403fdeec391e798bf0",
+        "rev": "67a709cfe5d0643dafd798b0b613ed579de8be05",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755261305,
-        "narHash": "sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq+lj1wHdu8=",
+        "lastModified": 1757937573,
+        "narHash": "sha256-B+MT526k5th4x22h213/CgzdkKWIaeaa0+Y0uuCkH/I=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "203a7b463f307c60026136dd1191d9001c43457f",
+        "rev": "134e117c969f42277f1c5e60c8fbcac103c2c454",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757020766,
-        "narHash": "sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0=",
+        "lastModified": 1757810152,
+        "narHash": "sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe83bbdde2ccdc2cb9573aa846abe8363f79a97a",
+        "rev": "9a094440e02a699be5c57453a092a8baf569bdad",
         "type": "github"
       },
       "original": {
@@ -748,11 +748,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1756911493,
-        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "lastModified": 1757873102,
+        "narHash": "sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF+44xG/xar2yE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "rev": "88cef159e47c0dc56f151593e044453a39a6e547",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757125853,
-        "narHash": "sha256-noKkYHKpT5lpvNSYrlH56d8cedthZfs010Uv6vTqLT4=",
+        "lastModified": 1757989933,
+        "narHash": "sha256-9cpKYWWPCFhgwQTww8S94rTXgg8Q8ydFv9fXM6I8xQM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8b70793a6be183536a5d562056dac10b7b36820d",
+        "rev": "8249aa3442fb9b45e615a35f39eca2fe5510d7c3",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757204011,
-        "narHash": "sha256-5a1iwJt+slNOV429cf6flinG8uUXI9d0xI9GrLe9QT8=",
+        "lastModified": 1757981556,
+        "narHash": "sha256-3ZC1NvBzECcFTrK6UqZujubC55nrXjlZKRPgzcn/t/c=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "722d22874e9fff8d13ff194bda0d9b502d923e09",
+        "rev": "cfa1d41b89c4e47e93702324ffd596ff8ac90482",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/bbf9abf395d0ec607a55dd9ddef1efee57883827?narHash=sha256-YesaX4RhgNmB0tNBNMgHnW/CV%2B7o1jrHcpH60Z9KMgg%3D' (2025-08-31)
  → 'github:k3d3/claude-desktop-linux-flake/a7f42f42426130a51b0542a651a2cb29f99ac2b6?narHash=sha256-Mbs2oXQa17jPEapXaYECJWxrvVKN8kk1hHpgSacbWDU%3D' (2025-09-14)
• Updated input 'disko':
    'github:nix-community/disko/a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1?narHash=sha256-dwWGlDhcO5SMIvMSTB4mjQ5Pvo2vtxvpIknhVnSz2I8%3D' (2025-09-01)
  → 'github:nix-community/disko/146f45bee02b8bd88812cfce6ffc0f933788875a?narHash=sha256-7lVWL5bC6xBIMWWDal41LlGAG%2B9u2zUorqo3QCUL4p4%3D' (2025-09-10)
• Updated input 'dot-xmonad':
    'github:ncaq/.xmonad/6f0cb3857a890aa086818e7f7659716f4f400c39?narHash=sha256-F2VPD1bSAR8FyMTTZOXNhBaed4hHjXR/fWLGiAkXpHo%3D' (2025-08-10)
  → 'github:ncaq/.xmonad/8bac4eb51d84abda0affb4e010afff4b22fe0d52?narHash=sha256-TQxyO4EqOVEX%2BvPbH9gPVLlmNgU4sz9tzDzUVgo/UhY%3D' (2025-09-12)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/7b64b0dfe9e38325bc6cd3a4f057b5215801c872?narHash=sha256-gVh7U8kYbIpexIXAHWL01vEtQ%2Bjc5PTY3w6bOfCGQhs%3D' (2025-09-07)
  → 'github:input-output-hk/haskell.nix/4cf808684da04f619adb63059b4336b450fb2370?narHash=sha256-Ai7%2BaYpVCjFPObJvWsOyvC5e3B3xdd4CPI2CWnXAtj0%3D' (2025-09-16)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/d22d519e92ee6d0348a659976d009f3419c3de52?narHash=sha256-FLpW1I62%2BNsfVy4F5hSs0%2BUj/vkJvjgj86WyZgrW2/s%3D' (2025-09-07)
  → 'github:input-output-hk/hackage.nix/93b934a7c4309811c07d0184d2502642aacbefeb?narHash=sha256-qnfIgU4ILEoUdSXNJT1FqI9vClMw%2B7bzawryci1b7kM%3D' (2025-09-16)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/bb8327a2c31bc99495e6b3f7bd0f0450c25f4143?narHash=sha256-dAPQdVpNP%2BwjqKh%2BXpvLgDf6QO03UXLsLXtJMetIo8o%3D' (2025-09-07)
  → 'github:input-output-hk/hackage.nix/3eec113f323d3d275ad4e8315e66630d93599488?narHash=sha256-Dog1K0lrVYqWqs1/nMLMpJYdRaedSpMm9RjUoFJK4rI%3D' (2025-09-16)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/722d22874e9fff8d13ff194bda0d9b502d923e09?narHash=sha256-5a1iwJt%2BslNOV429cf6flinG8uUXI9d0xI9GrLe9QT8%3D' (2025-09-07)
  → 'github:input-output-hk/stackage.nix/cfa1d41b89c4e47e93702324ffd596ff8ac90482?narHash=sha256-3ZC1NvBzECcFTrK6UqZujubC55nrXjlZKRPgzcn/t/c%3D' (2025-09-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/07fc025fe10487dd80f2ec694f1cd790e752d0e8?narHash=sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB%2BgTQ%3D' (2025-08-31)
  → 'github:nix-community/home-manager/f21d9167782c086a33ad53e2311854a8f13c281e?narHash=sha256-K6PEI5PYY94TVMH0mX3MbZNYFme7oNRKml/85BpRRAo%3D' (2025-09-14)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/11b2a10c7be726321bb854403fdeec391e798bf0?narHash=sha256-PtT7ix43ss8PONJ1VJw3f6t2yAoGH%2Bq462Sn8lrmWmk%3D' (2025-09-05)
  → 'github:NixOS/nixos-hardware/67a709cfe5d0643dafd798b0b613ed579de8be05?narHash=sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM%3D' (2025-09-15)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/203a7b463f307c60026136dd1191d9001c43457f?narHash=sha256-EOqCupB5X5WoGVHVcfOZcqy0SbKWNuY3kq%2Blj1wHdu8%3D' (2025-08-15)
  → 'github:nix-community/NixOS-WSL/134e117c969f42277f1c5e60c8fbcac103c2c454?narHash=sha256-B%2BMT526k5th4x22h213/CgzdkKWIaeaa0%2BY0uuCkH/I%3D' (2025-09-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/fe83bbdde2ccdc2cb9573aa846abe8363f79a97a?narHash=sha256-PLoSjHRa2bUbi1x9HoXgTx2AiuzNXs54c8omhadyvp0%3D' (2025-09-04)
  → 'github:NixOS/nixpkgs/9a094440e02a699be5c57453a092a8baf569bdad?narHash=sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs%3D' (2025-09-14)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/c6a788f552b7b7af703b1a29802a7233c0067908?narHash=sha256-6n/n1GZQ/vi%2BLhFXMSyoseKdNfc2QQaSBXJdgamrbkE%3D' (2025-09-03)
  → 'github:NixOS/nixpkgs/88cef159e47c0dc56f151593e044453a39a6e547?narHash=sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF%2B44xG/xar2yE%3D' (2025-09-14)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/8b70793a6be183536a5d562056dac10b7b36820d?narHash=sha256-noKkYHKpT5lpvNSYrlH56d8cedthZfs010Uv6vTqLT4%3D' (2025-09-06)
  → 'github:oxalica/rust-overlay/8249aa3442fb9b45e615a35f39eca2fe5510d7c3?narHash=sha256-9cpKYWWPCFhgwQTww8S94rTXgg8Q8ydFv9fXM6I8xQM%3D' (2025-09-16)
