### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757808445,
-        "narHash": "sha256-Mbs2oXQa17jPEapXaYECJWxrvVKN8kk1hHpgSacbWDU=",
+        "lastModified": 1759415048,
+        "narHash": "sha256-gx3SVrN7URzrP9OfZmDoJHcqryZhbWWj7J/rkVSSivA=",
         "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "a7f42f42426130a51b0542a651a2cb29f99ac2b6",
+        "rev": "1ff1cc5d6345dfe4c630949cb69e0b7b1d4e129d",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757508292,
-        "narHash": "sha256-7lVWL5bC6xBIMWWDal41LlGAG+9u2zUorqo3QCUL4p4=",
+        "lastModified": 1758287904,
+        "narHash": "sha256-IGmaEf3Do8o5Cwp1kXBN1wQmZwQN3NLfq5t4nHtVtcU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "146f45bee02b8bd88812cfce6ffc0f933788875a",
+        "rev": "67ff9807dd148e704baadbd4fd783b54282ca627",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757982288,
-        "narHash": "sha256-qnfIgU4ILEoUdSXNJT1FqI9vClMw+7bzawryci1b7kM=",
+        "lastModified": 1759537480,
+        "narHash": "sha256-PN0svvFMJvNTeW944+7x8gIsDFSVVMQkovlEURUsUm8=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "93b934a7c4309811c07d0184d2502642aacbefeb",
+        "rev": "afeb3e413dd333af360d6060abe23e023affd84d",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757982278,
-        "narHash": "sha256-Dog1K0lrVYqWqs1/nMLMpJYdRaedSpMm9RjUoFJK4rI=",
+        "lastModified": 1759537470,
+        "narHash": "sha256-rJA+qPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3eec113f323d3d275ad4e8315e66630d93599488",
+        "rev": "35c7af40a606576b339a476db7789ebbb8220952",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1757983887,
-        "narHash": "sha256-Ai7+aYpVCjFPObJvWsOyvC5e3B3xdd4CPI2CWnXAtj0=",
+        "lastModified": 1759539111,
+        "narHash": "sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4cf808684da04f619adb63059b4336b450fb2370",
+        "rev": "3269049024d866d8c7c421850ebea1f0a035bf24",
         "type": "github"
       },
       "original": {
@@ -551,11 +551,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757808926,
-        "narHash": "sha256-K6PEI5PYY94TVMH0mX3MbZNYFme7oNRKml/85BpRRAo=",
+        "lastModified": 1758463745,
+        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f21d9167782c086a33ad53e2311854a8f13c281e",
+        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
         "type": "github"
       },
       "original": {
@@ -600,11 +600,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757943327,
-        "narHash": "sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM=",
+        "lastModified": 1759261527,
+        "narHash": "sha256-wPd5oGvBBpUEzMF0kWnXge0WITNsITx/aGI9qLHgJ4g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "67a709cfe5d0643dafd798b0b613ed579de8be05",
+        "rev": "e087756cf4abbe1a34f3544c480fc1034d68742f",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757937573,
-        "narHash": "sha256-B+MT526k5th4x22h213/CgzdkKWIaeaa0+Y0uuCkH/I=",
+        "lastModified": 1759348509,
+        "narHash": "sha256-at9xMhxMP65JYWlGWYJ412VKbS+tXkTM3f5t9Q8IyMA=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "134e117c969f42277f1c5e60c8fbcac103c2c454",
+        "rev": "d96dda76c1f1827634ddf28d386feabd2d135d21",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757810152,
-        "narHash": "sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs=",
+        "lastModified": 1759281824,
+        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a094440e02a699be5c57453a092a8baf569bdad",
+        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
         "type": "github"
       },
       "original": {
@@ -748,11 +748,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1757873102,
-        "narHash": "sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF+44xG/xar2yE=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88cef159e47c0dc56f151593e044453a39a6e547",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757989933,
-        "narHash": "sha256-9cpKYWWPCFhgwQTww8S94rTXgg8Q8ydFv9fXM6I8xQM=",
+        "lastModified": 1759458749,
+        "narHash": "sha256-WKnbJnm1B2+TO2ZUudgS39EzecQeLl4/bnRtd3y46LI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8249aa3442fb9b45e615a35f39eca2fe5510d7c3",
+        "rev": "bbc3a8ae797d1700e57a4f4bcc4e79af727d4138",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1757981556,
-        "narHash": "sha256-3ZC1NvBzECcFTrK6UqZujubC55nrXjlZKRPgzcn/t/c=",
+        "lastModified": 1759450314,
+        "narHash": "sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "cfa1d41b89c4e47e93702324ffd596ff8ac90482",
+        "rev": "f8ea3e13773ce6fd88f5b6bb251c8f482a89d317",
         "type": "github"
       },
       "original": {
@@ -854,11 +854,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756662192,
-        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/a7f42f42426130a51b0542a651a2cb29f99ac2b6?narHash=sha256-Mbs2oXQa17jPEapXaYECJWxrvVKN8kk1hHpgSacbWDU%3D' (2025-09-14)
  → 'github:k3d3/claude-desktop-linux-flake/1ff1cc5d6345dfe4c630949cb69e0b7b1d4e129d?narHash=sha256-gx3SVrN7URzrP9OfZmDoJHcqryZhbWWj7J/rkVSSivA%3D' (2025-10-02)
• Updated input 'disko':
    'github:nix-community/disko/146f45bee02b8bd88812cfce6ffc0f933788875a?narHash=sha256-7lVWL5bC6xBIMWWDal41LlGAG%2B9u2zUorqo3QCUL4p4%3D' (2025-09-10)
  → 'github:nix-community/disko/67ff9807dd148e704baadbd4fd783b54282ca627?narHash=sha256-IGmaEf3Do8o5Cwp1kXBN1wQmZwQN3NLfq5t4nHtVtcU%3D' (2025-09-19)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/4524271976b625a4a605beefd893f270620fd751?narHash=sha256-%2BuWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw%3D' (2025-09-01)
  → 'github:hercules-ci/flake-parts/758cf7296bee11f1706a574c77d072b8a7baa881?narHash=sha256-wfG0S7pltlYyZTM%2BqqlhJ7GMw2fTF4mLKCIVhLii/4M%3D' (2025-10-01)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/4cf808684da04f619adb63059b4336b450fb2370?narHash=sha256-Ai7%2BaYpVCjFPObJvWsOyvC5e3B3xdd4CPI2CWnXAtj0%3D' (2025-09-16)
  → 'github:input-output-hk/haskell.nix/3269049024d866d8c7c421850ebea1f0a035bf24?narHash=sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ%3D' (2025-10-04)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/93b934a7c4309811c07d0184d2502642aacbefeb?narHash=sha256-qnfIgU4ILEoUdSXNJT1FqI9vClMw%2B7bzawryci1b7kM%3D' (2025-09-16)
  → 'github:input-output-hk/hackage.nix/afeb3e413dd333af360d6060abe23e023affd84d?narHash=sha256-PN0svvFMJvNTeW944%2B7x8gIsDFSVVMQkovlEURUsUm8%3D' (2025-10-04)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/3eec113f323d3d275ad4e8315e66630d93599488?narHash=sha256-Dog1K0lrVYqWqs1/nMLMpJYdRaedSpMm9RjUoFJK4rI%3D' (2025-09-16)
  → 'github:input-output-hk/hackage.nix/35c7af40a606576b339a476db7789ebbb8220952?narHash=sha256-rJA%2BqPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI%3D' (2025-10-04)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/cfa1d41b89c4e47e93702324ffd596ff8ac90482?narHash=sha256-3ZC1NvBzECcFTrK6UqZujubC55nrXjlZKRPgzcn/t/c%3D' (2025-09-16)
  → 'github:input-output-hk/stackage.nix/f8ea3e13773ce6fd88f5b6bb251c8f482a89d317?narHash=sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4%3D' (2025-10-03)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f21d9167782c086a33ad53e2311854a8f13c281e?narHash=sha256-K6PEI5PYY94TVMH0mX3MbZNYFme7oNRKml/85BpRRAo%3D' (2025-09-14)
  → 'github:nix-community/home-manager/3b955f5f0a942f9f60cdc9cacb7844335d0f21c3?narHash=sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA%3D' (2025-09-21)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/67a709cfe5d0643dafd798b0b613ed579de8be05?narHash=sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM%3D' (2025-09-15)
  → 'github:NixOS/nixos-hardware/e087756cf4abbe1a34f3544c480fc1034d68742f?narHash=sha256-wPd5oGvBBpUEzMF0kWnXge0WITNsITx/aGI9qLHgJ4g%3D' (2025-09-30)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/134e117c969f42277f1c5e60c8fbcac103c2c454?narHash=sha256-B%2BMT526k5th4x22h213/CgzdkKWIaeaa0%2BY0uuCkH/I%3D' (2025-09-15)
  → 'github:nix-community/NixOS-WSL/d96dda76c1f1827634ddf28d386feabd2d135d21?narHash=sha256-at9xMhxMP65JYWlGWYJ412VKbS%2BtXkTM3f5t9Q8IyMA%3D' (2025-10-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9a094440e02a699be5c57453a092a8baf569bdad?narHash=sha256-Vp9K5ol6h0J90jG7Rm4RWZsCB3x7v5VPx588TQ1dkfs%3D' (2025-09-14)
  → 'github:NixOS/nixpkgs/5b5be50345d4113d04ba58c444348849f5585b4a?narHash=sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0%3D' (2025-10-01)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/88cef159e47c0dc56f151593e044453a39a6e547?narHash=sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF%2B44xG/xar2yE%3D' (2025-09-14)
  → 'github:NixOS/nixpkgs/dc704e6102e76aad573f63b74c742cd96f8f1e6c?narHash=sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow%3D' (2025-10-02)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/8249aa3442fb9b45e615a35f39eca2fe5510d7c3?narHash=sha256-9cpKYWWPCFhgwQTww8S94rTXgg8Q8ydFv9fXM6I8xQM%3D' (2025-09-16)
  → 'github:oxalica/rust-overlay/bbc3a8ae797d1700e57a4f4bcc4e79af727d4138?narHash=sha256-WKnbJnm1B2%2BTO2ZUudgS39EzecQeLl4/bnRtd3y46LI%3D' (2025-10-03)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/1aabc6c05ccbcbf4a635fb7a90400e44282f61c4?narHash=sha256-F1oFfV51AE259I85av%2BMAia221XwMHCOtZCMcZLK2Jk%3D' (2025-08-31)
  → 'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
