### PR TITLE
ci: remove explicit model selection from claude workflow configs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,4 +62,3 @@ jobs:
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: |
             --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
-            --model claude-opus-4-1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,4 +55,3 @@ jobs:
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: |
             --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr:*)"
-            --model claude-opus-4-1


### PR DESCRIPTION
- claude-opus-4-1モデル指定を削除し、デフォルトモデル利用に変更
- 設定の簡素化と今後のモデル更新対応を容易化
