### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759415048,
-        "narHash": "sha256-gx3SVrN7URzrP9OfZmDoJHcqryZhbWWj7J/rkVSSivA=",
+        "lastModified": 1760048965,
+        "narHash": "sha256-ws4Hg+FW/pEntweBdKJnxqX6CI8Awew7UTkN024qZlk=",
         "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "1ff1cc5d6345dfe4c630949cb69e0b7b1d4e129d",
+        "rev": "afdc55a4961e864566758cd2c10176707ed75e64",
         "type": "github"
       },
       "original": {
@@ -136,14 +136,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1757651852,
-        "narHash": "sha256-TQxyO4EqOVEX+vPbH9gPVLlmNgU4sz9tzDzUVgo/UhY=",
+        "lastModified": 1759549800,
+        "narHash": "sha256-qrUyIPZQ5h3s8GqyhXPAVGEP5UGap+Hnnv2S+AVqc+c=",
         "owner": "ncaq",
         "repo": ".xmonad",
-        "rev": "8bac4eb51d84abda0affb4e010afff4b22fe0d52",
+        "rev": "6ddff23c21d2eb2eb3ad7910cb6317ccc2646286",
         "type": "github"
       },
       "original": {
@@ -224,11 +225,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759537480,
-        "narHash": "sha256-PN0svvFMJvNTeW944+7x8gIsDFSVVMQkovlEURUsUm8=",
+        "lastModified": 1760401501,
+        "narHash": "sha256-9OHoxOoHLi/ucvi4k3M/li1HhBWY5Xn4VAi4+6cmskQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "afeb3e413dd333af360d6060abe23e023affd84d",
+        "rev": "8a529b6761743b2d582d1ecaca0df1454a729168",
         "type": "github"
       },
       "original": {
@@ -240,11 +241,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759537470,
-        "narHash": "sha256-rJA+qPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI=",
+        "lastModified": 1760401490,
+        "narHash": "sha256-23yoe4d68cmiLV+f+NeU2ZIdVRUEF/m4tfysliCp0Vc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "35c7af40a606576b339a476db7789ebbb8220952",
+        "rev": "19dfc080114658671e820e460da77a68e34662e5",
         "type": "github"
       },
       "original": {
@@ -311,11 +312,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1759539111,
-        "narHash": "sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ=",
+        "lastModified": 1760403127,
+        "narHash": "sha256-Nx7bintaRzBarcV3S92xw5P68CdE+9/KkwjWibThd/M=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3269049024d866d8c7c421850ebea1f0a035bf24",
+        "rev": "8244bb25bacd06f80fb7d79537eede0d6449faf6",
         "type": "github"
       },
       "original": {
@@ -600,11 +601,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1759261527,
-        "narHash": "sha256-wPd5oGvBBpUEzMF0kWnXge0WITNsITx/aGI9qLHgJ4g=",
+        "lastModified": 1760106635,
+        "narHash": "sha256-2GoxVaKWTHBxRoeUYSjv0AfSOx4qw5CWSFz2b+VolKU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e087756cf4abbe1a34f3544c480fc1034d68742f",
+        "rev": "9ed85f8afebf2b7478f25db0a98d0e782c0ed903",
         "type": "github"
       },
       "original": {
@@ -621,11 +622,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759348509,
-        "narHash": "sha256-at9xMhxMP65JYWlGWYJ412VKbS+tXkTM3f5t9Q8IyMA=",
+        "lastModified": 1760454217,
+        "narHash": "sha256-qG4cQaYRKrAMj4OjISYYoWqJc+xcoJnLx2jsws7EdGg=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "d96dda76c1f1827634ddf28d386feabd2d135d21",
+        "rev": "a8209ae46721f2a70214d0a70388a812ec7740da",
         "type": "github"
       },
       "original": {
@@ -637,11 +638,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1760139962,
+        "narHash": "sha256-4xggC56Rub3WInz5eD7EZWXuLXpNvJiUPahGtMkwtuc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "7e297ddff44a3cc93673bb38d0374df8d0ad73e4",
         "type": "github"
       },
       "original": {
@@ -748,11 +749,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759417375,
-        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
+        "lastModified": 1760349414,
+        "narHash": "sha256-W4Ri1ZwYuNcBzqQQa7NnWfrv0wHMo7rduTWjIeU9dZk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
+        "rev": "c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec",
         "type": "github"
       },
       "original": {
@@ -793,7 +794,7 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "rust-overlay": {
@@ -803,11 +804,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759458749,
-        "narHash": "sha256-WKnbJnm1B2+TO2ZUudgS39EzecQeLl4/bnRtd3y46LI=",
+        "lastModified": 1760409263,
+        "narHash": "sha256-GvcdHmY3nZnU6GnUkEG1a7pDZPgFcuN+zGv3OgvfPH0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bbc3a8ae797d1700e57a4f4bcc4e79af727d4138",
+        "rev": "5694018463c2134e2369996b38deed41b1b9afc1",
         "type": "github"
       },
       "original": {
@@ -819,11 +820,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759450314,
-        "narHash": "sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4=",
+        "lastModified": 1760400715,
+        "narHash": "sha256-IrQRC0CiNrA71Rq40fWdTwBWGtXramBevsU/OEVcCtI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f8ea3e13773ce6fd88f5b6bb251c8f482a89d317",
+        "rev": "c9ed9ca5d8b9820d021c556481d2006319d143d4",
         "type": "github"
       },
       "original": {
@@ -850,6 +851,7 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "dot-xmonad",
           "nixpkgs"
         ]
       },
@@ -859,6 +861,26 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1760120816,
+        "narHash": "sha256-gq9rdocpmRZCwLS5vsHozwB6b5nrOBDNc2kkEaTXHfg=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "761ae7aff00907b607125b2f57338b74177697ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/1ff1cc5d6345dfe4c630949cb69e0b7b1d4e129d?narHash=sha256-gx3SVrN7URzrP9OfZmDoJHcqryZhbWWj7J/rkVSSivA%3D' (2025-10-02)
  → 'github:k3d3/claude-desktop-linux-flake/afdc55a4961e864566758cd2c10176707ed75e64?narHash=sha256-ws4Hg%2BFW/pEntweBdKJnxqX6CI8Awew7UTkN024qZlk%3D' (2025-10-09)
• Updated input 'dot-xmonad':
    'github:ncaq/.xmonad/8bac4eb51d84abda0affb4e010afff4b22fe0d52?narHash=sha256-TQxyO4EqOVEX%2BvPbH9gPVLlmNgU4sz9tzDzUVgo/UhY%3D' (2025-09-12)
  → 'github:ncaq/.xmonad/6ddff23c21d2eb2eb3ad7910cb6317ccc2646286?narHash=sha256-qrUyIPZQ5h3s8GqyhXPAVGEP5UGap%2BHnnv2S%2BAVqc%2Bc%3D' (2025-10-04)
• Added input 'dot-xmonad/treefmt-nix':
    'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
• Added input 'dot-xmonad/treefmt-nix/nixpkgs':
    follows 'dot-xmonad/nixpkgs'
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/3269049024d866d8c7c421850ebea1f0a035bf24?narHash=sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ%3D' (2025-10-04)
  → 'github:input-output-hk/haskell.nix/8244bb25bacd06f80fb7d79537eede0d6449faf6?narHash=sha256-Nx7bintaRzBarcV3S92xw5P68CdE%2B9/KkwjWibThd/M%3D' (2025-10-14)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/afeb3e413dd333af360d6060abe23e023affd84d?narHash=sha256-PN0svvFMJvNTeW944%2B7x8gIsDFSVVMQkovlEURUsUm8%3D' (2025-10-04)
  → 'github:input-output-hk/hackage.nix/8a529b6761743b2d582d1ecaca0df1454a729168?narHash=sha256-9OHoxOoHLi/ucvi4k3M/li1HhBWY5Xn4VAi4%2B6cmskQ%3D' (2025-10-14)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/35c7af40a606576b339a476db7789ebbb8220952?narHash=sha256-rJA%2BqPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI%3D' (2025-10-04)
  → 'github:input-output-hk/hackage.nix/19dfc080114658671e820e460da77a68e34662e5?narHash=sha256-23yoe4d68cmiLV%2Bf%2BNeU2ZIdVRUEF/m4tfysliCp0Vc%3D' (2025-10-14)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/f8ea3e13773ce6fd88f5b6bb251c8f482a89d317?narHash=sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4%3D' (2025-10-03)
  → 'github:input-output-hk/stackage.nix/c9ed9ca5d8b9820d021c556481d2006319d143d4?narHash=sha256-IrQRC0CiNrA71Rq40fWdTwBWGtXramBevsU/OEVcCtI%3D' (2025-10-14)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e087756cf4abbe1a34f3544c480fc1034d68742f?narHash=sha256-wPd5oGvBBpUEzMF0kWnXge0WITNsITx/aGI9qLHgJ4g%3D' (2025-09-30)
  → 'github:NixOS/nixos-hardware/9ed85f8afebf2b7478f25db0a98d0e782c0ed903?narHash=sha256-2GoxVaKWTHBxRoeUYSjv0AfSOx4qw5CWSFz2b%2BVolKU%3D' (2025-10-10)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/d96dda76c1f1827634ddf28d386feabd2d135d21?narHash=sha256-at9xMhxMP65JYWlGWYJ412VKbS%2BtXkTM3f5t9Q8IyMA%3D' (2025-10-01)
  → 'github:nix-community/NixOS-WSL/a8209ae46721f2a70214d0a70388a812ec7740da?narHash=sha256-qG4cQaYRKrAMj4OjISYYoWqJc%2BxcoJnLx2jsws7EdGg%3D' (2025-10-14)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5b5be50345d4113d04ba58c444348849f5585b4a?narHash=sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0%3D' (2025-10-01)
  → 'github:NixOS/nixpkgs/7e297ddff44a3cc93673bb38d0374df8d0ad73e4?narHash=sha256-4xggC56Rub3WInz5eD7EZWXuLXpNvJiUPahGtMkwtuc%3D' (2025-10-10)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/dc704e6102e76aad573f63b74c742cd96f8f1e6c?narHash=sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow%3D' (2025-10-02)
  → 'github:NixOS/nixpkgs/c12c63cd6c5eb34c7b4c3076c6a99e00fcab86ec?narHash=sha256-W4Ri1ZwYuNcBzqQQa7NnWfrv0wHMo7rduTWjIeU9dZk%3D' (2025-10-13)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/bbc3a8ae797d1700e57a4f4bcc4e79af727d4138?narHash=sha256-WKnbJnm1B2%2BTO2ZUudgS39EzecQeLl4/bnRtd3y46LI%3D' (2025-10-03)
  → 'github:oxalica/rust-overlay/5694018463c2134e2369996b38deed41b1b9afc1?narHash=sha256-GvcdHmY3nZnU6GnUkEG1a7pDZPgFcuN%2BzGv3OgvfPH0%3D' (2025-10-14)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
  → 'github:numtide/treefmt-nix/761ae7aff00907b607125b2f57338b74177697ed?narHash=sha256-gq9rdocpmRZCwLS5vsHozwB6b5nrOBDNc2kkEaTXHfg%3D' (2025-10-10)
