### PR TITLE
fix(grobi): outputs_connectedを使用して誤検出を防止

### DIFF
--- a/home/package/grobi.nix
+++ b/home/package/grobi.nix
@@ -91,7 +91,6 @@ in
       }
       {
         name = "dominaria-t"; # Top
-        atomic = true;
         outputs_connected = [
           "HDMI-0-GSM-30470-699895-LG HDR 4K-"
         ];


### PR DESCRIPTION
`configure_single`だとIDとかの検査なしに検出してしまうようなので、
`outputs_connected`を使うように変更しました。
