### PR TITLE
fix(flake): claude-desktop-linux-flakeのリポジトリを戻す

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,16 +93,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1761106071,
+        "lastModified": 1761124928,
         "narHash": "sha256-wlATQIC3QuMXHptDr58bIv+j7ebgFm+6unD90dpr2YI=",
-        "owner": "ncaq",
+        "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "266804c3b5ad0e9e0edfe58d830902675ebe1477",
+        "rev": "cede1b93368e946fb6dad41725a14f981080b84e",
         "type": "github"
       },
       "original": {
-        "owner": "ncaq",
-        "ref": "bump-version",
+        "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
     };
 
     claude-desktop = {
-      url = "github:ncaq/claude-desktop-linux-flake/bump-version";
+      url = "github:k3d3/claude-desktop-linux-flake";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
[feat: bump version to 0.14.4 and update hash by ncaq · Pull Request #79 · k3d3/claude-desktop-linux-flake](https://github.com/k3d3/claude-desktop-linux-flake/pull/79)
が取り込まれたので上流に戻します。
