### PR TITLE
feat(seminar): add Forgejo service and Cloudflare ingress

### DIFF
--- a/home/package/general.nix
+++ b/home/package/general.nix
@@ -6,6 +6,7 @@
     attic-client
     bcache-tools
     cachix
+    cloudflared
     cryptsetup
     ddcutil
     dig

--- a/home/package/ssh.nix
+++ b/home/package/ssh.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  programs.ssh = {
+    enable = true;
+    matchBlocks = {
+      "forgejo-ssh.ncaq.net" = {
+        proxyCommand = ''
+          ${pkgs.cloudflared}/bin/cloudflared access ssh --hostname %h
+        '';
+      };
+    };
+  };
+}

--- a/nixos/host/seminar/cloudflare.nix
+++ b/nixos/host/seminar/cloudflare.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  config,
   username,
   ...
 }:
@@ -30,6 +31,10 @@ in
       default = "http_status:404";
       credentialsFile = "/home/${username}/.cloudflared/tunnel-seminar.json";
       ingress = {
+        "forgejo.ncaq.net" =
+          "http://${toString config.services.forgejo.settings.server.HTTP_ADDR}:${toString config.services.forgejo.settings.server.HTTP_PORT}";
+        "forgejo-ssh.ncaq.net" =
+          "ssh://localhost:${toString config.services.forgejo.settings.server.SSH_PORT}";
         "nix-cache.ncaq.net" = "http://localhost:10000";
       };
     };

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -1,0 +1,31 @@
+{ config, ... }:
+{
+  services.forgejo = {
+    enable = true;
+    database = {
+      type = "postgres";
+    };
+    settings = {
+      server = {
+        HTTP_PORT = 10001;
+        DOMAIN = "forgejo.ncaq.net";
+        ROOT_URL = "https://forgejo.ncaq.net/"; # デフォルトだとCloudflareを介した外から見たportにならないので手動で指定します。
+        SSH_DOMAIN = "forgejo-ssh.ncaq.net"; # Cloudflare Tunnelは複数のプロトコルを同一ドメインで扱えないため分けます。
+      };
+      session = {
+        COOKIE_SECURE = true;
+      };
+      service = {
+        # 個人専用向けにふさわしい設定。
+        DISABLE_REGISTRATION = true; # 新規登録を無効化。
+        REQUIRE_SIGNIN_VIEW = true; # サイト閲覧にログインを必須化。
+      };
+      repository = {
+        DEFAULT_BRANCH = "master";
+      };
+    };
+  };
+  environment.systemPackages = [
+    config.services.forgejo.package # サーバ上で管理CLIコマンドを使えるようにします。
+  ];
+}


### PR DESCRIPTION
close #277
forgejoをseminarサーバ上でセットアップしました。
Cloudflare Tunnel経由でアクセスできるようにしました。
クライアント側からssh接続する時にCloudflare Tunnelを経由するように設定しました。
