### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761124928,
-        "narHash": "sha256-wlATQIC3QuMXHptDr58bIv+j7ebgFm+6unD90dpr2YI=",
+        "lastModified": 1761825061,
+        "narHash": "sha256-AeRQZKr8+1XQer+WmbwtQaQBy05UDgeNNE7YZjNLuS0=",
         "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "cede1b93368e946fb6dad41725a14f981080b84e",
+        "rev": "791cd93cfe216ad06ab740f0fdc142119b1d6ec2",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760701190,
-        "narHash": "sha256-y7UhnWlER8r776JsySqsbTUh2Txf7K30smfHlqdaIQw=",
+        "lastModified": 1762276996,
+        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3a9450b26e69dcb6f8de6e2b07b3fc1c288d85f5",
+        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760948891,
-        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
+        "lastModified": 1762440070,
+        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
+        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1761092776,
-        "narHash": "sha256-/FojP2ovsoCttLYacs/F8VaIaHlUNnOzDVgpIB2S/IA=",
+        "lastModified": 1762561447,
+        "narHash": "sha256-cIzA3oVThdRAKwFWfld+8HKS6yeOlxmmTiL7eRFNbDk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "24414f2e4c091a2f29516463df454b20f95b95cc",
+        "rev": "3790462042f98c3fc264ce39a3fcc5ace843fc3b",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1761092766,
-        "narHash": "sha256-ByMfqwg3U+Wrc71jS0fQQ/yvk5fiD3Y0QXdpd03EFmY=",
+        "lastModified": 1762561438,
+        "narHash": "sha256-gjYC9eWxBhfNU+MnbXdTZIJqM3kEw+8/Lw0Sy61KiM4=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "eca88f42fc7681d9774d2a04b59cde817985b443",
+        "rev": "a55381cbf5a56ac69fdb568c80c8e3d2d840459f",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1761094340,
-        "narHash": "sha256-ilXnxGh/g7tCRjcvBmJx5ZjmwnRQ/Jqwf1MFdF1qJT4=",
+        "lastModified": 1762563126,
+        "narHash": "sha256-EOds/CW2Lg3SmkJ9c9V0t0FB1xBtuiaJFlkaSXQFPnk=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d3e91db1ce5b41f9c9a012f7304a62a8dc98dce7",
+        "rev": "7a652487e84f74ca32cc1a16e77c2915a8da1096",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1760958188,
-        "narHash": "sha256-2m1S4jl+GEDtlt2QqeHil8Ny456dcGSKJAM7q3j/BFU=",
+        "lastModified": 1762463231,
+        "narHash": "sha256-hv1mG5j5PTbnWbtHHomzTus77pIxsc4x8VrMjc7+/YE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d6645c340ef7d821602fd2cd199e8d1eed10afbc",
+        "rev": "52113c4f5cfd1e823001310e56d9c8d0699a6226",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760536587,
-        "narHash": "sha256-wfWqt+igns/VazjPLkyb4Z/wpn4v+XIjUeI3xY/1ENg=",
+        "lastModified": 1762251193,
+        "narHash": "sha256-CmSddz8e2kM+ITbYutluhKZyXXwI9Sg2lf7XXSvc8oY=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "f98ee1de1fa36eca63c67b600f5d617e184e82ea",
+        "rev": "e001844d4553aef268f97b32d3a825b6370eed91",
         "type": "github"
       },
       "original": {
@@ -640,11 +640,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760862643,
-        "narHash": "sha256-PXwG0TM7Ek87DNx4LbGWuD93PbFeKAJs4FfALtp7Wo0=",
+        "lastModified": 1762498405,
+        "narHash": "sha256-Zg/SCgCaAioc0/SVZQJxuECGPJy+OAeBcGeA5okdYDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33c6dca0c0cb31d6addcd34e90a63ad61826b28c",
+        "rev": "6faeb062ee4cf4f105989d490831713cc5a43ee1",
         "type": "github"
       },
       "original": {
@@ -736,11 +736,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -751,11 +751,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1760965567,
-        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
+        "lastModified": 1762361079,
+        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
+        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
         "type": "github"
       },
       "original": {
@@ -806,11 +806,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761100675,
-        "narHash": "sha256-LX3TCDBeNpCWTDXtGyRASVcLmRPChSli34bgHnZ1DCw=",
+        "lastModified": 1762483116,
+        "narHash": "sha256-Z8EVsTH10BjCdFyPxbUu5jBV+HGL39rh9+beQcnNRm0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "72161c6c53f6e3f8dadaf54b2204a5094c6a16ae",
+        "rev": "9de55b59b6aaadbd9dbf223765a835239b767ee5",
         "type": "github"
       },
       "original": {
@@ -822,11 +822,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1761091962,
-        "narHash": "sha256-q/CmJkzaMUgc0ZnYsPne7vcAkRXIGwMXNx9hRiD6Ph8=",
+        "lastModified": 1762560769,
+        "narHash": "sha256-srSwB2Csn6yHUT0efxEG9DNFqO5jGojX8eXUjXf9yhE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f868e5134d2165fdc28998a14d1959c2de4739b2",
+        "rev": "23e18e78d743db21094c8e0e6484575680ec57f8",
         "type": "github"
       },
       "original": {
@@ -857,11 +857,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760945191,
-        "narHash": "sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4=",
+        "lastModified": 1762410071,
+        "narHash": "sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g+mjR/p5TEg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
+        "rev": "97a30861b13c3731a84e09405414398fbf3e109f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/cede1b93368e946fb6dad41725a14f981080b84e?narHash=sha256-wlATQIC3QuMXHptDr58bIv%2Bj7ebgFm%2B6unD90dpr2YI%3D' (2025-10-22)
  → 'github:k3d3/claude-desktop-linux-flake/791cd93cfe216ad06ab740f0fdc142119b1d6ec2?narHash=sha256-AeRQZKr8%2B1XQer%2BWmbwtQaQBy05UDgeNNE7YZjNLuS0%3D' (2025-10-30)
• Updated input 'disko':
    'github:nix-community/disko/3a9450b26e69dcb6f8de6e2b07b3fc1c288d85f5?narHash=sha256-y7UhnWlER8r776JsySqsbTUh2Txf7K30smfHlqdaIQw%3D' (2025-10-17)
  → 'github:nix-community/disko/af087d076d3860760b3323f6b583f4d828c1ac17?narHash=sha256-TtcPgPmp2f0FAnc%2BDMEw4ardEgv1SGNR3/WFGH0N19M%3D' (2025-11-04)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/864599284fc7c0ba6357ed89ed5e2cd5040f0c04?narHash=sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4%3D' (2025-10-20)
  → 'github:hercules-ci/flake-parts/26d05891e14c88eb4a5d5bee659c0db5afb609d8?narHash=sha256-xxdepIcb39UJ94%2BYydGP221rjnpkDZUlykKuF54PsqI%3D' (2025-11-06)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/a73b9c743612e4244d865a2fdee11865283c04e6?narHash=sha256-x2rJ%2BOvzq0sCMpgfgGaaqgBSwY%2BLST%2BWbZ6TytnT9Rk%3D' (2025-08-10)
  → 'github:nix-community/nixpkgs.lib/719359f4562934ae99f5443f20aa06c2ffff91fc?narHash=sha256-b0yj6kfvO8ApcSE%2BQmA6mUfu8IYG6/uU28OFn4PaC8M%3D' (2025-10-29)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/d3e91db1ce5b41f9c9a012f7304a62a8dc98dce7?narHash=sha256-ilXnxGh/g7tCRjcvBmJx5ZjmwnRQ/Jqwf1MFdF1qJT4%3D' (2025-10-22)
  → 'github:input-output-hk/haskell.nix/7a652487e84f74ca32cc1a16e77c2915a8da1096?narHash=sha256-EOds/CW2Lg3SmkJ9c9V0t0FB1xBtuiaJFlkaSXQFPnk%3D' (2025-11-08)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/24414f2e4c091a2f29516463df454b20f95b95cc?narHash=sha256-/FojP2ovsoCttLYacs/F8VaIaHlUNnOzDVgpIB2S/IA%3D' (2025-10-22)
  → 'github:input-output-hk/hackage.nix/3790462042f98c3fc264ce39a3fcc5ace843fc3b?narHash=sha256-cIzA3oVThdRAKwFWfld%2B8HKS6yeOlxmmTiL7eRFNbDk%3D' (2025-11-08)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/eca88f42fc7681d9774d2a04b59cde817985b443?narHash=sha256-ByMfqwg3U%2BWrc71jS0fQQ/yvk5fiD3Y0QXdpd03EFmY%3D' (2025-10-22)
  → 'github:input-output-hk/hackage.nix/a55381cbf5a56ac69fdb568c80c8e3d2d840459f?narHash=sha256-gjYC9eWxBhfNU%2BMnbXdTZIJqM3kEw%2B8/Lw0Sy61KiM4%3D' (2025-11-08)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/f868e5134d2165fdc28998a14d1959c2de4739b2?narHash=sha256-q/CmJkzaMUgc0ZnYsPne7vcAkRXIGwMXNx9hRiD6Ph8%3D' (2025-10-22)
  → 'github:input-output-hk/stackage.nix/23e18e78d743db21094c8e0e6484575680ec57f8?narHash=sha256-srSwB2Csn6yHUT0efxEG9DNFqO5jGojX8eXUjXf9yhE%3D' (2025-11-08)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d6645c340ef7d821602fd2cd199e8d1eed10afbc?narHash=sha256-2m1S4jl%2BGEDtlt2QqeHil8Ny456dcGSKJAM7q3j/BFU%3D' (2025-10-20)
  → 'github:NixOS/nixos-hardware/52113c4f5cfd1e823001310e56d9c8d0699a6226?narHash=sha256-hv1mG5j5PTbnWbtHHomzTus77pIxsc4x8VrMjc7%2B/YE%3D' (2025-11-06)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/f98ee1de1fa36eca63c67b600f5d617e184e82ea?narHash=sha256-wfWqt%2Bigns/VazjPLkyb4Z/wpn4v%2BXIjUeI3xY/1ENg%3D' (2025-10-15)
  → 'github:nix-community/NixOS-WSL/e001844d4553aef268f97b32d3a825b6370eed91?narHash=sha256-CmSddz8e2kM%2BITbYutluhKZyXXwI9Sg2lf7XXSvc8oY%3D' (2025-11-04)
• Updated input 'nixos-wsl/flake-compat':
    'github:edolstra/flake-compat/9100a0f413b0c601e0533d1d94ffd501ce2e7885?narHash=sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX%2BfjA8Xf8PUmqCY%3D' (2025-05-12)
  → 'github:edolstra/flake-compat/f387cd2afec9419c8ee37694406ca490c3f34ee5?narHash=sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4%3D' (2025-10-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/33c6dca0c0cb31d6addcd34e90a63ad61826b28c?narHash=sha256-PXwG0TM7Ek87DNx4LbGWuD93PbFeKAJs4FfALtp7Wo0%3D' (2025-10-19)
  → 'github:NixOS/nixpkgs/6faeb062ee4cf4f105989d490831713cc5a43ee1?narHash=sha256-Zg/SCgCaAioc0/SVZQJxuECGPJy%2BOAeBcGeA5okdYDc%3D' (2025-11-07)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/cb82756ecc37fa623f8cf3e88854f9bf7f64af93?narHash=sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg%3D' (2025-10-20)
  → 'github:NixOS/nixpkgs/ffcdcf99d65c61956d882df249a9be53e5902ea5?narHash=sha256-lz718rr1BDpZBYk7%2BG8cE6wee3PiBUpn8aomG/vLLiY%3D' (2025-11-05)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/72161c6c53f6e3f8dadaf54b2204a5094c6a16ae?narHash=sha256-LX3TCDBeNpCWTDXtGyRASVcLmRPChSli34bgHnZ1DCw%3D' (2025-10-22)
  → 'github:oxalica/rust-overlay/9de55b59b6aaadbd9dbf223765a835239b767ee5?narHash=sha256-Z8EVsTH10BjCdFyPxbUu5jBV%2BHGL39rh9%2BbeQcnNRm0%3D' (2025-11-07)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/f56b1934f5f8fcab8deb5d38d42fd692632b47c2?narHash=sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4%3D' (2025-10-20)
  → 'github:numtide/treefmt-nix/97a30861b13c3731a84e09405414398fbf3e109f?narHash=sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g%2BmjR/p5TEg%3D' (2025-11-06)
