### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761825061,
-        "narHash": "sha256-AeRQZKr8+1XQer+WmbwtQaQBy05UDgeNNE7YZjNLuS0=",
+        "lastModified": 1764098187,
+        "narHash": "sha256-H6JjWXhKqxZ8QLMoqndZx9e5x0Sv5AiipSmqvIxIbgo=",
         "owner": "k3d3",
         "repo": "claude-desktop-linux-flake",
-        "rev": "791cd93cfe216ad06ab740f0fdc142119b1d6ec2",
+        "rev": "b2b040cb68231d2118906507d9cc8fd181ca6308",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762276996,
-        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
+        "lastModified": 1764110879,
+        "narHash": "sha256-xanUzIb0tf3kJ+PoOFmXEXV1jM3PjkDT/TQ5DYeNYRc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
+        "rev": "aecba248f9a7d68c5d1ed15de2d1c8a4c994a3c5",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762440070,
-        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1762561447,
-        "narHash": "sha256-cIzA3oVThdRAKwFWfld+8HKS6yeOlxmmTiL7eRFNbDk=",
+        "lastModified": 1764203197,
+        "narHash": "sha256-F78Z41DIC8ThihxzipceyVOjE2xHCFXHK/e0lq40mFw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3790462042f98c3fc264ce39a3fcc5ace843fc3b",
+        "rev": "9587f62bb414245da9ff8771a6baa1923bf05ad5",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1762561438,
-        "narHash": "sha256-gjYC9eWxBhfNU+MnbXdTZIJqM3kEw+8/Lw0Sy61KiM4=",
+        "lastModified": 1764203186,
+        "narHash": "sha256-1SBGn2VNS1HSWFF9X3LG0VdqNJp5wXpB6dT8fEIG6Bc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a55381cbf5a56ac69fdb568c80c8e3d2d840459f",
+        "rev": "ba8969ca61a38e1738c4e35d402f7d43c491aaf0",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1762563126,
-        "narHash": "sha256-EOds/CW2Lg3SmkJ9c9V0t0FB1xBtuiaJFlkaSXQFPnk=",
+        "lastModified": 1764204741,
+        "narHash": "sha256-EUTooiwyFrcH3w5rbAWKMZrUHDeblf4qnds1RQYFjjQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7a652487e84f74ca32cc1a16e77c2915a8da1096",
+        "rev": "e4e2b4d20b6ca833f4dcc268badf1538e903b7f1",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758463745,
-        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
+        "lastModified": 1763992789,
+        "narHash": "sha256-WHkdBlw6oyxXIra/vQPYLtqY+3G8dUVZM8bEXk0t8x4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
+        "rev": "44831a7eaba4360fb81f2acc5ea6de5fde90aaa3",
         "type": "github"
       },
       "original": {
@@ -603,11 +603,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1762463231,
-        "narHash": "sha256-hv1mG5j5PTbnWbtHHomzTus77pIxsc4x8VrMjc7+/YE=",
+        "lastModified": 1764080039,
+        "narHash": "sha256-b1MtLQsQc4Ji1u08f+C6g5XrmLPkJQ1fhNkCt+0AERQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "52113c4f5cfd1e823001310e56d9c8d0699a6226",
+        "rev": "da17006633ca9cda369be82893ae36824a2ddf1a",
         "type": "github"
       },
       "original": {
@@ -624,11 +624,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762251193,
-        "narHash": "sha256-CmSddz8e2kM+ITbYutluhKZyXXwI9Sg2lf7XXSvc8oY=",
+        "lastModified": 1764072830,
+        "narHash": "sha256-ezkjlUCohD9o9c47Ey0/I4CamSS0QEORTqGvyGqMud0=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "e001844d4553aef268f97b32d3a825b6370eed91",
+        "rev": "c7832dd786175e20f2697179e0e03efadffe4201",
         "type": "github"
       },
       "original": {
@@ -640,11 +640,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762498405,
-        "narHash": "sha256-Zg/SCgCaAioc0/SVZQJxuECGPJy+OAeBcGeA5okdYDc=",
+        "lastModified": 1763948260,
+        "narHash": "sha256-dY9qLD0H0zOUgU3vWacPY6Qc421BeQAfm8kBuBtPVE0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6faeb062ee4cf4f105989d490831713cc5a43ee1",
+        "rev": "1c8ba8d3f7634acac4a2094eef7c32ad9106532c",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1757716134,
-        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "lastModified": 1762303001,
+        "narHash": "sha256-6Q5fx8I7kI+uHL97pdpUnTm1Uu+OazpHfnv+DCAihtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "rev": "139de9c2cb757650424fe8aa2a980eaa93a9e733",
         "type": "github"
       },
       "original": {
@@ -751,11 +751,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762361079,
-        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
+        "lastModified": 1764167966,
+        "narHash": "sha256-nXv6xb7cq+XpjBYIjWEGTLCqQetxJu6zvVlrqHMsCOA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
+        "rev": "5c46f3bd98147c8d82366df95bbef2cab3a967ea",
         "type": "github"
       },
       "original": {
@@ -806,11 +806,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762483116,
-        "narHash": "sha256-Z8EVsTH10BjCdFyPxbUu5jBV+HGL39rh9+beQcnNRm0=",
+        "lastModified": 1764211126,
+        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9de55b59b6aaadbd9dbf223765a835239b767ee5",
+        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
         "type": "github"
       },
       "original": {
@@ -822,11 +822,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1762560769,
-        "narHash": "sha256-srSwB2Csn6yHUT0efxEG9DNFqO5jGojX8eXUjXf9yhE=",
+        "lastModified": 1764202380,
+        "narHash": "sha256-nEi+fd6xfVvrOdye3cMGvA9vuBAtp/ZSYELm/TU41ao=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "23e18e78d743db21094c8e0e6484575680ec57f8",
+        "rev": "373df81259feb7b322ddd7feab955911e5d7ea88",
         "type": "github"
       },
       "original": {
@@ -857,11 +857,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762410071,
-        "narHash": "sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g+mjR/p5TEg=",
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "97a30861b13c3731a84e09405414398fbf3e109f",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'claude-desktop':
    'github:k3d3/claude-desktop-linux-flake/791cd93cfe216ad06ab740f0fdc142119b1d6ec2?narHash=sha256-AeRQZKr8%2B1XQer%2BWmbwtQaQBy05UDgeNNE7YZjNLuS0%3D' (2025-10-30)
  → 'github:k3d3/claude-desktop-linux-flake/b2b040cb68231d2118906507d9cc8fd181ca6308?narHash=sha256-H6JjWXhKqxZ8QLMoqndZx9e5x0Sv5AiipSmqvIxIbgo%3D' (2025-11-25)
• Updated input 'disko':
    'github:nix-community/disko/af087d076d3860760b3323f6b583f4d828c1ac17?narHash=sha256-TtcPgPmp2f0FAnc%2BDMEw4ardEgv1SGNR3/WFGH0N19M%3D' (2025-11-04)
  → 'github:nix-community/disko/aecba248f9a7d68c5d1ed15de2d1c8a4c994a3c5?narHash=sha256-xanUzIb0tf3kJ%2BPoOFmXEXV1jM3PjkDT/TQ5DYeNYRc%3D' (2025-11-25)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/26d05891e14c88eb4a5d5bee659c0db5afb609d8?narHash=sha256-xxdepIcb39UJ94%2BYydGP221rjnpkDZUlykKuF54PsqI%3D' (2025-11-06)
  → 'github:hercules-ci/flake-parts/2cccadc7357c0ba201788ae99c4dfa90728ef5e0?narHash=sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q%3D' (2025-11-21)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/7a652487e84f74ca32cc1a16e77c2915a8da1096?narHash=sha256-EOds/CW2Lg3SmkJ9c9V0t0FB1xBtuiaJFlkaSXQFPnk%3D' (2025-11-08)
  → 'github:input-output-hk/haskell.nix/e4e2b4d20b6ca833f4dcc268badf1538e903b7f1?narHash=sha256-EUTooiwyFrcH3w5rbAWKMZrUHDeblf4qnds1RQYFjjQ%3D' (2025-11-27)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/3790462042f98c3fc264ce39a3fcc5ace843fc3b?narHash=sha256-cIzA3oVThdRAKwFWfld%2B8HKS6yeOlxmmTiL7eRFNbDk%3D' (2025-11-08)
  → 'github:input-output-hk/hackage.nix/9587f62bb414245da9ff8771a6baa1923bf05ad5?narHash=sha256-F78Z41DIC8ThihxzipceyVOjE2xHCFXHK/e0lq40mFw%3D' (2025-11-27)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/a55381cbf5a56ac69fdb568c80c8e3d2d840459f?narHash=sha256-gjYC9eWxBhfNU%2BMnbXdTZIJqM3kEw%2B8/Lw0Sy61KiM4%3D' (2025-11-08)
  → 'github:input-output-hk/hackage.nix/ba8969ca61a38e1738c4e35d402f7d43c491aaf0?narHash=sha256-1SBGn2VNS1HSWFF9X3LG0VdqNJp5wXpB6dT8fEIG6Bc%3D' (2025-11-27)
• Updated input 'haskellNix/nixpkgs-2411':
    'github:NixOS/nixpkgs/f09dede81861f3a83f7f06641ead34f02f37597f?narHash=sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk%3D' (2025-05-23)
  → 'github:NixOS/nixpkgs/5ab036a8d97cb9476fbe81b09076e6e91d15e1b6?narHash=sha256-kNf%2BobkpJZWar7HZymXZbW%2BRlk3HTEIMlpc6FCNz0Ds%3D' (2025-06-30)
• Updated input 'haskellNix/nixpkgs-2505':
    'github:NixOS/nixpkgs/e85b5aa112a98805a016bbf6291e726debbc448a?narHash=sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU%3D' (2025-09-12)
  → 'github:NixOS/nixpkgs/139de9c2cb757650424fe8aa2a980eaa93a9e733?narHash=sha256-6Q5fx8I7kI%2BuHL97pdpUnTm1Uu%2BOazpHfnv%2BDCAihtE%3D' (2025-11-05)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/23e18e78d743db21094c8e0e6484575680ec57f8?narHash=sha256-srSwB2Csn6yHUT0efxEG9DNFqO5jGojX8eXUjXf9yhE%3D' (2025-11-08)
  → 'github:input-output-hk/stackage.nix/373df81259feb7b322ddd7feab955911e5d7ea88?narHash=sha256-nEi%2Bfd6xfVvrOdye3cMGvA9vuBAtp/ZSYELm/TU41ao%3D' (2025-11-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/3b955f5f0a942f9f60cdc9cacb7844335d0f21c3?narHash=sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA%3D' (2025-09-21)
  → 'github:nix-community/home-manager/44831a7eaba4360fb81f2acc5ea6de5fde90aaa3?narHash=sha256-WHkdBlw6oyxXIra/vQPYLtqY%2B3G8dUVZM8bEXk0t8x4%3D' (2025-11-24)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/52113c4f5cfd1e823001310e56d9c8d0699a6226?narHash=sha256-hv1mG5j5PTbnWbtHHomzTus77pIxsc4x8VrMjc7%2B/YE%3D' (2025-11-06)
  → 'github:NixOS/nixos-hardware/da17006633ca9cda369be82893ae36824a2ddf1a?narHash=sha256-b1MtLQsQc4Ji1u08f%2BC6g5XrmLPkJQ1fhNkCt%2B0AERQ%3D' (2025-11-25)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/e001844d4553aef268f97b32d3a825b6370eed91?narHash=sha256-CmSddz8e2kM%2BITbYutluhKZyXXwI9Sg2lf7XXSvc8oY%3D' (2025-11-04)
  → 'github:nix-community/NixOS-WSL/c7832dd786175e20f2697179e0e03efadffe4201?narHash=sha256-ezkjlUCohD9o9c47Ey0/I4CamSS0QEORTqGvyGqMud0%3D' (2025-11-25)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/6faeb062ee4cf4f105989d490831713cc5a43ee1?narHash=sha256-Zg/SCgCaAioc0/SVZQJxuECGPJy%2BOAeBcGeA5okdYDc%3D' (2025-11-07)
  → 'github:NixOS/nixpkgs/1c8ba8d3f7634acac4a2094eef7c32ad9106532c?narHash=sha256-dY9qLD0H0zOUgU3vWacPY6Qc421BeQAfm8kBuBtPVE0%3D' (2025-11-24)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/ffcdcf99d65c61956d882df249a9be53e5902ea5?narHash=sha256-lz718rr1BDpZBYk7%2BG8cE6wee3PiBUpn8aomG/vLLiY%3D' (2025-11-05)
  → 'github:NixOS/nixpkgs/5c46f3bd98147c8d82366df95bbef2cab3a967ea?narHash=sha256-nXv6xb7cq%2BXpjBYIjWEGTLCqQetxJu6zvVlrqHMsCOA%3D' (2025-11-26)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/9de55b59b6aaadbd9dbf223765a835239b767ee5?narHash=sha256-Z8EVsTH10BjCdFyPxbUu5jBV%2BHGL39rh9%2BbeQcnNRm0%3D' (2025-11-07)
  → 'github:oxalica/rust-overlay/895935bff08cfcfb663fb9c8263c43596e7cd1ed?narHash=sha256-p5y13PnMZYd5WdHk%2BXCzyUaLGBUCwnz2n4KYKEZM0Pw%3D' (2025-11-27)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/97a30861b13c3731a84e09405414398fbf3e109f?narHash=sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g%2BmjR/p5TEg%3D' (2025-11-06)
  → 'github:numtide/treefmt-nix/5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4?narHash=sha256-AlEObg0syDl%2BSpi4LsZIBrjw%2BsnSVU4T8MOeuZJUJjM%3D' (2025-11-12)
