### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759549800,
-        "narHash": "sha256-qrUyIPZQ5h3s8GqyhXPAVGEP5UGap+Hnnv2S+AVqc+c=",
+        "lastModified": 1765005058,
+        "narHash": "sha256-33KAi2yEUKe2US25XmrSULqRBsoqswLVzgZmg+LHOqQ=",
         "owner": "ncaq",
         "repo": ".xmonad",
-        "rev": "6ddff23c21d2eb2eb3ad7910cb6317ccc2646286",
+        "rev": "351b574463dbd042e0003a436cd3dd2c88507ed2",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1764980769,
-        "narHash": "sha256-GR7udqehfHtR1k3qTRmygbbxN/vbZAqroR6SLNxaOYA=",
+        "lastModified": 1765153629,
+        "narHash": "sha256-XEoPzAxi+P5+54GdVOXIgOoLpnAC7UaJeTfVJ/uN5YI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a7cf7e356d4c35d04089136bbe256ba10521ad98",
+        "rev": "5999bde02da34086b161bd1c583563b0fa0ac7cd",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1764980759,
-        "narHash": "sha256-4aBYziHvJIW6If35bW6gBTf9szrsDon/kQLo7MBR7PQ=",
+        "lastModified": 1765153622,
+        "narHash": "sha256-9Q6aBAbB6fup4ie+tohV17LLzrwcvwKnPu5gz4fpzhE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "dc84ef2f749161d60947e96da212373ded0b123a",
+        "rev": "a53012835027c67f23c11b0d7eced04e50d26094",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1764982332,
-        "narHash": "sha256-cqK5A7L8yi2pXuUNE4lLipzzv18wsZOrJsgAJ6uXpPU=",
+        "lastModified": 1765155108,
+        "narHash": "sha256-E4qTzzzuEQmZdaC0J1D8WTFLtU+20z9R3BW4vMitYyo=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a62c9d889082c407557174c0647c6a950fd2fcef",
+        "rev": "268ef52619a35d7800f7123b533d0d2ff626f6ba",
         "type": "github"
       },
       "original": {
@@ -555,11 +555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764866045,
-        "narHash": "sha256-0GsEtXV9OquDQ1VclQfP16cU5VZh7NEVIOjSH4UaJuM=",
+        "lastModified": 1765170903,
+        "narHash": "sha256-O8VTGey1xxiRW+Fpb+Ps9zU7ShmxUA1a7cMTcENCVNg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f63d0fe9d81d36e5fc95497217a72e02b8b7bcab",
+        "rev": "20561be440a11ec57a89715480717baf19fe6343",
         "type": "github"
       },
       "original": {
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764730608,
-        "narHash": "sha256-FxKIa3OCSRVC23qrk7VT68vExUcmSruJ8OobVlSWOxc=",
+        "lastModified": 1765191003,
+        "narHash": "sha256-d3b3eQsdgXZDW/y4fmDuNiGBjZzwFrLhwD5i3NmM1mM=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "10124c58674360765adcb38c9a8b081fb72904e4",
+        "rev": "a16b061ec61831755df35fae916d19b0ac5a43cc",
         "type": "github"
       },
       "original": {
@@ -641,11 +641,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764831616,
-        "narHash": "sha256-OtzF5wBvO0jgW1WW1rQU9cMGx7zuvkF7CAVJ1ypzkxA=",
+        "lastModified": 1764983851,
+        "narHash": "sha256-y7RPKl/jJ/KAP/VKLMghMgXTlvNIJMHKskl8/Uuar7o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c97c47f2bac4fa59e2cbdeba289686ae615f8ed4",
+        "rev": "d9bc5c7dceb30d8d6fafa10aeb6aa8a48c218454",
         "type": "github"
       },
       "original": {
@@ -737,11 +737,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1764836381,
-        "narHash": "sha256-8jemYbbW9EBttQKHep7Rj8kzXaxsrk/lACdXA2DN5Xk=",
+        "lastModified": 1764939437,
+        "narHash": "sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff06bd3398fb1bea6c937039ece7e7c8aa396ebf",
+        "rev": "00d2457e2f608b4be6fe8b470b0a36816324b0ae",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764915887,
-        "narHash": "sha256-CeBCJ9BMsuzVgn8GVfuSRZ6xeau7szzG0Xn6O/OxP9M=",
+        "lastModified": 1764947035,
+        "narHash": "sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx+J2FfutM7T9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42e29df35be6ef54091d3a3b4e97056ce0a98ce8",
+        "rev": "a672be65651c80d3f592a89b3945466584a22069",
         "type": "github"
       },
       "original": {
@@ -840,11 +840,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764902447,
-        "narHash": "sha256-wNqkDBj+tjK619sTHPEA7uhjr7DHHEY8OsFou31dxy0=",
+        "lastModified": 1765161692,
+        "narHash": "sha256-XdY9AFzmgRPYIhP4N+WiCHMNxPoifP5/Ld+orMYBD8c=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d914a744a83098eeb28125d2848ad383b209223f",
+        "rev": "7ed7e8c74be95906275805db68201e74e9904f07",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1764979984,
-        "narHash": "sha256-wFbJQgFPD3t9YqrUGWHENwokLL2wwiw5G6BCuGuRFxI=",
+        "lastModified": 1765152851,
+        "narHash": "sha256-ASFuvvW1RaJI1e7RIEYB4E+qArwbluUI0/lkzO0nTuY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "4cbb79a34cb17bc22a564ca5a6625106ee0c4bdb",
+        "rev": "b1526181e1b6f4aa62bfb0ce380a83671a1865b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'dot-xmonad':
    'github:ncaq/.xmonad/6ddff23c21d2eb2eb3ad7910cb6317ccc2646286?narHash=sha256-qrUyIPZQ5h3s8GqyhXPAVGEP5UGap%2BHnnv2S%2BAVqc%2Bc%3D' (2025-10-04)
  → 'github:ncaq/.xmonad/351b574463dbd042e0003a436cd3dd2c88507ed2?narHash=sha256-33KAi2yEUKe2US25XmrSULqRBsoqswLVzgZmg%2BLHOqQ%3D' (2025-12-06)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/a62c9d889082c407557174c0647c6a950fd2fcef?narHash=sha256-cqK5A7L8yi2pXuUNE4lLipzzv18wsZOrJsgAJ6uXpPU%3D' (2025-12-06)
  → 'github:input-output-hk/haskell.nix/268ef52619a35d7800f7123b533d0d2ff626f6ba?narHash=sha256-E4qTzzzuEQmZdaC0J1D8WTFLtU%2B20z9R3BW4vMitYyo%3D' (2025-12-08)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/a7cf7e356d4c35d04089136bbe256ba10521ad98?narHash=sha256-GR7udqehfHtR1k3qTRmygbbxN/vbZAqroR6SLNxaOYA%3D' (2025-12-06)
  → 'github:input-output-hk/hackage.nix/5999bde02da34086b161bd1c583563b0fa0ac7cd?narHash=sha256-XEoPzAxi%2BP5%2B54GdVOXIgOoLpnAC7UaJeTfVJ/uN5YI%3D' (2025-12-08)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/dc84ef2f749161d60947e96da212373ded0b123a?narHash=sha256-4aBYziHvJIW6If35bW6gBTf9szrsDon/kQLo7MBR7PQ%3D' (2025-12-06)
  → 'github:input-output-hk/hackage.nix/a53012835027c67f23c11b0d7eced04e50d26094?narHash=sha256-9Q6aBAbB6fup4ie%2BtohV17LLzrwcvwKnPu5gz4fpzhE%3D' (2025-12-08)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/4cbb79a34cb17bc22a564ca5a6625106ee0c4bdb?narHash=sha256-wFbJQgFPD3t9YqrUGWHENwokLL2wwiw5G6BCuGuRFxI%3D' (2025-12-06)
  → 'github:input-output-hk/stackage.nix/b1526181e1b6f4aa62bfb0ce380a83671a1865b5?narHash=sha256-ASFuvvW1RaJI1e7RIEYB4E%2BqArwbluUI0/lkzO0nTuY%3D' (2025-12-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f63d0fe9d81d36e5fc95497217a72e02b8b7bcab?narHash=sha256-0GsEtXV9OquDQ1VclQfP16cU5VZh7NEVIOjSH4UaJuM%3D' (2025-12-04)
  → 'github:nix-community/home-manager/20561be440a11ec57a89715480717baf19fe6343?narHash=sha256-O8VTGey1xxiRW%2BFpb%2BPs9zU7ShmxUA1a7cMTcENCVNg%3D' (2025-12-08)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/10124c58674360765adcb38c9a8b081fb72904e4?narHash=sha256-FxKIa3OCSRVC23qrk7VT68vExUcmSruJ8OobVlSWOxc%3D' (2025-12-03)
  → 'github:nix-community/NixOS-WSL/a16b061ec61831755df35fae916d19b0ac5a43cc?narHash=sha256-d3b3eQsdgXZDW/y4fmDuNiGBjZzwFrLhwD5i3NmM1mM%3D' (2025-12-08)
• Updated input 'nixos-wsl/flake-compat':
    'github:edolstra/flake-compat/f387cd2afec9419c8ee37694406ca490c3f34ee5?narHash=sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4%3D' (2025-10-27)
  → 'github:edolstra/flake-compat/65f23138d8d09a92e30f1e5c87611b23ef451bf3?narHash=sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0%2BrrA%3D' (2025-12-07)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c97c47f2bac4fa59e2cbdeba289686ae615f8ed4?narHash=sha256-OtzF5wBvO0jgW1WW1rQU9cMGx7zuvkF7CAVJ1ypzkxA%3D' (2025-12-04)
  → 'github:NixOS/nixpkgs/d9bc5c7dceb30d8d6fafa10aeb6aa8a48c218454?narHash=sha256-y7RPKl/jJ/KAP/VKLMghMgXTlvNIJMHKskl8/Uuar7o%3D' (2025-12-06)
• Updated input 'nixpkgs-2505':
    'github:NixOS/nixpkgs/ff06bd3398fb1bea6c937039ece7e7c8aa396ebf?narHash=sha256-8jemYbbW9EBttQKHep7Rj8kzXaxsrk/lACdXA2DN5Xk%3D' (2025-12-04)
  → 'github:NixOS/nixpkgs/00d2457e2f608b4be6fe8b470b0a36816324b0ae?narHash=sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII%3D' (2025-12-05)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/42e29df35be6ef54091d3a3b4e97056ce0a98ce8?narHash=sha256-CeBCJ9BMsuzVgn8GVfuSRZ6xeau7szzG0Xn6O/OxP9M%3D' (2025-12-05)
  → 'github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069?narHash=sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx%2BJ2FfutM7T9w%3D' (2025-12-05)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/d914a744a83098eeb28125d2848ad383b209223f?narHash=sha256-wNqkDBj%2BtjK619sTHPEA7uhjr7DHHEY8OsFou31dxy0%3D' (2025-12-05)
  → 'github:oxalica/rust-overlay/7ed7e8c74be95906275805db68201e74e9904f07?narHash=sha256-XdY9AFzmgRPYIhP4N%2BWiCHMNxPoifP5/Ld%2BorMYBD8c%3D' (2025-12-08)
