### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764627417,
-        "narHash": "sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4=",
+        "lastModified": 1765688338,
+        "narHash": "sha256-MjrytR2kiHYUnzX11cXaD31tS7kKdhM1KFaac0+KAig=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5a88a6eceb8fd732b983e72b732f6f4b8269bef3",
+        "rev": "be1a6b8a05afdd5d5fa69fcaf3c4ead7014c9fd8",
         "type": "github"
       },
       "original": {
@@ -193,11 +193,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1765495779,
+        "narHash": "sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "5635c32d666a59ec9a55cab87e898889869f7b71",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765153629,
-        "narHash": "sha256-XEoPzAxi+P5+54GdVOXIgOoLpnAC7UaJeTfVJ/uN5YI=",
+        "lastModified": 1765758589,
+        "narHash": "sha256-Iu/lkhaFPj5QzGW+ie++fYgC9Kze2h/mmQzSUcjldms=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5999bde02da34086b161bd1c583563b0fa0ac7cd",
+        "rev": "08590f41172fe0f524330b4d88ad56dfb40491ea",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765153622,
-        "narHash": "sha256-9Q6aBAbB6fup4ie+tohV17LLzrwcvwKnPu5gz4fpzhE=",
+        "lastModified": 1765758578,
+        "narHash": "sha256-VPLG4t/SoCTdLOz9QFYiCjOph8rLsUIet20cg2JJV1E=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a53012835027c67f23c11b0d7eced04e50d26094",
+        "rev": "ee8cb0044bb365a2e1d975c019b80f8817c72b9e",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1765155108,
-        "narHash": "sha256-E4qTzzzuEQmZdaC0J1D8WTFLtU+20z9R3BW4vMitYyo=",
+        "lastModified": 1765759940,
+        "narHash": "sha256-0hYlsr9yFfvxHcXjTodFkHoIQ9QDaHXP7/4nI5/OgN8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "268ef52619a35d7800f7123b533d0d2ff626f6ba",
+        "rev": "643d58fe360166b538594a9bfc1c4ce95a5b023c",
         "type": "github"
       },
       "original": {
@@ -555,11 +555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765170903,
-        "narHash": "sha256-O8VTGey1xxiRW+Fpb+Ps9zU7ShmxUA1a7cMTcENCVNg=",
+        "lastModified": 1765605144,
+        "narHash": "sha256-RM2xs+1HdHxesjOelxoA3eSvXShC8pmBvtyTke4Ango=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20561be440a11ec57a89715480717baf19fe6343",
+        "rev": "90b62096f099b73043a747348c11dbfcfbdea949",
         "type": "github"
       },
       "original": {
@@ -625,11 +625,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765191003,
-        "narHash": "sha256-d3b3eQsdgXZDW/y4fmDuNiGBjZzwFrLhwD5i3NmM1mM=",
+        "lastModified": 1765644731,
+        "narHash": "sha256-dgSPo+NeAwcBeP4Un9GT+SMsOdLAc0DOLP6cFqoMHK8=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "a16b061ec61831755df35fae916d19b0ac5a43cc",
+        "rev": "b160ef46075d8ddc73f026909282d47c0eabb836",
         "type": "github"
       },
       "original": {
@@ -641,11 +641,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764983851,
-        "narHash": "sha256-y7RPKl/jJ/KAP/VKLMghMgXTlvNIJMHKskl8/Uuar7o=",
+        "lastModified": 1765608474,
+        "narHash": "sha256-9Wx53UK0z8Di5iesJID0tS1dRKwGxI4i7tsSanOHhF0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9bc5c7dceb30d8d6fafa10aeb6aa8a48c218454",
+        "rev": "28bb483c11a1214a73f9fd2d9928a6e2ea86ec71",
         "type": "github"
       },
       "original": {
@@ -737,11 +737,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1764939437,
-        "narHash": "sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII=",
+        "lastModified": 1765363881,
+        "narHash": "sha256-3C3xWn8/2Zzr7sxVBmpc1H1QfxjNfta5IMFe3O9ZEPw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00d2457e2f608b4be6fe8b470b0a36816324b0ae",
+        "rev": "d2b1213bf5ec5e62d96b003ab4b5cbc42abfc0d0",
         "type": "github"
       },
       "original": {
@@ -784,11 +784,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764947035,
-        "narHash": "sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx+J2FfutM7T9w=",
+        "lastModified": 1765644376,
+        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a672be65651c80d3f592a89b3945466584a22069",
+        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
         "type": "github"
       },
       "original": {
@@ -840,11 +840,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765161692,
-        "narHash": "sha256-XdY9AFzmgRPYIhP4N+WiCHMNxPoifP5/Ld+orMYBD8c=",
+        "lastModified": 1765766816,
+        "narHash": "sha256-m2au5a2x9L3ikyBi0g3/NRJSjmHVDvT42mn+O6FlyPs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ed7e8c74be95906275805db68201e74e9904f07",
+        "rev": "4f53a635709d82652567f51ef7af4365fbc0c88b",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765152851,
-        "narHash": "sha256-ASFuvvW1RaJI1e7RIEYB4E+qArwbluUI0/lkzO0nTuY=",
+        "lastModified": 1765757694,
+        "narHash": "sha256-gQeXpO+l6TSjpULcdyhH8kZDtjNk5OIFsW49ONbjWtc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "b1526181e1b6f4aa62bfb0ce380a83671a1865b5",
+        "rev": "1dec64e3c0b626a4732800c00857e6dcd321a9d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/5a88a6eceb8fd732b983e72b732f6f4b8269bef3?narHash=sha256-D6xc3Rl8Ab6wucJWdvjNsGYGSxNjQHzRc2EZ6eeQ6l4%3D' (2025-12-01)
  → 'github:nix-community/disko/be1a6b8a05afdd5d5fa69fcaf3c4ead7014c9fd8?narHash=sha256-MjrytR2kiHYUnzX11cXaD31tS7kKdhM1KFaac0%2BKAig%3D' (2025-12-14)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/2cccadc7357c0ba201788ae99c4dfa90728ef5e0?narHash=sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q%3D' (2025-11-21)
  → 'github:hercules-ci/flake-parts/5635c32d666a59ec9a55cab87e898889869f7b71?narHash=sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM%3D' (2025-12-11)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/268ef52619a35d7800f7123b533d0d2ff626f6ba?narHash=sha256-E4qTzzzuEQmZdaC0J1D8WTFLtU%2B20z9R3BW4vMitYyo%3D' (2025-12-08)
  → 'github:input-output-hk/haskell.nix/643d58fe360166b538594a9bfc1c4ce95a5b023c?narHash=sha256-0hYlsr9yFfvxHcXjTodFkHoIQ9QDaHXP7/4nI5/OgN8%3D' (2025-12-15)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/5999bde02da34086b161bd1c583563b0fa0ac7cd?narHash=sha256-XEoPzAxi%2BP5%2B54GdVOXIgOoLpnAC7UaJeTfVJ/uN5YI%3D' (2025-12-08)
  → 'github:input-output-hk/hackage.nix/08590f41172fe0f524330b4d88ad56dfb40491ea?narHash=sha256-Iu/lkhaFPj5QzGW%2Bie%2B%2BfYgC9Kze2h/mmQzSUcjldms%3D' (2025-12-15)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/a53012835027c67f23c11b0d7eced04e50d26094?narHash=sha256-9Q6aBAbB6fup4ie%2BtohV17LLzrwcvwKnPu5gz4fpzhE%3D' (2025-12-08)
  → 'github:input-output-hk/hackage.nix/ee8cb0044bb365a2e1d975c019b80f8817c72b9e?narHash=sha256-VPLG4t/SoCTdLOz9QFYiCjOph8rLsUIet20cg2JJV1E%3D' (2025-12-15)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/b1526181e1b6f4aa62bfb0ce380a83671a1865b5?narHash=sha256-ASFuvvW1RaJI1e7RIEYB4E%2BqArwbluUI0/lkzO0nTuY%3D' (2025-12-08)
  → 'github:input-output-hk/stackage.nix/1dec64e3c0b626a4732800c00857e6dcd321a9d2?narHash=sha256-gQeXpO%2Bl6TSjpULcdyhH8kZDtjNk5OIFsW49ONbjWtc%3D' (2025-12-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/20561be440a11ec57a89715480717baf19fe6343?narHash=sha256-O8VTGey1xxiRW%2BFpb%2BPs9zU7ShmxUA1a7cMTcENCVNg%3D' (2025-12-08)
  → 'github:nix-community/home-manager/90b62096f099b73043a747348c11dbfcfbdea949?narHash=sha256-RM2xs%2B1HdHxesjOelxoA3eSvXShC8pmBvtyTke4Ango%3D' (2025-12-13)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/a16b061ec61831755df35fae916d19b0ac5a43cc?narHash=sha256-d3b3eQsdgXZDW/y4fmDuNiGBjZzwFrLhwD5i3NmM1mM%3D' (2025-12-08)
  → 'github:nix-community/NixOS-WSL/b160ef46075d8ddc73f026909282d47c0eabb836?narHash=sha256-dgSPo%2BNeAwcBeP4Un9GT%2BSMsOdLAc0DOLP6cFqoMHK8%3D' (2025-12-13)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/d9bc5c7dceb30d8d6fafa10aeb6aa8a48c218454?narHash=sha256-y7RPKl/jJ/KAP/VKLMghMgXTlvNIJMHKskl8/Uuar7o%3D' (2025-12-06)
  → 'github:NixOS/nixpkgs/28bb483c11a1214a73f9fd2d9928a6e2ea86ec71?narHash=sha256-9Wx53UK0z8Di5iesJID0tS1dRKwGxI4i7tsSanOHhF0%3D' (2025-12-13)
• Updated input 'nixpkgs-2505':
    'github:NixOS/nixpkgs/00d2457e2f608b4be6fe8b470b0a36816324b0ae?narHash=sha256-4TLFHUwXraw9Df5mXC/vCrJgb50CRr3CzUzF0Mn3CII%3D' (2025-12-05)
  → 'github:NixOS/nixpkgs/d2b1213bf5ec5e62d96b003ab4b5cbc42abfc0d0?narHash=sha256-3C3xWn8/2Zzr7sxVBmpc1H1QfxjNfta5IMFe3O9ZEPw%3D' (2025-12-10)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069?narHash=sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx%2BJ2FfutM7T9w%3D' (2025-12-05)
  → 'github:NixOS/nixpkgs/23735a82a828372c4ef92c660864e82fbe2f5fbe?narHash=sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE%3D' (2025-12-13)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/7ed7e8c74be95906275805db68201e74e9904f07?narHash=sha256-XdY9AFzmgRPYIhP4N%2BWiCHMNxPoifP5/Ld%2BorMYBD8c%3D' (2025-12-08)
  → 'github:oxalica/rust-overlay/4f53a635709d82652567f51ef7af4365fbc0c88b?narHash=sha256-m2au5a2x9L3ikyBi0g3/NRJSjmHVDvT42mn%2BO6FlyPs%3D' (2025-12-15)
