### PR TITLE
feat(font): Firgeフォントとfirge-nixを導入し設定を更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,6 +155,26 @@
         "type": "github"
       }
     },
+    "firge-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765876310,
+        "narHash": "sha256-1ID2zFp0LnP4T2RFZ1dB2fYYOzIH1keVet5jP/aUmNc=",
+        "owner": "ncaq",
+        "repo": "firge-nix",
+        "rev": "f9294236ec07c68192bac1b893c5e9f82d77a14a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ncaq",
+        "repo": "firge-nix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -820,6 +840,7 @@
         "claude-desktop": "claude-desktop",
         "disko": "disko",
         "dot-xmonad": "dot-xmonad",
+        "firge-nix": "firge-nix",
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,11 @@
         flake-utils.follows = "flake-utils";
       };
     };
+
+    firge-nix = {
+      url = "github:ncaq/firge-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -77,6 +82,7 @@
       rust-overlay,
       dot-xmonad,
       claude-desktop,
+      firge-nix,
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -120,7 +126,10 @@
                     { ... }:
                     {
                       nixpkgs.config.allowUnfree = true;
-                      nixpkgs.overlays = [ rust-overlay.overlays.default ];
+                      nixpkgs.overlays = [
+                        rust-overlay.overlays.default
+                        firge-nix.overlays.default
+                      ];
                     }
                   )
                   ./home
@@ -165,7 +174,10 @@
                     { ... }:
                     {
                       nixpkgs.config.allowUnfree = true;
-                      nixpkgs.overlays = [ rust-overlay.overlays.default ];
+                      nixpkgs.overlays = [
+                        rust-overlay.overlays.default
+                        firge-nix.overlays.default
+                      ];
                     }
                   )
                   disko.nixosModules.default

--- a/home/package/font.nix
+++ b/home/package/font.nix
@@ -28,13 +28,13 @@ in
   fonts.fontconfig = {
     enable = true;
     defaultFonts = {
-      sansSerif = [ "Fira Sans" ];
+      sansSerif = [ "monospace" ]; # 日本語フォントをしっかり合成しているフォントをプログラミングフォントしか知らないため。
       serif = [
         "Noto Serif CJK JP"
         "emoji"
       ];
       monospace = [
-        "Fira Mono"
+        "FirgeNerd Console"
         "emoji"
       ];
       emoji = [ "Noto Color Emoji" ];
@@ -43,6 +43,8 @@ in
 
   home.packages = with pkgs; [
     fira
+    firge-font
+    firge-nerd-font
     hackgen-nf-font
     noto-fonts
     noto-fonts-cjk-sans


### PR DESCRIPTION
- firge-nix flakeを追加し、overlaysに組み込み
- FirgeNerd Consoleをmonospaceフォントに設定
- firge-font, firge-nerd-fontをhome.packagesに追加
- デフォルトsansSerifフォントをmonospaceに変更
