### PR TITLE
fix(claude): claudeのsandbox設定を削除して動作トラブルを回避

### DIFF
--- a/home/config/claude/settings.json
+++ b/home/config/claude/settings.json
@@ -270,10 +270,6 @@
     "defaultMode": "acceptEdits",
     "additionalDirectories": ["~/dotfiles/"]
   },
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": true
-  },
   "statusLine": {
     "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"


### PR DESCRIPTION
あまりにもsandboxが原因で問題が発生して、
Claude Codeが原因に気が付かないことが多かったので、
現状のところは無効化します。
