### PR TITLE
build(git-hooks): git-hooksのバージョン更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -246,16 +246,22 @@
     },
     "git-hooks": {
       "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
         "nixpkgs": [
           "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1766199708,
-        "narHash": "sha256-O9CGLAqI2cVF4EySLtiQwruy0QaeqqlozERY81B3ywU=",
+        "lastModified": 1766203355,
+        "narHash": "sha256-m04Rp1njgodx1RzrPtL0oPGA3q7ddLvLemXHvPBLDYA=",
         "owner": "ncaq",
         "repo": "git-hooks",
-        "rev": "1c01dd901390b5f9e725a53450347a3fdfc1ac06",
+        "rev": "53f86e828254925eac7995ac0e613af9027b2bad",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,11 @@
 
     git-hooks = {
       url = "github:ncaq/git-hooks";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        treefmt-nix.follows = "treefmt-nix";
+      };
     };
 
     dot-xmonad = {

--- a/home/package/git.nix
+++ b/home/package/git.nix
@@ -1,6 +1,6 @@
 { pkgs, inputs, ... }:
 {
-  imports = [ inputs.git-hooks.homeManagerModules.default ];
+  imports = [ inputs.git-hooks.modules.homeManager.default ];
   programs = {
     git = {
       enable = true;


### PR DESCRIPTION
- git-hooksのリビジョンを更新し、flake-partsとtreefmt-nixのinputsを追加
- homeManagerModules.defaultからmodules.homeManager.defaultへの参照に修正
- flake.nixのinputs構成を最新仕様に対応
