### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765688338,
-        "narHash": "sha256-MjrytR2kiHYUnzX11cXaD31tS7kKdhM1KFaac0+KAig=",
+        "lastModified": 1766150702,
+        "narHash": "sha256-P0kM+5o+DKnB6raXgFEk3azw8Wqg5FL6wyl9jD+G5a4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "be1a6b8a05afdd5d5fa69fcaf3c4ead7014c9fd8",
+        "rev": "916506443ecd0d0b4a0f4cf9d40a3c22ce39b378",
         "type": "github"
       },
       "original": {
@@ -235,11 +235,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765495779,
-        "narHash": "sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5635c32d666a59ec9a55cab87e898889869f7b71",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766203355,
-        "narHash": "sha256-m04Rp1njgodx1RzrPtL0oPGA3q7ddLvLemXHvPBLDYA=",
+        "lastModified": 1766206777,
+        "narHash": "sha256-OvHhDheZtG+CRTJFYOgqjRIAbV6Ii+9mxKs9niZbjws=",
         "owner": "ncaq",
         "repo": "git-hooks",
-        "rev": "53f86e828254925eac7995ac0e613af9027b2bad",
+        "rev": "05730ed5104475cc9a109fa764b4f723eefef3c4",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765758589,
-        "narHash": "sha256-Iu/lkhaFPj5QzGW+ie++fYgC9Kze2h/mmQzSUcjldms=",
+        "lastModified": 1766276986,
+        "narHash": "sha256-DI+/5EOhDQaZZfFI3CINc7J8r0Cm7C2MYaS3xZg1meM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "08590f41172fe0f524330b4d88ad56dfb40491ea",
+        "rev": "d8928a5337b6d8c492c7b885dcca33877c5d737b",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765758578,
-        "narHash": "sha256-VPLG4t/SoCTdLOz9QFYiCjOph8rLsUIet20cg2JJV1E=",
+        "lastModified": 1766276975,
+        "narHash": "sha256-mQO3OcYMFM2cWWFPLE5ltA4TSEs+I6pgkk0kto0vsmo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ee8cb0044bb365a2e1d975c019b80f8817c72b9e",
+        "rev": "c8befd7d01ed6ba6e8c52d58813448a7b87f1946",
         "type": "github"
       },
       "original": {
@@ -383,11 +383,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1765759940,
-        "narHash": "sha256-0hYlsr9yFfvxHcXjTodFkHoIQ9QDaHXP7/4nI5/OgN8=",
+        "lastModified": 1766278310,
+        "narHash": "sha256-aYj36TcSwCr7mD8P7GqzJ7wah5GS7lbUUcpOUWPDNOM=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "643d58fe360166b538594a9bfc1c4ce95a5b023c",
+        "rev": "aa4b343a57b24b53c2fb62b0a99944f553379c3b",
         "type": "github"
       },
       "original": {
@@ -623,11 +623,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765605144,
-        "narHash": "sha256-RM2xs+1HdHxesjOelxoA3eSvXShC8pmBvtyTke4Ango=",
+        "lastModified": 1766292113,
+        "narHash": "sha256-sWTtmkQujRpjWYCnZc8LWdDiCzrRlSBPrGovkZpLkBI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90b62096f099b73043a747348c11dbfcfbdea949",
+        "rev": "fdec8815a86db36f42fc9c8cb2931cd8485f5aed",
         "type": "github"
       },
       "original": {
@@ -731,11 +731,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765644731,
-        "narHash": "sha256-dgSPo+NeAwcBeP4Un9GT+SMsOdLAc0DOLP6cFqoMHK8=",
+        "lastModified": 1765841014,
+        "narHash": "sha256-55V0AJ36V5Egh4kMhWtDh117eE3GOjwq5LhwxDn9eHg=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "b160ef46075d8ddc73f026909282d47c0eabb836",
+        "rev": "be4af8042e7a61fa12fda58fe9a3b3babdefe17b",
         "type": "github"
       },
       "original": {
@@ -747,11 +747,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765608474,
-        "narHash": "sha256-9Wx53UK0z8Di5iesJID0tS1dRKwGxI4i7tsSanOHhF0=",
+        "lastModified": 1766201043,
+        "narHash": "sha256-eplAP+rorKKd0gNjV3rA6+0WMzb1X1i16F5m5pASnjA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28bb483c11a1214a73f9fd2d9928a6e2ea86ec71",
+        "rev": "b3aad468604d3e488d627c0b43984eb60e75e782",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1765363881,
-        "narHash": "sha256-3C3xWn8/2Zzr7sxVBmpc1H1QfxjNfta5IMFe3O9ZEPw=",
+        "lastModified": 1766014764,
+        "narHash": "sha256-+73VffE5GP5fvbib6Hs1Su6LehG+9UV1Kzs90T2gBLA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2b1213bf5ec5e62d96b003ab4b5cbc42abfc0d0",
+        "rev": "2b0d2b456e4e8452cf1c16d00118d145f31160f9",
         "type": "github"
       },
       "original": {
@@ -875,11 +875,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -890,11 +890,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1765644376,
-        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
+        "lastModified": 1766125104,
+        "narHash": "sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O+LiaeCPWEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
+        "rev": "7d853e518814cca2a657b72eeba67ae20ebf7059",
         "type": "github"
       },
       "original": {
@@ -1000,11 +1000,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765766816,
-        "narHash": "sha256-m2au5a2x9L3ikyBi0g3/NRJSjmHVDvT42mn+O6FlyPs=",
+        "lastModified": 1766285238,
+        "narHash": "sha256-DqVXFZ4ToiFHgnxebMWVL70W+U+JOxpmfD37eWD/Qc8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4f53a635709d82652567f51ef7af4365fbc0c88b",
+        "rev": "c4249d0c370d573d95e33b472014eae4f2507c2f",
         "type": "github"
       },
       "original": {
@@ -1016,11 +1016,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765757694,
-        "narHash": "sha256-gQeXpO+l6TSjpULcdyhH8kZDtjNk5OIFsW49ONbjWtc=",
+        "lastModified": 1766276095,
+        "narHash": "sha256-tvVLGWjNHyIhlst8poB0/c3gNnHygibmFqj+gEA+JRs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "1dec64e3c0b626a4732800c00857e6dcd321a9d2",
+        "rev": "bed92b6c57656b9b32176ea5b9796be66dc29257",
         "type": "github"
       },
       "original": {
@@ -1051,11 +1051,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762938485,
-        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
+        "lastModified": 1766000401,
+        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
         "type": "github"
       },
       "original": {
@@ -1083,11 +1083,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765241491,
-        "narHash": "sha256-qLYvZ4kiBnEoC4CX/aXxo9g53xNdAgJgJWEDMxAdsJ8=",
+        "lastModified": 1766216772,
+        "narHash": "sha256-6851zgaWRAyZDvgGQEU1kfMiVwTY+AwypMwzWBYeb/g=",
         "owner": "ncaq",
         "repo": "www.ncaq.net",
-        "rev": "77e3f6a4071fb70577122ef15cc4973954bdcd3d",
+        "rev": "51496d19671466fb1b1a6eb9542757c845e538e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/be1a6b8a05afdd5d5fa69fcaf3c4ead7014c9fd8?narHash=sha256-MjrytR2kiHYUnzX11cXaD31tS7kKdhM1KFaac0%2BKAig%3D' (2025-12-14)
  → 'github:nix-community/disko/916506443ecd0d0b4a0f4cf9d40a3c22ce39b378?narHash=sha256-P0kM%2B5o%2BDKnB6raXgFEk3azw8Wqg5FL6wyl9jD%2BG5a4%3D' (2025-12-19)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/5635c32d666a59ec9a55cab87e898889869f7b71?narHash=sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM%3D' (2025-12-11)
  → 'github:hercules-ci/flake-parts/a34fae9c08a15ad73f295041fec82323541400a9?narHash=sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw%3D' (2025-12-15)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/719359f4562934ae99f5443f20aa06c2ffff91fc?narHash=sha256-b0yj6kfvO8ApcSE%2BQmA6mUfu8IYG6/uU28OFn4PaC8M%3D' (2025-10-29)
  → 'github:nix-community/nixpkgs.lib/2075416fcb47225d9b68ac469a5c4801a9c4dd85?narHash=sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo%3D' (2025-12-14)
• Updated input 'git-hooks':
    'github:ncaq/git-hooks/53f86e828254925eac7995ac0e613af9027b2bad?narHash=sha256-m04Rp1njgodx1RzrPtL0oPGA3q7ddLvLemXHvPBLDYA%3D' (2025-12-20)
  → 'github:ncaq/git-hooks/05730ed5104475cc9a109fa764b4f723eefef3c4?narHash=sha256-OvHhDheZtG%2BCRTJFYOgqjRIAbV6Ii%2B9mxKs9niZbjws%3D' (2025-12-20)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/643d58fe360166b538594a9bfc1c4ce95a5b023c?narHash=sha256-0hYlsr9yFfvxHcXjTodFkHoIQ9QDaHXP7/4nI5/OgN8%3D' (2025-12-15)
  → 'github:input-output-hk/haskell.nix/aa4b343a57b24b53c2fb62b0a99944f553379c3b?narHash=sha256-aYj36TcSwCr7mD8P7GqzJ7wah5GS7lbUUcpOUWPDNOM%3D' (2025-12-21)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/08590f41172fe0f524330b4d88ad56dfb40491ea?narHash=sha256-Iu/lkhaFPj5QzGW%2Bie%2B%2BfYgC9Kze2h/mmQzSUcjldms%3D' (2025-12-15)
  → 'github:input-output-hk/hackage.nix/d8928a5337b6d8c492c7b885dcca33877c5d737b?narHash=sha256-DI%2B/5EOhDQaZZfFI3CINc7J8r0Cm7C2MYaS3xZg1meM%3D' (2025-12-21)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/ee8cb0044bb365a2e1d975c019b80f8817c72b9e?narHash=sha256-VPLG4t/SoCTdLOz9QFYiCjOph8rLsUIet20cg2JJV1E%3D' (2025-12-15)
  → 'github:input-output-hk/hackage.nix/c8befd7d01ed6ba6e8c52d58813448a7b87f1946?narHash=sha256-mQO3OcYMFM2cWWFPLE5ltA4TSEs%2BI6pgkk0kto0vsmo%3D' (2025-12-21)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/1dec64e3c0b626a4732800c00857e6dcd321a9d2?narHash=sha256-gQeXpO%2Bl6TSjpULcdyhH8kZDtjNk5OIFsW49ONbjWtc%3D' (2025-12-15)
  → 'github:input-output-hk/stackage.nix/bed92b6c57656b9b32176ea5b9796be66dc29257?narHash=sha256-tvVLGWjNHyIhlst8poB0/c3gNnHygibmFqj%2BgEA%2BJRs%3D' (2025-12-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/90b62096f099b73043a747348c11dbfcfbdea949?narHash=sha256-RM2xs%2B1HdHxesjOelxoA3eSvXShC8pmBvtyTke4Ango%3D' (2025-12-13)
  → 'github:nix-community/home-manager/fdec8815a86db36f42fc9c8cb2931cd8485f5aed?narHash=sha256-sWTtmkQujRpjWYCnZc8LWdDiCzrRlSBPrGovkZpLkBI%3D' (2025-12-21)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/b160ef46075d8ddc73f026909282d47c0eabb836?narHash=sha256-dgSPo%2BNeAwcBeP4Un9GT%2BSMsOdLAc0DOLP6cFqoMHK8%3D' (2025-12-13)
  → 'github:nix-community/NixOS-WSL/be4af8042e7a61fa12fda58fe9a3b3babdefe17b?narHash=sha256-55V0AJ36V5Egh4kMhWtDh117eE3GOjwq5LhwxDn9eHg%3D' (2025-12-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/28bb483c11a1214a73f9fd2d9928a6e2ea86ec71?narHash=sha256-9Wx53UK0z8Di5iesJID0tS1dRKwGxI4i7tsSanOHhF0%3D' (2025-12-13)
  → 'github:NixOS/nixpkgs/b3aad468604d3e488d627c0b43984eb60e75e782?narHash=sha256-eplAP%2BrorKKd0gNjV3rA6%2B0WMzb1X1i16F5m5pASnjA%3D' (2025-12-20)
• Updated input 'nixpkgs-2505':
    'github:NixOS/nixpkgs/d2b1213bf5ec5e62d96b003ab4b5cbc42abfc0d0?narHash=sha256-3C3xWn8/2Zzr7sxVBmpc1H1QfxjNfta5IMFe3O9ZEPw%3D' (2025-12-10)
  → 'github:NixOS/nixpkgs/2b0d2b456e4e8452cf1c16d00118d145f31160f9?narHash=sha256-%2B73VffE5GP5fvbib6Hs1Su6LehG%2B9UV1Kzs90T2gBLA%3D' (2025-12-17)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/23735a82a828372c4ef92c660864e82fbe2f5fbe?narHash=sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE%3D' (2025-12-13)
  → 'github:NixOS/nixpkgs/7d853e518814cca2a657b72eeba67ae20ebf7059?narHash=sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O%2BLiaeCPWEM%3D' (2025-12-19)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/4f53a635709d82652567f51ef7af4365fbc0c88b?narHash=sha256-m2au5a2x9L3ikyBi0g3/NRJSjmHVDvT42mn%2BO6FlyPs%3D' (2025-12-15)
  → 'github:oxalica/rust-overlay/c4249d0c370d573d95e33b472014eae4f2507c2f?narHash=sha256-DqVXFZ4ToiFHgnxebMWVL70W%2BU%2BJOxpmfD37eWD/Qc8%3D' (2025-12-21)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4?narHash=sha256-AlEObg0syDl%2BSpi4LsZIBrjw%2BsnSVU4T8MOeuZJUJjM%3D' (2025-11-12)
  → 'github:numtide/treefmt-nix/42d96e75aa56a3f70cab7e7dc4a32868db28e8fd?narHash=sha256-%2BcqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI%3D' (2025-12-17)
• Updated input 'www-ncaq-net':
    'github:ncaq/www.ncaq.net/77e3f6a4071fb70577122ef15cc4973954bdcd3d?narHash=sha256-qLYvZ4kiBnEoC4CX/aXxo9g53xNdAgJgJWEDMxAdsJ8%3D' (2025-12-09)
  → 'github:ncaq/www.ncaq.net/51496d19671466fb1b1a6eb9542757c845e538e5?narHash=sha256-6851zgaWRAyZDvgGQEU1kfMiVwTY%2BAwypMwzWBYeb/g%3D' (2025-12-20)
