### PR TITLE
fix(claude): additionalDirectoriesに/nix/store/を追加して静的ビルドディレクトリの読み取りを許可

### DIFF
--- a/home/config/claude/settings.json
+++ b/home/config/claude/settings.json
@@ -280,7 +280,7 @@
     ],
     "deny": ["Bash(git commit:*)", "Bash(head:*)", "Bash(rm:*)", "Bash(tail:*)"],
     "defaultMode": "acceptEdits",
-    "additionalDirectories": ["~/dotfiles/"]
+    "additionalDirectories": ["/nix/store/", "~/dotfiles/"]
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
resultのシンボリックリンクを見ようとたどる時に、
許可を求めてくることが多いです。
ビルド後のバイナリファイルに機密情報が含まれている方がおかしいので全部許可します。
読み取り専用になっているはずなので壊すリスクもほぼありませんし。
