### PR TITLE
fix(locate): locateの除外パターンにprojectsを追加

### DIFF
--- a/nixos/core/locate.nix
+++ b/nixos/core/locate.nix
@@ -49,6 +49,7 @@
       "file-backup"
       "htmlcache"
       "node_modules"
+      "projects" # claude code
       "site-packages"
       "steam-runtime"
       "store"


### PR DESCRIPTION
Emacsのディレクトリ補完に大量のclaude codeのindexが表示されてしまうので仕方なく除外。
本当は`projects`という一般的な名前を除外するのは避けたいが、
フルパスを指定するのはもっと嫌なので妥協します。
