### PR TITLE
feat(firefox): NixOSオプション検索エンジンを追加

### DIFF
--- a/home/package/firefox.nix
+++ b/home/package/firefox.nix
@@ -234,6 +234,25 @@
                   "@mdn"
                 ];
               };
+              nixos-options = {
+                name = "NixOS Search - Options";
+                urls = [
+                  {
+                    template = "https://search.nixos.org/options";
+                    params = [
+                      {
+                        name = "query";
+                        value = "{searchTerms}";
+                      }
+                    ];
+                  }
+                ];
+                icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+                definedAliases = [
+                  "nn"
+                  "@nixos-options"
+                ];
+              };
               nixos-packages = {
                 name = "NixOS Search - Packages";
                 urls = [


### PR DESCRIPTION
close #227

- Firefoxの検索エンジンに「NixOS Search - Options」を追加
- クエリパラメータやアイコン、エイリアスを設定
- NixOSパッケージ検索エンジンとの一貫性を確保
