### PR TITLE
fix: READMEとハードウェア手順をローカルapp参照に統一しapps追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo nixos-generate-config --show-hardware-config --no-filesystems > ~/dotfiles/
 NEW_HOST=please-input-new-hostname
 nix --extra-experimental-features 'flakes nix-command' run 'nixpkgs#git' -- clone https://github.com/ncaq/dotfiles.git
 cd dotfiles
-sudo nix --experimental-features 'flakes nix-command' run github:nix-community/disko/latest -- --mode format,mount --flake ".#${NEW_HOST}"
+sudo nix --experimental-features 'flakes nix-command' run '.#disko' -- --mode format,mount --flake ".#${NEW_HOST}"
 sudo nixos-install --flake ".#${NEW_HOST}" --root /mnt
 ```
 
@@ -130,7 +130,7 @@ Please reboot.
 ## Non NixOS(home-manager standalone)
 
 ```zsh
-nix run home-manager/release-25.11 -- --flake ".#${USER}" init --switch .
+nix run '.#home-manager' -- --flake ".#${USER}" init --switch .
 ```
 
 # Rebuild
@@ -164,7 +164,7 @@ nix flake check
 ## Dynamic
 
 ```zsh
-nix run github:nix-community/home-manager -- switch --flake ".#${USER}" -n -b backup
+nix run '.#home-manager' -- switch --flake ".#${USER}" -n -b backup
 ```
 
 # Policy

--- a/flake.nix
+++ b/flake.nix
@@ -257,6 +257,7 @@
       perSystem =
         {
           pkgs,
+          inputs',
           ...
         }:
         {
@@ -271,6 +272,21 @@
             };
           };
           apps = {
+            home-manager = {
+              type = "app";
+              meta.description = "Manage user configuration with Nix";
+              program = "${inputs'.home-manager.packages.home-manager}/bin/home-manager";
+            };
+            disko = {
+              type = "app";
+              meta.description = "Declarative disk partitioning";
+              program = "${inputs'.disko.packages.disko}/bin/disko";
+            };
+            fastfetch = {
+              type = "app";
+              meta.description = "Fast system information tool";
+              program = "${pkgs.fastfetch}/bin/fastfetch";
+            };
             cachix-push = {
               type = "app";
               meta = {

--- a/home/prompt/environment/hardware.md
+++ b/home/prompt/environment/hardware.md
@@ -6,7 +6,7 @@
 特にディスクの利用サイズなどは日々変動します。
 
 ```console
-nix run --file '<nixpkgs>' fastfetch -- --logo none
+nix run "$HOME/dotfiles#fastfetch" -- --logo none
 ```
 
 コマンドを動いているマシンで実行することでほぼ同じ最新の情報を取得できます。


### PR DESCRIPTION
close #279

互換性が不意に壊されるのを防ぐためにexportしたものを参照してrunします。
cloneする前に実行する場合はどうしようもないので許容しています。
実行するもの安定していることでおなじみのgitですし。
