### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,11 +273,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766968211,
-        "narHash": "sha256-DB5Kx0nbd2nNIAlzDsuaMJVR0ZuE6eDGXLiBUrjjhhQ=",
+        "lastModified": 1767141591,
+        "narHash": "sha256-cCEabPdI8876eBSe7mL/DbWPlqD2CYKxyD1ePAtKkAs=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "bda3f7d0638491fa48a4c2399d55a10f037376c8",
+        "rev": "a12363ce5e23fb52e0f13135776737883a8bc2c0",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766968201,
-        "narHash": "sha256-3wxI03LTp1UByFjA8FmswrFAmWFSB7myEXXEMQ7mYcg=",
+        "lastModified": 1767140915,
+        "narHash": "sha256-Tk830ruFUpoIUbQng/Z/GfUdxGHMb76Dm87dhS8V4UA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "b8cb05b495e1aeb0652095778e4a54271198299b",
+        "rev": "c12c9956e383c3d3953d192c5eb19abfd7313eaa",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1766969545,
-        "narHash": "sha256-PxhXIz6lyCfmN1C0g+dic6BNHLWQLKKyZEc5T5nJZ4I=",
+        "lastModified": 1767142341,
+        "narHash": "sha256-hJN59/YH+QqPynH9KDeSwF/ZLSKs4CEh042MDECfdU8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6d16075ed12340596c2cb2970076def2e27b916e",
+        "rev": "6d704c80bba2a732228d51efa7ca533933f50343",
         "type": "github"
       },
       "original": {
@@ -601,11 +601,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766939458,
-        "narHash": "sha256-VvZeAKyB3vhyHStSO8ACKzWRKNQPmVWktjfuSVdvtUA=",
+        "lastModified": 1767024057,
+        "narHash": "sha256-B1aycRjMRvb6QOGbnqDhiDzZwMebj5jxZ5qyJzaKvpI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e298a148013c980e3c8c0ac075295fab5074d643",
+        "rev": "34578a2fdfce4257ce5f5baf6e7efbd4e4e252b1",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1766568855,
-        "narHash": "sha256-UXVtN77D7pzKmzOotFTStgZBqpOcf8cO95FcupWp4Zo=",
+        "lastModified": 1767185284,
+        "narHash": "sha256-ljDBUDpD1Cg5n3mJI81Hz5qeZAwCGxon4kQW3Ho3+6Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c5db9569ac9cc70929c268ac461f4003e3e5ca80",
+        "rev": "40b1a28dce561bea34858287fbb23052c3ee63fe",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766736597,
-        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "lastModified": 1767047869,
+        "narHash": "sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "rev": "89dbf01df72eb5ebe3b24a86334b12c27d68016a",
         "type": "github"
       },
       "original": {
@@ -821,11 +821,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1766687554,
-        "narHash": "sha256-DegN7KD/EtFSKXf2jvqL6lvev6GlfAAatYBcRC8goEo=",
+        "lastModified": 1767051569,
+        "narHash": "sha256-0MnuWoN+n1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd0ca39c92fdb4012ed8d60e1683c26fddadd136",
+        "rev": "40ee5e1944bebdd128f9fbada44faefddfde29bd",
         "type": "github"
       },
       "original": {
@@ -868,11 +868,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1766870016,
-        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
+        "lastModified": 1767151656,
+        "narHash": "sha256-ujL2AoYBnJBN262HD95yer7QYUmYp5kFZGYbyCCKxq8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
+        "rev": "f665af0cdb70ed27e1bd8f9fdfecaf451260fc55",
         "type": "github"
       },
       "original": {
@@ -962,11 +962,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766890375,
-        "narHash": "sha256-0Zi7ChAtjq/efwQYmp7kOJPcSt6ya9ynSUe6ppgZhsQ=",
+        "lastModified": 1767149068,
+        "narHash": "sha256-TjfAb58Ybz/93e2jP0qD846dj+VqiY7wk+EqsxcZ708=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "91e1f7a0017065360f447622d11b7ce6ed04772f",
+        "rev": "6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3",
         "type": "github"
       },
       "original": {
@@ -978,11 +978,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766967338,
-        "narHash": "sha256-78iiKkp1JDPD2bpgQyhQz4h8Fau7OKxLQnoK8DVe4JI=",
+        "lastModified": 1767140080,
+        "narHash": "sha256-qEi8of88mZJW1+0kNpO0Gf6/ZufBHDX38eWqab5h5JE=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "da8818e32949d1f588a94667d3b7cb606cf9895e",
+        "rev": "25130e3cf5893818f368b46746761fc2c97edd96",
         "type": "github"
       },
       "original": {
@@ -1013,11 +1013,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766000401,
-        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
+        "lastModified": 1767122417,
+        "narHash": "sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
+        "rev": "dec15f37015ac2e774c84d0952d57fcdf169b54d",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766912586,
-        "narHash": "sha256-cD2kQn8JAc91S2gSuu3lbTgWEWIl+9/aD8/KN1C6i0Q=",
+        "lastModified": 1767079391,
+        "narHash": "sha256-OpI4g1y4YjuOYGClk4LAltqUprKsxr83rxMyYR+z2s4=",
         "owner": "ncaq",
         "repo": "www.ncaq.net",
-        "rev": "842669ca2ca660645cf83375ced0eee91702dff3",
+        "rev": "3c0a673a0e76ae96d2be058467a6c70c74c25f75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/6d16075ed12340596c2cb2970076def2e27b916e?narHash=sha256-PxhXIz6lyCfmN1C0g%2Bdic6BNHLWQLKKyZEc5T5nJZ4I%3D' (2025-12-29)
  → 'github:input-output-hk/haskell.nix/6d704c80bba2a732228d51efa7ca533933f50343?narHash=sha256-hJN59/YH%2BQqPynH9KDeSwF/ZLSKs4CEh042MDECfdU8%3D' (2025-12-31)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/bda3f7d0638491fa48a4c2399d55a10f037376c8?narHash=sha256-DB5Kx0nbd2nNIAlzDsuaMJVR0ZuE6eDGXLiBUrjjhhQ%3D' (2025-12-29)
  → 'github:input-output-hk/hackage.nix/a12363ce5e23fb52e0f13135776737883a8bc2c0?narHash=sha256-cCEabPdI8876eBSe7mL/DbWPlqD2CYKxyD1ePAtKkAs%3D' (2025-12-31)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/b8cb05b495e1aeb0652095778e4a54271198299b?narHash=sha256-3wxI03LTp1UByFjA8FmswrFAmWFSB7myEXXEMQ7mYcg%3D' (2025-12-29)
  → 'github:input-output-hk/hackage.nix/c12c9956e383c3d3953d192c5eb19abfd7313eaa?narHash=sha256-Tk830ruFUpoIUbQng/Z/GfUdxGHMb76Dm87dhS8V4UA%3D' (2025-12-31)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/da8818e32949d1f588a94667d3b7cb606cf9895e?narHash=sha256-78iiKkp1JDPD2bpgQyhQz4h8Fau7OKxLQnoK8DVe4JI%3D' (2025-12-29)
  → 'github:input-output-hk/stackage.nix/25130e3cf5893818f368b46746761fc2c97edd96?narHash=sha256-qEi8of88mZJW1%2B0kNpO0Gf6/ZufBHDX38eWqab5h5JE%3D' (2025-12-31)
• Updated input 'home-manager':
    'github:nix-community/home-manager/e298a148013c980e3c8c0ac075295fab5074d643?narHash=sha256-VvZeAKyB3vhyHStSO8ACKzWRKNQPmVWktjfuSVdvtUA%3D' (2025-12-28)
  → 'github:nix-community/home-manager/34578a2fdfce4257ce5f5baf6e7efbd4e4e252b1?narHash=sha256-B1aycRjMRvb6QOGbnqDhiDzZwMebj5jxZ5qyJzaKvpI%3D' (2025-12-29)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/c5db9569ac9cc70929c268ac461f4003e3e5ca80?narHash=sha256-UXVtN77D7pzKmzOotFTStgZBqpOcf8cO95FcupWp4Zo%3D' (2025-12-24)
  → 'github:NixOS/nixos-hardware/40b1a28dce561bea34858287fbb23052c3ee63fe?narHash=sha256-ljDBUDpD1Cg5n3mJI81Hz5qeZAwCGxon4kQW3Ho3%2B6Q%3D' (2025-12-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f560ccec6b1116b22e6ed15f4c510997d99d5852?narHash=sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ%3D' (2025-12-26)
  → 'github:NixOS/nixpkgs/89dbf01df72eb5ebe3b24a86334b12c27d68016a?narHash=sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo%3D' (2025-12-29)
• Updated input 'nixpkgs-2505':
    'github:NixOS/nixpkgs/fd0ca39c92fdb4012ed8d60e1683c26fddadd136?narHash=sha256-DegN7KD/EtFSKXf2jvqL6lvev6GlfAAatYBcRC8goEo%3D' (2025-12-25)
  → 'github:NixOS/nixpkgs/40ee5e1944bebdd128f9fbada44faefddfde29bd?narHash=sha256-0MnuWoN%2Bn1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4%3D' (2025-12-29)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce?narHash=sha256-fHmxAesa6XNqnIkcS6%2BnIHuEmgd/iZSP/VXxweiEuQw%3D' (2025-12-27)
  → 'github:NixOS/nixpkgs/f665af0cdb70ed27e1bd8f9fdfecaf451260fc55?narHash=sha256-ujL2AoYBnJBN262HD95yer7QYUmYp5kFZGYbyCCKxq8%3D' (2025-12-31)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/91e1f7a0017065360f447622d11b7ce6ed04772f?narHash=sha256-0Zi7ChAtjq/efwQYmp7kOJPcSt6ya9ynSUe6ppgZhsQ%3D' (2025-12-28)
  → 'github:oxalica/rust-overlay/6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3?narHash=sha256-TjfAb58Ybz/93e2jP0qD846dj%2BVqiY7wk%2BEqsxcZ708%3D' (2025-12-31)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/42d96e75aa56a3f70cab7e7dc4a32868db28e8fd?narHash=sha256-%2BcqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI%3D' (2025-12-17)
  → 'github:numtide/treefmt-nix/dec15f37015ac2e774c84d0952d57fcdf169b54d?narHash=sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o%3D' (2025-12-30)
• Updated input 'www-ncaq-net':
    'github:ncaq/www.ncaq.net/842669ca2ca660645cf83375ced0eee91702dff3?narHash=sha256-cD2kQn8JAc91S2gSuu3lbTgWEWIl%2B9/aD8/KN1C6i0Q%3D' (2025-12-28)
  → 'github:ncaq/www.ncaq.net/3c0a673a0e76ae96d2be058467a6c70c74c25f75?narHash=sha256-OpI4g1y4YjuOYGClk4LAltqUprKsxr83rxMyYR%2Bz2s4%3D' (2025-12-30)
