### PR TITLE
fix(dpms): DPMSタイマーを6/7/8時間に延長

### DIFF
--- a/nixos/desktop/dpms.nix
+++ b/nixos/desktop/dpms.nix
@@ -12,8 +12,8 @@
         ${pkgs.xorg.xset}/bin/xset s off
         # DPMSを有効化
         ${pkgs.xorg.xset}/bin/xset +dpms
-        # DPMS設定 (スタンバイ:120分, サスペンド:240分, オフ:240分)
-        ${pkgs.xorg.xset}/bin/xset dpms 7200 14400 14400
+        # DPMS設定 (スタンバイ:6時間, サスペンド:7時間, オフ:8時間)
+        ${pkgs.xorg.xset}/bin/xset dpms 21600 25200 28800
       '';
       Environment = [
         "DISPLAY=:0"


### PR DESCRIPTION
割と今使ってる最近のOLEDは雑に放置してても焼き付きが起きにくいことがわかってきたことと、
DisplayPortの影響か一度スタンバイに入るとウィンドウマネージャがぐちゃぐちゃになってしまうため、
DPMSのタイマーを延長しました。

- スタンバイ・サスペンド・オフの各タイマーをそれぞれ6時間・7時間・8時間に変更
- 長時間のアイドル時にも画面が維持されるよう調整
