### PR TITLE
refactor(seminar/vpn): Tailscaleのビルド回避ワークアラウンドを削除

### DIFF
--- a/nixos/host/seminar/vpn.nix
+++ b/nixos/host/seminar/vpn.nix
@@ -1,18 +1,8 @@
-{ pkgs, lib, ... }:
+{ ... }:
 {
   services.tailscale = {
     enable = true;
     useRoutingFeatures = "server"; # Exit Nodeとして動作
-    # [tailscale: Build failure with portlist tests on NixOS 25.05 - "seek /proc/net/tcp: illegal seek" · Issue #438765 · NixOS/nixpkgs](https://github.com/nixos/nixpkgs/issues/438765)
-    package = pkgs.tailscale.overrideAttrs (old: {
-      checkFlags = builtins.map (
-        flag:
-        if lib.hasPrefix "-skip=" flag then
-          flag + "|^TestGetList$|^TestIgnoreLocallyBoundPorts$|^TestPoller$"
-        else
-          flag
-      ) old.checkFlags;
-    });
   };
   # Exit Nodeとして動作するために転送を許可。
   boot.kernel.sysctl = {


### PR DESCRIPTION
リンク先のissueがcloseされているし解決したらしい。

- NixOS 25.05向けのTailscaleビルド失敗回避用パッチを削除
- pkgs, libの依存も不要になったため削除
