### PR TITLE
fix(tailscale-exit-node): レイテンシ判定でexit node自動切替を改善

### DIFF
--- a/nixos/laptop/tailscale-exit-node.nix
+++ b/nixos/laptop/tailscale-exit-node.nix
@@ -2,9 +2,11 @@
 # ただしseminarと同じローカルネットワークにいる場合は無駄なので通常の通信を行います。
 { pkgs, ... }:
 let
-  # seminarへの接続がダイレクトかDERP経由かで、
-  # ローカルネットワークにいるかを判定し、
+  # tailscale pingのレイテンシでローカルネットワークにいるかを判定し、
   # exit nodeの設定を切り替えるスクリプト。
+  # ローカルネットワークなら数ms、外部なら数10ms以上になります。
+  # セキュリティ的にあまり厳密な判定ではありませんが、
+  # そもそもそこまで差し迫ってVPNを使いたいわけではないので許容します。
   tailscaleExitNodeScript = pkgs.writeShellScript "tailscale-exit-node" ''
     set -euo pipefail
 
@@ -21,14 +23,18 @@ let
       sleep 1
     done
 
-    # tailscale pingでダイレクト接続かDERP経由かを判定
-    # DERP経由ならローカルネットワーク外なのでexit nodeを有効化
-    if ${pkgs.tailscale}/bin/tailscale ping -c 1 seminar 2>&1 | ${pkgs.gnugrep}/bin/grep -q "via DERP"; then
-      echo "seminar is reachable via DERP, enabling exit node"
-      ${pkgs.tailscale}/bin/tailscale set --exit-node=seminar
-    else
-      echo "seminar is reachable directly, disabling exit node"
+    # tailscale pingでレイテンシを取得
+    # 出力例: pong from seminar (100.82.4.93) via 192.168.10.88:41641 in 4ms
+    ping_output=$(${pkgs.tailscale}/bin/tailscale ping -c 1 seminar 2>&1) || true
+    latency=$(echo "$ping_output" | ${pkgs.gnugrep}/bin/grep -oP 'in \K[0-9]+(?=ms)' || echo "999")
+
+    # レイテンシが10ms以下ならローカルネットワーク
+    if [ "$latency" -le 10 ]; then
+      echo "seminar latency is ''${latency}ms (local network), disabling exit node"
       ${pkgs.tailscale}/bin/tailscale set --exit-node=
+    else
+      echo "seminar latency is ''${latency}ms (external network), enabling exit node"
+      ${pkgs.tailscale}/bin/tailscale set --exit-node=seminar
     fi
   '';
 in


### PR DESCRIPTION
`tailscale ping`だと直接接続か正しく判定できなかったため。
