### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766975680,
-        "narHash": "sha256-6Qn5GYzloXxNFK5sOWjkOsuP4b4W1yAyTZfIRnhVMq0=",
+        "lastModified": 1767509180,
+        "narHash": "sha256-kZc2vs2LTcWGLyxaAzKgImYSN0LEOR6Kuox9ODwvsC0=",
         "owner": "ncaq",
         "repo": ".xmonad",
-        "rev": "c23e8a494b8508492da7b8cd8b5c0427517fbed0",
+        "rev": "35957c203d325ca6868895b41494421dff392833",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767141591,
-        "narHash": "sha256-cCEabPdI8876eBSe7mL/DbWPlqD2CYKxyD1ePAtKkAs=",
+        "lastModified": 1767486597,
+        "narHash": "sha256-tK/DYq6BPBKJ77S883LmrCalI4Z/CcDz2nl6zmwGlGA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a12363ce5e23fb52e0f13135776737883a8bc2c0",
+        "rev": "7a26d9050e4bd84681295fa6a43ff163420fe6b7",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767140915,
-        "narHash": "sha256-Tk830ruFUpoIUbQng/Z/GfUdxGHMb76Dm87dhS8V4UA=",
+        "lastModified": 1767486589,
+        "narHash": "sha256-oSaUhrrDU11sMMgW/5ymN2KCzGCyx2Q9NTEmuXzhlDQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c12c9956e383c3d3953d192c5eb19abfd7313eaa",
+        "rev": "a641a88a098f6ef3abbe8a8e85fb9f104c532343",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1767142341,
-        "narHash": "sha256-hJN59/YH+QqPynH9KDeSwF/ZLSKs4CEh042MDECfdU8=",
+        "lastModified": 1767487947,
+        "narHash": "sha256-qPb6w5Qro5z9PU10+DXipju5R0QLwbe3oeUET6n7c6Y=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6d704c80bba2a732228d51efa7ca533933f50343",
+        "rev": "bc0754042e35a3bf9da655f284bef1c9e8b7396a",
         "type": "github"
       },
       "original": {
@@ -601,11 +601,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767024057,
-        "narHash": "sha256-B1aycRjMRvb6QOGbnqDhiDzZwMebj5jxZ5qyJzaKvpI=",
+        "lastModified": 1767280655,
+        "narHash": "sha256-YmaYMduV5ko8zURUT1VLGDbVC1L/bxHS0NsiPoZ6bBM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34578a2fdfce4257ce5f5baf6e7efbd4e4e252b1",
+        "rev": "d49d2543f02dbd789ed032188c84570d929223cb",
         "type": "github"
       },
       "original": {
@@ -725,11 +725,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767047869,
-        "narHash": "sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo=",
+        "lastModified": 1767325753,
+        "narHash": "sha256-yA/CuWyqm+AQo2ivGy6PlYrjZBQm7jfbe461+4HF2fo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89dbf01df72eb5ebe3b24a86334b12c27d68016a",
+        "rev": "64049ca74d63e971b627b5f3178d95642e61cedd",
         "type": "github"
       },
       "original": {
@@ -868,11 +868,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1767151656,
-        "narHash": "sha256-ujL2AoYBnJBN262HD95yer7QYUmYp5kFZGYbyCCKxq8=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f665af0cdb70ed27e1bd8f9fdfecaf451260fc55",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
@@ -962,11 +962,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767149068,
-        "narHash": "sha256-TjfAb58Ybz/93e2jP0qD846dj+VqiY7wk+EqsxcZ708=",
+        "lastModified": 1767495280,
+        "narHash": "sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3",
+        "rev": "cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1",
         "type": "github"
       },
       "original": {
@@ -978,11 +978,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767140080,
-        "narHash": "sha256-qEi8of88mZJW1+0kNpO0Gf6/ZufBHDX38eWqab5h5JE=",
+        "lastModified": 1767485734,
+        "narHash": "sha256-0fL+WNN8MsCiXdhbwMPEeC4vdpxhNA2AESEyv+SKDno=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "25130e3cf5893818f368b46746761fc2c97edd96",
+        "rev": "c2a17547e07da8bed3f646743e4271bc1800235e",
         "type": "github"
       },
       "original": {
@@ -1013,11 +1013,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767122417,
-        "narHash": "sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o=",
+        "lastModified": 1767468822,
+        "narHash": "sha256-MpffQxHxmjVKMiQd0Tg2IM/bSjjdQAM+NDcX6yxj7rE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "dec15f37015ac2e774c84d0952d57fcdf169b54d",
+        "rev": "d56486eb9493ad9c4777c65932618e9c2d0468fc",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767079391,
-        "narHash": "sha256-OpI4g1y4YjuOYGClk4LAltqUprKsxr83rxMyYR+z2s4=",
+        "lastModified": 1767507302,
+        "narHash": "sha256-uQFvKWZIGgZ3ZIv7+LTZJUwLdZ+b4VGm60BHJSiteqo=",
         "owner": "ncaq",
         "repo": "www.ncaq.net",
-        "rev": "3c0a673a0e76ae96d2be058467a6c70c74c25f75",
+        "rev": "8be52fbd75fd3c10c35ca19d16aede7ebb128781",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'dot-xmonad':
    'github:ncaq/.xmonad/c23e8a494b8508492da7b8cd8b5c0427517fbed0?narHash=sha256-6Qn5GYzloXxNFK5sOWjkOsuP4b4W1yAyTZfIRnhVMq0%3D' (2025-12-29)
  → 'github:ncaq/.xmonad/35957c203d325ca6868895b41494421dff392833?narHash=sha256-kZc2vs2LTcWGLyxaAzKgImYSN0LEOR6Kuox9ODwvsC0%3D' (2026-01-04)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/6d704c80bba2a732228d51efa7ca533933f50343?narHash=sha256-hJN59/YH%2BQqPynH9KDeSwF/ZLSKs4CEh042MDECfdU8%3D' (2025-12-31)
  → 'github:input-output-hk/haskell.nix/bc0754042e35a3bf9da655f284bef1c9e8b7396a?narHash=sha256-qPb6w5Qro5z9PU10%2BDXipju5R0QLwbe3oeUET6n7c6Y%3D' (2026-01-04)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/a12363ce5e23fb52e0f13135776737883a8bc2c0?narHash=sha256-cCEabPdI8876eBSe7mL/DbWPlqD2CYKxyD1ePAtKkAs%3D' (2025-12-31)
  → 'github:input-output-hk/hackage.nix/7a26d9050e4bd84681295fa6a43ff163420fe6b7?narHash=sha256-tK/DYq6BPBKJ77S883LmrCalI4Z/CcDz2nl6zmwGlGA%3D' (2026-01-04)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/c12c9956e383c3d3953d192c5eb19abfd7313eaa?narHash=sha256-Tk830ruFUpoIUbQng/Z/GfUdxGHMb76Dm87dhS8V4UA%3D' (2025-12-31)
  → 'github:input-output-hk/hackage.nix/a641a88a098f6ef3abbe8a8e85fb9f104c532343?narHash=sha256-oSaUhrrDU11sMMgW/5ymN2KCzGCyx2Q9NTEmuXzhlDQ%3D' (2026-01-04)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/25130e3cf5893818f368b46746761fc2c97edd96?narHash=sha256-qEi8of88mZJW1%2B0kNpO0Gf6/ZufBHDX38eWqab5h5JE%3D' (2025-12-31)
  → 'github:input-output-hk/stackage.nix/c2a17547e07da8bed3f646743e4271bc1800235e?narHash=sha256-0fL%2BWNN8MsCiXdhbwMPEeC4vdpxhNA2AESEyv%2BSKDno%3D' (2026-01-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/34578a2fdfce4257ce5f5baf6e7efbd4e4e252b1?narHash=sha256-B1aycRjMRvb6QOGbnqDhiDzZwMebj5jxZ5qyJzaKvpI%3D' (2025-12-29)
  → 'github:nix-community/home-manager/d49d2543f02dbd789ed032188c84570d929223cb?narHash=sha256-YmaYMduV5ko8zURUT1VLGDbVC1L/bxHS0NsiPoZ6bBM%3D' (2026-01-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/89dbf01df72eb5ebe3b24a86334b12c27d68016a?narHash=sha256-tzYsEzXEVa7op1LTnrLSiPGrcCY6948iD0EcNLWcmzo%3D' (2025-12-29)
  → 'github:NixOS/nixpkgs/64049ca74d63e971b627b5f3178d95642e61cedd?narHash=sha256-yA/CuWyqm%2BAQo2ivGy6PlYrjZBQm7jfbe461%2B4HF2fo%3D' (2026-01-02)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/f665af0cdb70ed27e1bd8f9fdfecaf451260fc55?narHash=sha256-ujL2AoYBnJBN262HD95yer7QYUmYp5kFZGYbyCCKxq8%3D' (2025-12-31)
  → 'github:NixOS/nixpkgs/16c7794d0a28b5a37904d55bcca36003b9109aaa?narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D' (2026-01-02)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3?narHash=sha256-TjfAb58Ybz/93e2jP0qD846dj%2BVqiY7wk%2BEqsxcZ708%3D' (2025-12-31)
  → 'github:oxalica/rust-overlay/cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1?narHash=sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ%3D' (2026-01-04)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/dec15f37015ac2e774c84d0952d57fcdf169b54d?narHash=sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o%3D' (2025-12-30)
  → 'github:numtide/treefmt-nix/d56486eb9493ad9c4777c65932618e9c2d0468fc?narHash=sha256-MpffQxHxmjVKMiQd0Tg2IM/bSjjdQAM%2BNDcX6yxj7rE%3D' (2026-01-03)
• Updated input 'www-ncaq-net':
    'github:ncaq/www.ncaq.net/3c0a673a0e76ae96d2be058467a6c70c74c25f75?narHash=sha256-OpI4g1y4YjuOYGClk4LAltqUprKsxr83rxMyYR%2Bz2s4%3D' (2025-12-30)
  → 'github:ncaq/www.ncaq.net/8be52fbd75fd3c10c35ca19d16aede7ebb128781?narHash=sha256-uQFvKWZIGgZ3ZIv7%2BLTZJUwLdZ%2Bb4VGm60BHJSiteqo%3D' (2026-01-04)
