### PR TITLE
fix(trayscale): 起動時にウインドウを非表示にするautostartエントリを追加

### DIFF
--- a/home/package/trayscale.nix
+++ b/home/package/trayscale.nix
@@ -4,11 +4,18 @@
   isWSL,
   ...
 }:
+let
+  # デフォルトだとウインドウが起動時に表示されてしまうためトレイにのみ表示するように引数を追加したdesktopファイルを作成。
+  trayscale-autostart-desktop = pkgs.runCommand "trayscale-autostart.desktop" { } ''
+    substitute ${pkgs.trayscale}/share/applications/dev.deedles.Trayscale.desktop $out \
+      --replace-fail "Exec=trayscale" "Exec=trayscale --hide-window"
+  '';
+in
 lib.mkIf (!isWSL) {
   home.packages = [ pkgs.trayscale ];
 
   xdg.autostart = {
     enable = true;
-    entries = [ "${pkgs.trayscale}/share/applications/dev.deedles.Trayscale.desktop" ];
+    entries = [ trayscale-autostart-desktop ];
   };
 }


### PR DESCRIPTION
- trayscaleのautostart用desktopファイルに--hide-window引数を追加
- 起動時にウインドウを表示せずトレイのみで動作するよう修正
