### PR TITLE
feat(zsh): Zsh統合機能を有効化

### DIFF
--- a/home/package/zsh.nix
+++ b/home/package/zsh.nix
@@ -23,6 +23,8 @@ in
     autojump.enable = true;
   };
 
+  home.shell.enableZshIntegration = true;
+
   home.activation.cloneZshConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     if [ ! -d "${zshDotDir}" ]; then
       $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.zsh.d.git "${zshDotDir}"


### PR DESCRIPTION
グローバルに他の連携機能が有効になるオプションを有効化。

- home.shell.enableZshIntegrationをtrueに設定
- Zshの統合機能がHome Managerで有効化される
