### PR TITLE
feat(nixos): YubiKeyスマートカード対応設定を追加

### DIFF
--- a/nixos/native-linux/yubikey.nix
+++ b/nixos/native-linux/yubikey.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+{
+  services = {
+    pcscd.enable = true; # GPGなどと通信をします。
+    udev.packages = [ pkgs.yubikey-personalization ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    yubikey-manager # ykman コマンド - YubiKeyの状態確認やPIN管理に便利。
+  ];
+}


### PR DESCRIPTION
- pcscdサービスを有効化しGPG等との通信を可能に
- udevにyubikey-personalizationパッケージを追加
- systemPackagesにyubikey-managerを追加
