### PR TITLE
fix: パッケージ自体のインストールもしなければいけなかったらしい

### DIFF
--- a/home/package/gpg.nix
+++ b/home/package/gpg.nix
@@ -9,5 +9,6 @@
   home.packages = with pkgs; [
     gcr # pinentry-gnome3の動作に必要。
     paperkey
+    pinentry-gnome3
   ];
 }


### PR DESCRIPTION
- **fix(gpg): pinentry-gnome3の依存パッケージgcrを追加**
- **fix(gpg): pinentry-gnome3をhome.packagesに追加して依存解決**
