### PR TITLE
feat(gpg): pinentryをgnome3からqtに変更しパスワード入力性を改善

### DIFF
--- a/home/package/gpg.nix
+++ b/home/package/gpg.nix
@@ -4,11 +4,10 @@
   services.gpg-agent = with pkgs; {
     enable = true;
     enableSshSupport = true;
-    pinentry.package = pinentry-gnome3;
+    pinentry.package = pinentry-qt; # pinentry-gnome3はモーダルでパスワードマネージャが使いづらい。
   };
   home.packages = with pkgs; [
-    gcr # pinentry-gnome3の動作に必要。
     paperkey
-    pinentry-gnome3
+    pinentry-qt # パッケージ指定するだけではなく実際にインストールする必要があります。
   ];
 }


### PR DESCRIPTION
- pinentry-gnome3はモーダルでパスワードマネージャとの併用が困難なため
- gcrおよびpinentry-gnome3の依存を削除
- pinentry-qtを利用することで利便性を向上
