### PR TITLE
fix(gpg): YubiKey利用時のscdaemon設定を追加し認識問題を修正

### DIFF
--- a/home/package/gpg.nix
+++ b/home/package/gpg.nix
@@ -1,6 +1,13 @@
 { pkgs, ... }:
 {
-  programs.gpg.enable = true;
+  programs.gpg = {
+    enable = true;
+    scdaemonSettings = {
+      # `gpg --card-status`などがドライバの不一致で失敗する問題の対策。
+      disable-ccid = true;
+      reader-port = "Yubico YubiKey";
+    };
+  };
   services.gpg-agent = with pkgs; {
     enable = true;
     enableSshSupport = true;


### PR DESCRIPTION
- scdaemonのdisable-ccidとreader-portを設定しドライバ不一致による
  認識エラーを回避
- `gpg --card-status`実行時のYubiKey認識問題を解消
