### PR TITLE
feat(gpg): GPGエージェントのパスフレーズキャッシュを5年に延長

### DIFF
--- a/home/package/gpg.nix
+++ b/home/package/gpg.nix
@@ -18,6 +18,10 @@
     enable = true;
     enableSshSupport = true;
     pinentry.package = pinentry-qt; # pinentry-gnome3はモーダルでパスワードマネージャが使いづらい。
+    # GPGの証明にパスフレーズは不要だと思うのでキャッシュ時間を長くして実質無制限にします。
+    # 証明書を持っていることが重要なのであって、パスフレーズを入力させることにあまり意味は無いと考えています。
+    defaultCacheTtl = 157680000; # 5年(60 * 60 * 24 * 365 * 5)
+    maxCacheTtl = 157680000;
   };
   home.packages = with pkgs; [
     paperkey


### PR DESCRIPTION
関連issue #395

- defaultCacheTtlとmaxCacheTtlを157680000秒(5年)に設定
- 証明書所持が重要でパスフレーズ入力の意味が薄いためキャッシュを実質無制限化
