### PR TITLE
docs(yubikey): YubiKeyの利用状況と制限についてコメントを追加

### DIFF
--- a/nixos/native-linux/yubikey.nix
+++ b/nixos/native-linux/yubikey.nix
@@ -1,5 +1,9 @@
 { pkgs, ... }:
 {
+  # YubiKeyは一応持ってるので使えるように設定していますが、
+  # ファームウェアのバージョンが現状古くて楕円曲線暗号に対応していないため、
+  # 今はあまり使っていません。
+
   services = {
     pcscd.enable = true; # GPGなどと通信をします。
     udev.packages = [ pkgs.yubikey-personalization ];


### PR DESCRIPTION
- 所有しているYubiKeyのファームウェアが古く、楕円曲線暗号に
  非対応であるため現在はあまり利用していない旨をコメントで明記
- 今後の利用や設定変更時の参考情報として追記
