### PR TITLE
build(editorconfig): 広い言語拡張子に対応

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,7 @@ indent_size = 2
 indent_size = 4
 
 # 標準インデントがタブの言語。
-[*.{go,make,mk},Makefile]
+[{*.go,*.make,*.mk,Makefile}]
 indent_style = tab
 
 [*.md]


### PR DESCRIPTION
これをコピーしておけば大抵のプロジェクトセットアップに対応できるようにしておきます。
このプロジェクト自体にも役に立つかもしれません。

- デフォルトのインデント幅を2に統一し、例外を個別指定
- Markdownや各言語のインデント設定を明確化
- コメントを加筆し指針とフォーマッター向け説明を充実
