### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767486597,
-        "narHash": "sha256-tK/DYq6BPBKJ77S883LmrCalI4Z/CcDz2nl6zmwGlGA=",
+        "lastModified": 1767919209,
+        "narHash": "sha256-r0zwXFehzLtReDJSlRmPSpTWew9sbrWjJOhabTLsw80=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7a26d9050e4bd84681295fa6a43ff163420fe6b7",
+        "rev": "03d6486168116d34d90dd9331b513776f7900579",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767486589,
-        "narHash": "sha256-oSaUhrrDU11sMMgW/5ymN2KCzGCyx2Q9NTEmuXzhlDQ=",
+        "lastModified": 1767918529,
+        "narHash": "sha256-inDBsGGjTLZhN4fplsIZ4YzWcdmYx1Po0WZYd9RGDic=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a641a88a098f6ef3abbe8a8e85fb9f104c532343",
+        "rev": "dfb35c879ed4ee16ae3981e17c1caaf02f5d5a76",
         "type": "github"
       },
       "original": {
@@ -335,6 +335,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -361,11 +362,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1767487947,
-        "narHash": "sha256-qPb6w5Qro5z9PU10+DXipju5R0QLwbe3oeUET6n7c6Y=",
+        "lastModified": 1767919942,
+        "narHash": "sha256-4jdJA5YfIFckR81qZuTs2BRGzx0lo7tdc1Ff3a8NcPM=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "bc0754042e35a3bf9da655f284bef1c9e8b7396a",
+        "rev": "6fb14c4df7526df06707f87909ecbf8d267d2f28",
         "type": "github"
       },
       "original": {
@@ -454,6 +455,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -601,11 +619,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767280655,
-        "narHash": "sha256-YmaYMduV5ko8zURUT1VLGDbVC1L/bxHS0NsiPoZ6bBM=",
+        "lastModified": 1767910483,
+        "narHash": "sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d49d2543f02dbd789ed032188c84570d929223cb",
+        "rev": "82fb7dedaad83e5e279127a38ef410bcfac6d77c",
         "type": "github"
       },
       "original": {
@@ -725,11 +743,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767325753,
-        "narHash": "sha256-yA/CuWyqm+AQo2ivGy6PlYrjZBQm7jfbe461+4HF2fo=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64049ca74d63e971b627b5f3178d95642e61cedd",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {
@@ -821,11 +839,11 @@
     },
     "nixpkgs-2505_2": {
       "locked": {
-        "lastModified": 1767051569,
-        "narHash": "sha256-0MnuWoN+n1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40ee5e1944bebdd128f9fbada44faefddfde29bd",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -963,11 +981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767495280,
-        "narHash": "sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ=",
+        "lastModified": 1767926800,
+        "narHash": "sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ+b0a2cKDc8RZyt+o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1",
+        "rev": "499e9eed88ff9494b6604205b42847e847dfeb91",
         "type": "github"
       },
       "original": {
@@ -983,11 +1001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767499857,
-        "narHash": "sha256-0zUU/PW09d6oBaR8x8vMHcAhg1MOvo3CwoXgHijzzNE=",
+        "lastModified": 1767826491,
+        "narHash": "sha256-WSBENPotD2MIhZwolL6GC9npqgaS5fkM7j07V2i/Ur8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ecc41505948ec2ab0325f14c9862a4329c2b4190",
+        "rev": "ea3adcb6d2a000d9a69d0e23cad1f2cacb3a9fbe",
         "type": "github"
       },
       "original": {
@@ -999,11 +1017,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767485734,
-        "narHash": "sha256-0fL+WNN8MsCiXdhbwMPEeC4vdpxhNA2AESEyv+SKDno=",
+        "lastModified": 1767917667,
+        "narHash": "sha256-zXpHylKKHs90GzD6i3vOrd5vDC/k6Xgym94eLUJYDhc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "c2a17547e07da8bed3f646743e4271bc1800235e",
+        "rev": "5d7d2224aea57cd832aa240127f9881c991393b7",
         "type": "github"
       },
       "original": {
@@ -1034,11 +1052,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767468822,
-        "narHash": "sha256-MpffQxHxmjVKMiQd0Tg2IM/bSjjdQAM+NDcX6yxj7rE=",
+        "lastModified": 1767801790,
+        "narHash": "sha256-QfX6g3Wj2vQe7oBJEbTf0npvC6sJoDbF9hb2+gM5tf8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d56486eb9493ad9c4777c65932618e9c2d0468fc",
+        "rev": "778a1d691f1ef45dd68c661715c5bf8cbf131c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/a34fae9c08a15ad73f295041fec82323541400a9?narHash=sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw%3D' (2025-12-15)
  → 'github:hercules-ci/flake-parts/250481aafeb741edfe23d29195671c19b36b6dca?narHash=sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY%3D' (2026-01-05)
• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/bc0754042e35a3bf9da655f284bef1c9e8b7396a?narHash=sha256-qPb6w5Qro5z9PU10%2BDXipju5R0QLwbe3oeUET6n7c6Y%3D' (2026-01-04)
  → 'github:input-output-hk/haskell.nix/6fb14c4df7526df06707f87909ecbf8d267d2f28?narHash=sha256-4jdJA5YfIFckR81qZuTs2BRGzx0lo7tdc1Ff3a8NcPM%3D' (2026-01-09)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/7a26d9050e4bd84681295fa6a43ff163420fe6b7?narHash=sha256-tK/DYq6BPBKJ77S883LmrCalI4Z/CcDz2nl6zmwGlGA%3D' (2026-01-04)
  → 'github:input-output-hk/hackage.nix/03d6486168116d34d90dd9331b513776f7900579?narHash=sha256-r0zwXFehzLtReDJSlRmPSpTWew9sbrWjJOhabTLsw80%3D' (2026-01-09)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/a641a88a098f6ef3abbe8a8e85fb9f104c532343?narHash=sha256-oSaUhrrDU11sMMgW/5ymN2KCzGCyx2Q9NTEmuXzhlDQ%3D' (2026-01-04)
  → 'github:input-output-hk/hackage.nix/dfb35c879ed4ee16ae3981e17c1caaf02f5d5a76?narHash=sha256-inDBsGGjTLZhN4fplsIZ4YzWcdmYx1Po0WZYd9RGDic%3D' (2026-01-09)
• Added input 'haskellNix/hls-2.12':
    'github:haskell/haskell-language-server/7d983de4fa7ff54369f6dd31444bdb9869aec83e?narHash=sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w%3D' (2025-09-24)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/c2a17547e07da8bed3f646743e4271bc1800235e?narHash=sha256-0fL%2BWNN8MsCiXdhbwMPEeC4vdpxhNA2AESEyv%2BSKDno%3D' (2026-01-04)
  → 'github:input-output-hk/stackage.nix/5d7d2224aea57cd832aa240127f9881c991393b7?narHash=sha256-zXpHylKKHs90GzD6i3vOrd5vDC/k6Xgym94eLUJYDhc%3D' (2026-01-09)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d49d2543f02dbd789ed032188c84570d929223cb?narHash=sha256-YmaYMduV5ko8zURUT1VLGDbVC1L/bxHS0NsiPoZ6bBM%3D' (2026-01-01)
  → 'github:nix-community/home-manager/82fb7dedaad83e5e279127a38ef410bcfac6d77c?narHash=sha256-MOU5YdVu4DVwuT5ztXgQpPuRRBjSjUGIdUzOQr9iQOY%3D' (2026-01-08)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/64049ca74d63e971b627b5f3178d95642e61cedd?narHash=sha256-yA/CuWyqm%2BAQo2ivGy6PlYrjZBQm7jfbe461%2B4HF2fo%3D' (2026-01-02)
  → 'github:NixOS/nixpkgs/d351d0653aeb7877273920cd3e823994e7579b0b?narHash=sha256-r4GVX%2BFToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE%3D' (2026-01-07)
• Updated input 'nixpkgs-2505':
    'github:NixOS/nixpkgs/40ee5e1944bebdd128f9fbada44faefddfde29bd?narHash=sha256-0MnuWoN%2Bn1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4%3D' (2025-12-29)
  → 'github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d?narHash=sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w%3D' (2026-01-02)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/cb24c5cc207ba8e9a4ce245eedd2d37c3a988bc1?narHash=sha256-hEEgtE/RSRigw8xscchGymf/t1nluZwTfru4QF6O1CQ%3D' (2026-01-04)
  → 'github:oxalica/rust-overlay/499e9eed88ff9494b6604205b42847e847dfeb91?narHash=sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ%2Bb0a2cKDc8RZyt%2Bo%3D' (2026-01-09)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ecc41505948ec2ab0325f14c9862a4329c2b4190?narHash=sha256-0zUU/PW09d6oBaR8x8vMHcAhg1MOvo3CwoXgHijzzNE%3D' (2026-01-04)
  → 'github:Mic92/sops-nix/ea3adcb6d2a000d9a69d0e23cad1f2cacb3a9fbe?narHash=sha256-WSBENPotD2MIhZwolL6GC9npqgaS5fkM7j07V2i/Ur8%3D' (2026-01-07)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/d56486eb9493ad9c4777c65932618e9c2d0468fc?narHash=sha256-MpffQxHxmjVKMiQd0Tg2IM/bSjjdQAM%2BNDcX6yxj7rE%3D' (2026-01-03)
  → 'github:numtide/treefmt-nix/778a1d691f1ef45dd68c661715c5bf8cbf131c80?narHash=sha256-QfX6g3Wj2vQe7oBJEbTf0npvC6sJoDbF9hb2%2BgM5tf8%3D' (2026-01-07)
