### PR TITLE
refactor(claude-code): デフォルトで許可してリスクの高いコマンドをaskすることで設定を短縮

### DIFF
--- a/home/package/claude-code.nix
+++ b/home/package/claude-code.nix
@@ -191,7 +191,6 @@ in
           "~/dotfiles/"
         ];
         allow = jsRunnerPermissions ++ [
-          "Bash(atop:*)"
           "Bash(cabal build:*)"
           "Bash(cabal clean:*)"
           "Bash(cabal haddock:*)"
@@ -239,8 +238,6 @@ in
           "Bash(hlint:*)"
           "Bash(hostname)"
           "Bash(hostnamectl status:*)"
-          "Bash(iostat:*)"
-          "Bash(iotop:*)"
           "Bash(journalctl:*)"
           "Bash(jq:*)"
           "Bash(localectl status:*)"
@@ -299,7 +296,6 @@ in
           "Bash(stack test:*)"
           "Bash(systemctl status:*)"
           "Bash(timedatectl status:*)"
-          "Bash(top:*)"
           "Bash(touch:*)"
           "Bash(trash:*)"
           "Bash(tree:*)"


### PR DESCRIPTION
- **refactor: JSパッケージマネージャの許可コマンド生成を共通化**
- **refactor(package): dockerコマンドを基本許可してリスクの高い操作をask管理に変更**
- **refactor(claude-code): ghコマンドをデフォルト許可してリスクの高いコマンドをaskに**
- **fix(claude-code): リスクの高いコマンドのうち本当に高いものはdenyする**
- **fix(package): Bashのatop, iostat, iotop許可設定を削除**
