### PR TITLE
fix(flake): www-ncaq-netのinputsを削除しflake=falseを設定

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,11 +273,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767919209,
-        "narHash": "sha256-r0zwXFehzLtReDJSlRmPSpTWew9sbrWjJOhabTLsw80=",
+        "lastModified": 1768004872,
+        "narHash": "sha256-fGUgwLCC3cxLkidLN/5CT+hwJs+uagAlWekgzh/s8ck=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "03d6486168116d34d90dd9331b513776f7900579",
+        "rev": "59df1017e99d66798f2b030ee76467274813051e",
         "type": "github"
       },
       "original": {
@@ -289,11 +289,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767918529,
-        "narHash": "sha256-inDBsGGjTLZhN4fplsIZ4YzWcdmYx1Po0WZYd9RGDic=",
+        "lastModified": 1768004862,
+        "narHash": "sha256-iYcbtE3J+LgYeFPoNLuqkdWNEoVBK26ZKHyxvvMAXwo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "dfb35c879ed4ee16ae3981e17c1caaf02f5d5a76",
+        "rev": "a22b855948d60653b698255474c8f26daf57d099",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1767919942,
-        "narHash": "sha256-4jdJA5YfIFckR81qZuTs2BRGzx0lo7tdc1Ff3a8NcPM=",
+        "lastModified": 1768006334,
+        "narHash": "sha256-VlRvJP4axZ+uWz5UJ/n+HB1rAYbTIWk79/PFRMwQ7ac=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6fb14c4df7526df06707f87909ecbf8d267d2f28",
+        "rev": "87b3757e1504f52a8d6798ca11ceb7c0c53313dc",
         "type": "github"
       },
       "original": {
@@ -649,22 +649,6 @@
         "type": "github"
       }
     },
-    "html-tidy-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1643123835,
-        "narHash": "sha256-vbedA9J8LPSFmgrF8CTWoIvKO2SVp4LivBloY/lZk1s=",
-        "owner": "htacg",
-        "repo": "tidy-html5",
-        "rev": "d08ddc2860aa95ba8e301343a30837f157977cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "htacg",
-        "repo": "tidy-html5",
-        "type": "github"
-      }
-    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -679,28 +663,6 @@
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "nix-github-actions": {
-      "inputs": {
-        "nixpkgs": [
-          "www-ncaq-net",
-          "poetry2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
         "type": "github"
       }
     },
@@ -886,11 +848,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1767995494,
+        "narHash": "sha256-2EwKigq/8Yfl0D1+BaqsF1qh40DxX+rDdDyw1razX/Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "45a1530683263666f42d1de4cdda328109d5a676",
         "type": "github"
       },
       "original": {
@@ -914,41 +876,6 @@
         "owner": "angerman",
         "ref": "master",
         "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": [
-          "www-ncaq-net",
-          "flake-utils"
-        ],
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": [
-          "www-ncaq-net",
-          "nixpkgs"
-        ],
-        "systems": [
-          "www-ncaq-net",
-          "flake-utils",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "www-ncaq-net",
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1743690424,
-        "narHash": "sha256-cX98bUuKuihOaRp8dNV1Mq7u6/CQZWTPth2IJPATBXc=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "ce2369db77f45688172384bbeb962bc6c2ea6f94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
         "type": "github"
       }
     },
@@ -981,11 +908,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767926800,
-        "narHash": "sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ+b0a2cKDc8RZyt+o=",
+        "lastModified": 1768012928,
+        "narHash": "sha256-HFFVQaux1JoOjEvgBT0ASk1Je+jsipyO5c91FoLMed8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "499e9eed88ff9494b6604205b42847e847dfeb91",
+        "rev": "312b4371e72f644ffcff25b23615195e3b390643",
         "type": "github"
       },
       "original": {
@@ -1001,11 +928,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767826491,
-        "narHash": "sha256-WSBENPotD2MIhZwolL6GC9npqgaS5fkM7j07V2i/Ur8=",
+        "lastModified": 1768032389,
+        "narHash": "sha256-BVpTd93G0XmAK1iXiBdhUA5Uvt+WmM1YL0mA4REcT68=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ea3adcb6d2a000d9a69d0e23cad1f2cacb3a9fbe",
+        "rev": "a8cfe238b93166f9f96c0df67a94e572554ee624",
         "type": "github"
       },
       "original": {
@@ -1017,11 +944,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1767917667,
-        "narHash": "sha256-zXpHylKKHs90GzD6i3vOrd5vDC/k6Xgym94eLUJYDhc=",
+        "lastModified": 1768004033,
+        "narHash": "sha256-ELLqUlLd8bUUNWZ0d1bxIlVUmq1KmX6qiV3sUQCxIIg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5d7d2224aea57cd832aa240127f9881c991393b7",
+        "rev": "4e3eadd1b8795f25ac61ab8546ff9dbb49bba5fe",
         "type": "github"
       },
       "original": {
@@ -1052,11 +979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767801790,
-        "narHash": "sha256-QfX6g3Wj2vQe7oBJEbTf0npvC6sJoDbF9hb2+gM5tf8=",
+        "lastModified": 1768031762,
+        "narHash": "sha256-b2gJDJfi+TbA7Hu2sKip+1mWqya0GJaWrrXQjpbOVTU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "778a1d691f1ef45dd68c661715c5bf8cbf131c80",
+        "rev": "0c445aa21b01fd1d4bb58927f7b268568af87b20",
         "type": "github"
       },
       "original": {
@@ -1066,28 +993,13 @@
       }
     },
     "www-ncaq-net": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "haskellNix": [
-          "haskellNix"
-        ],
-        "html-tidy-src": "html-tidy-src",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "poetry2nix": "poetry2nix",
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1767507302,
-        "narHash": "sha256-uQFvKWZIGgZ3ZIv7+LTZJUwLdZ+b4VGm60BHJSiteqo=",
+        "lastModified": 1768043206,
+        "narHash": "sha256-6UZiDZLqW7D4WLGkY+yJ+AkLR+a/beXWDdhx9fEGxfo=",
         "owner": "ncaq",
         "repo": "www.ncaq.net",
-        "rev": "8be52fbd75fd3c10c35ca19d16aede7ebb128781",
+        "rev": "93832264c8b921176fc54cc4837a3ebb6b12cca6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,12 +60,7 @@
 
     www-ncaq-net = {
       url = "github:ncaq/www.ncaq.net";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
-        treefmt-nix.follows = "treefmt-nix";
-        haskellNix.follows = "haskellNix";
-      };
+      flake = false;
     };
 
     dot-xmonad = {


### PR DESCRIPTION
プログラムとして期待せず記事ファイルのみを参照するため、
flakeとして見る必要はありません。
無駄に依存関係が広がることを防ぎます。
