### PR TITLE
fix(claude): claude-codeへの言語設定の方法をプロンプトベースから設定ベースに変更

### DIFF
--- a/home/package/claude-code.nix
+++ b/home/package/claude-code.nix
@@ -202,6 +202,7 @@ in
         type = "command";
         command = lib.getExe ccstatusline;
       };
+      language = "japanese";
       permissions = {
         defaultMode = "acceptEdits";
         additionalDirectories = [

--- a/home/prompt/default.nix
+++ b/home/prompt/default.nix
@@ -52,7 +52,6 @@ in
       # プログラミングに直接関係ない情報は省きます。
       coding-agent = lib.concatStringsSep "\n" (
         [
-          (builtins.readFile ./assistant/language.md)
           (builtins.readFile ./assistant/form.md)
           (builtins.readFile ./environment/software.md)
         ]


### PR DESCRIPTION
- claude-code.nixにlanguage = "japanese"を追加
- promptのcoding-agentからlanguage.mdの読み込みを削除
