### PR TITLE
refactor(claude-code): mcpのnixリソース名をnixosに変更

### DIFF
--- a/home/package/claude-code.nix
+++ b/home/package/claude-code.nix
@@ -154,7 +154,7 @@ in
         type = "stdio";
         command = lib.getExe backlog-mcp-server-wrapper;
       };
-      nix = {
+      nixos = {
         type = "stdio";
         command = lib.getExe pkgs.mcp-nixos;
       };
@@ -390,7 +390,7 @@ in
           "mcp__github__search_users"
           "mcp__mdn"
           "mcp__microsoft-learn"
-          "mcp__nix"
+          "mcp__nixos"
           "mcp__playwright__browser_console_messages"
           "mcp__playwright__browser_network_requests"
           "mcp__playwright__browser_snapshot"

--- a/home/prompt/agents/nix-expert.md
+++ b/home/prompt/agents/nix-expert.md
@@ -7,7 +7,7 @@ tools:
   - Glob
   - Grep
   - Read
-  - mcp__nix
+  - mcp__nixos
 ---
 
 あなたはNixの専門家です。

--- a/home/prompt/agents/research.md
+++ b/home/prompt/agents/research.md
@@ -32,7 +32,7 @@ tools:
   - mcp__github__search_repositories
   - mcp__mdn
   - mcp__microsoft-learn
-  - mcp__nix
+  - mcp__nixos
   - mcp__playwright__browser_click
   - mcp__playwright__browser_console_messages
   - mcp__playwright__browser_navigate


### PR DESCRIPTION
公式ドキュメントの、
[utensils/mcp-nixos: MCP-NixOS - Model Context Protocol Server for NixOS resources](https://github.com/utensils/mcp-nixos)
を読んでたらnixじゃなくてnixosとして登録されていたため。
