### PR TITLE
ci: Claude Code Reviewに再度レビューを依頼する

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: |
+            Review this PR. Do NOT skip the review even if you have commented before.
+            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
           claude_args: --model opus
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
plugin版になってから二度目のレビューをしなくなった。
とりあえずworkaroundしてみます。
ついでに明示的に`--comment`オプションをつけます。

- 以前コメント済みでも必ずレビューを実施するようプロンプトを修正
- /code-review:code-review --comment を利用しPRにコメントを残すように変更
