### PR TITLE
ci: claude-code-reviewアクションのプラグイン設定とプロンプトを修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,11 +45,9 @@ jobs:
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugin_marketplaces: "https://github.com/ncaq/claude-code.git#code-review-when-new-commit"
           plugins: "code-review@claude-code-plugins"
-          prompt: |
-            Review this PR. Do NOT skip the review even if you have commented before.
-            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           claude_args: --model opus
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
[fix(code-review): allow re-review when new commits by ncaq · Pull Request #19622 · anthropics/claude-code](https://github.com/anthropics/claude-code/pull/19622)
で提出したものを実際に試してみます。
