### PR TITLE
ci: plugin_marketplacesのURLからブランチ指定を削除

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,7 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/ncaq/claude-code.git#code-review-when-new-commit"
+          plugin_marketplaces: "https://github.com/ncaq/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           claude_args: --model opus


### PR DESCRIPTION
ブランチ指定構文が使えなかった。
仕方なくfork先のデフォルトブランチにpushして動作確認します。
