### PR TITLE
ci: claude-code-reviewを前の形式に戻す

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -45,9 +45,31 @@ jobs:
         uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-          plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          claude_args: --model opus
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions.
+            Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: >-
+            --model opus --allowed-tools "
+            Bash(gh issue list:*),
+            Bash(gh issue view:*),
+            Bash(gh pr comment:*),
+            Bash(gh pr diff:*),
+            Bash(gh pr list:*),
+            Bash(gh pr view:*),
+            Bash(gh search:*)
+            "


### PR DESCRIPTION
`claude-code-plugins`は公式に予約されているとか出てきて、
流石に動作確認が面倒になりました。
問題が解決するまで全て前の形式に戻すことにします。

- **Revert "Merge pull request #455 from ncaq/fix-re-review-branch"**
- **Revert "Merge pull request #454 from ncaq/use-my-claude-code-review"**
- **Revert "Merge pull request #453 from ncaq/claude-re-review"**
- **Revert "Merge pull request #437 from ncaq/bump-claude-code-review-config"**
