### PR TITLE
feat(nixos): 未暗号化リムーバブルストレージ用のマウント設定

### DIFF
--- a/nixos/core/user.nix
+++ b/nixos/core/user.nix
@@ -2,6 +2,7 @@
 {
   users.users.${username} = {
     isNormalUser = true;
+    uid = 1000;
     extraGroups = [
       "input"
       "networkmanager"

--- a/nixos/native-linux/removable.nix
+++ b/nixos/native-linux/removable.nix
@@ -1,0 +1,24 @@
+# 使っているリムーバブルストレージのうち暗号化していないものを記述
+{ config, username, ... }:
+let
+  userConfig = config.users.users.${username};
+  uid = toString userConfig.uid;
+  gid = toString config.users.groups.${userConfig.group}.gid;
+in
+{
+  fileSystems = {
+    "/mnt/turugi" = {
+      device = "/dev/disk/by-label/turugi";
+      fsType = "exfat";
+      options = [
+        "noatime"
+        "uid=${uid}"
+        "gid=${gid}"
+        "noauto"
+      ];
+    };
+  };
+  systemd.tmpfiles.rules = [
+    "d /mnt/turugi 0755 root root -"
+  ];
+}


### PR DESCRIPTION
uidは予測可能なようにもう固定化してしまいます。

- exFAT形式の/dev/disk/by-label/turugiを/mnt/turugiにマウントする設定を追加
- noauto, noatimeオプションを指定
