### PR TITLE
refactor(gpg): GPGエージェントのキャッシュTTL設定を削除

### DIFF
--- a/home/package/gpg.nix
+++ b/home/package/gpg.nix
@@ -21,10 +21,6 @@ in
     enable = true;
     enableSshSupport = true;
     pinentry.package = pinentry-qt; # pinentry-gnome3はモーダルでパスワードマネージャが使いづらい。
-    # GPGの証明にパスフレーズは不要だと思うのでキャッシュ時間を長くして実質無制限にします。
-    # 証明書を持っていることが重要なのであって、パスフレーズを入力させることにあまり意味は無いと考えています。
-    defaultCacheTtl = 157680000; # 5年(60 * 60 * 24 * 365 * 5)
-    maxCacheTtl = 157680000;
     # SSH認証に使用するGPGサブキーのkeygrip。
     # `gpg --list-keys --with-keygrip`で[A]能力を持つサブキーのkeygripを確認できる。
     sshKeys = [


### PR DESCRIPTION
普段副鍵のパスフレーズは削除しているので、
無用な設定になりました。
