### PR TITLE
feat(seminar): Caddyサービス追加とTailscale設定を拡張

### DIFF
--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -1,0 +1,9 @@
+_: {
+  services.caddy = {
+    enable = true;
+    email = "ncaq@ncaq.net";
+    virtualHosts."seminar.border-saurolophus.ts.net".extraConfig = ''
+      respond "Hello from seminar!"
+    '';
+  };
+}

--- a/nixos/host/seminar/tailscale.nix
+++ b/nixos/host/seminar/tailscale.nix
@@ -1,7 +1,13 @@
 _: {
   # Exit Nodeとして動作するための追加設定。
-  # 基本的なTailscale有効化は nixos/core/tailscale.nix で行っている。
-  services.tailscale.useRoutingFeatures = "both";
+  # 基本的なTailscale有効化は nixos/core/tailscale.nix で行っています。
+  services.tailscale = {
+    openFirewall = true;
+    permitCertUid = "caddy";
+    useRoutingFeatures = "both";
+  };
+
+  # IP転送を有効化。
   boot.kernel.sysctl = {
     "net.ipv4.ip_forward" = 1;
     "net.ipv6.conf.all.forwarding" = 1;


### PR DESCRIPTION
- seminarホスト用にCaddyサービスを有効化し、仮想ホストを追加
- TailscaleでopenFirewallとpermitCertUidを設定し証明書連携を強化
- コメントを修正し説明を明確化
