### PR TITLE
feat(bump-cabal-index-state): `nix flake update`の手順を削除

### DIFF
--- a/home/prompt/commands/bump-cabal-index-state.md
+++ b/home/prompt/commands/bump-cabal-index-state.md
@@ -18,11 +18,6 @@ cabalプロジェクトの`index-state`を最新に更新します。
 
 # 手順
 
-## haskell.nixの使用確認
-
-まずプロジェクトがhaskell.nixを使用しているか確認してください。
-`flake.nix`または`flake.lock`に`haskell.nix`への参照があるか確認します。
-
 ## cabal updateの実行
 
 ```bash


### PR DESCRIPTION
nixの`flake.lock`の更新とcabalの更新は分離したい場面も多いし、
`nix flake update`は以下のshell aliasを設定しているので実行するのも簡単です。

```console
nix-flake-update-commit is an alias for nix flake update --commit-lock-file --option commit-lockfile-summary "build(deps): bump \`flake.lock\`"
```

よってcabalの更新という一つのことだけをするコマンドにしました。
例えば`flake.lock`の更新をGitHub Actionsで自動化している場合などは、
こちらの方が便利だと思います。

- haskell.nix未使用時の重複手順を削除
- 動作確認手順をNix有無で明確化
- flake.lock更新コマンドの説明を簡素化
- index-state更新やエラー対応の説明を整理
