### PR TITLE
fix(caddy): プロトコルを明示してvirtualHosts設定を修正

### DIFF
--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -30,7 +30,9 @@ in
     '';
     # tailscale serveはlocalhost宛のプロキシのみサポートするため、
     # caddyで中継します。
-    virtualHosts."localhost:8081".extraConfig = ''
+    # httpsが解決されたものをhttp同士で中継する必要があるため、
+    # わかりやすさも考えてプロトコルを明示的に指定しています。
+    virtualHosts."http://localhost:8081".extraConfig = ''
       reverse_proxy http://${atticdAddr}:8080
     '';
   };


### PR DESCRIPTION
- https解決後の中継先をhttpで明示的に指定
- 設定の可読性と意図の明確化
