### PR TITLE
feat(seminar): Tailscale経由のatticキャッシュ公開設定を削除

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -21,16 +21,3 @@ runs:
       with:
         name: ncaq-dotfiles
         authToken: "${{ inputs.cachix-auth-token }}"
-    - name: Configure attic cache
-      if: inputs.attic-token != ''
-      shell: bash
-      env:
-        ATTIC_TOKEN: "${{ inputs.attic-token }}"
-      run: |
-        NETRC_FILE=$(nix config show --json | jq -r '.["netrc-file"].value')
-        printf 'machine seminar.border-saurolophus.ts.net password %s\n' "$ATTIC_TOKEN" | sudo tee -a "$NETRC_FILE" > /dev/null
-        sudo tee -a /etc/nix/nix.conf > /dev/null <<'EOF'
-        extra-substituters = https://seminar.border-saurolophus.ts.net/nix/cache/private/
-        extra-trusted-public-keys = private:7SHPFhFIAzd4F78w1+EXgwP0HKApgLBbu9IJG8GE2I4=
-        EOF
-        sudo systemctl restart nix-daemon

--- a/nixos/host/seminar/atticd.nix
+++ b/nixos/host/seminar/atticd.nix
@@ -71,7 +71,6 @@ in
             listen = "[::]:8080";
             allowed-hosts = [
               "cache.nix.ncaq.net"
-              "seminar.border-saurolophus.ts.net"
             ];
             api-endpoint = "https://cache.nix.ncaq.net/";
             database.url = "postgresql:///atticd?host=/run/postgresql";

--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -28,12 +28,5 @@ in
       }
       reverse_proxy http://${atticdAddr}:8080
     '';
-    # tailscale serveはlocalhost宛のプロキシのみサポートするため、
-    # caddyで中継します。
-    # httpsが解決されたものをhttp同士で中継する必要があるため、
-    # わかりやすさも考えてプロトコルを明示的に指定しています。
-    virtualHosts."http://localhost:8081".extraConfig = ''
-      reverse_proxy http://${atticdAddr}:8080
-    '';
   };
 }

--- a/nixos/host/seminar/tailscale.nix
+++ b/nixos/host/seminar/tailscale.nix
@@ -1,9 +1,4 @@
-{
-  pkgs,
-  lib,
-  ...
-}:
-{
+_: {
   # Exit Nodeとして動作するための追加設定。
   # 基本的なTailscale有効化は nixos/core/tailscale.nix で行っています。
   services.tailscale = {
@@ -16,48 +11,5 @@
   boot.kernel.sysctl = {
     "net.ipv4.ip_forward" = 1;
     "net.ipv6.conf.all.forwarding" = 1;
-  };
-
-  # Tailscale Serve/Funnelでatticキャッシュを公開インターネットに露出する。
-  # GitHub Actionsなど外部CIからNixキャッシュとしてアクセス可能にするため。
-  systemd.services.tailscale-serve-attic = {
-    description = "Tailscale Serve for attic cache";
-    requires = [
-      "tailscaled.service"
-      "caddy.service"
-    ];
-    after = [
-      "tailscaled.service"
-      "caddy.service"
-    ];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      ExecStart = lib.getExe (
-        pkgs.writeShellApplication {
-          name = "tailscale-serve-attic-start";
-          runtimeInputs = with pkgs; [
-            tailscale
-          ];
-          text = ''
-            tailscale serve --bg --set-path /nix/cache/ http://localhost:8081
-            tailscale funnel --bg 443
-          '';
-        }
-      );
-      ExecStop = lib.getExe (
-        pkgs.writeShellApplication {
-          name = "tailscale-serve-attic-stop";
-          runtimeInputs = with pkgs; [
-            tailscale
-          ];
-          text = ''
-            tailscale funnel off 443 || echo "tailscale funnel off 443 failed" >&2
-            tailscale serve reset || echo "tailscale serve reset failed" >&2
-          '';
-        }
-      );
-    };
   };
 }


### PR DESCRIPTION
問題 #506
から波及して、
普通のキャッシュのエンドポイントもおかしくなってしまったため、
一度Tailscale経由のatticキャッシュ公開設定を削除します。

- GitHub Actionsのatticキャッシュ設定を削除
- atticdのallowed-hostsからTailscaleドメインを削除
- caddyのTailscale向けプロキシ設定を削除
- tailscale.nixからatticキャッシュ公開用systemdサービスを削除