### PR TITLE
fix(attic-client): attic-initサービスにsops-nix依存を追加

### DIFF
--- a/home/core/attic-client.nix
+++ b/home/core/attic-client.nix
@@ -19,6 +19,9 @@
   systemd.user.services.attic-init = {
     Unit = {
       Description = "Initialize Attic Cache Configuration";
+      Requires = [
+        "sops-nix.service"
+      ];
       Wants = [
         "network-online.target"
         "nss-lookup.target"
@@ -26,6 +29,7 @@
       After = [
         "network-online.target"
         "nss-lookup.target"
+        "sops-nix.service"
       ];
       Before = [
         "attic-watch-store-ncaq-private.service"


### PR DESCRIPTION
- attic-initのRequiresとAfterにsops-nix.serviceを追加し、
  シークレット復号が完了してから初期化が行われるように修正
- サービス起動順序の安定性を向上
