### PR TITLE
ci: home-managerとnixosのビルドジョブを追加

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,3 +23,29 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           attic-token: "${{ secrets.ATTIC_TOKEN }}"
       - run: nix flake check
+
+  build-home-manager:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          attic-token: "${{ secrets.ATTIC_TOKEN }}"
+      - run: nix build .#homeConfigurations.ncaq.activationPackage
+
+  build-nixos:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          attic-token: "${{ secrets.ATTIC_TOKEN }}"
+      - run: nix build .#nixosConfigurations.bullet.config.system.build.toplevel # bulletが退役したらメインマシンに変更すること

--- a/flake.nix
+++ b/flake.nix
@@ -333,29 +333,6 @@
               meta.description = "Fast system information tool";
               program = "${pkgs.fastfetch}/bin/fastfetch";
             };
-            cachix-push = {
-              type = "app";
-              meta = {
-                description = "Push cache to cachix";
-              };
-              program = pkgs.writeShellApplication {
-                name = "cachix-push";
-                runtimeInputs = with pkgs; [
-                  cachix
-                  jq
-                ];
-                text = ''
-                  echo "Push inputs"
-                  nix flake archive --json|jq -r '.path,(.inputs|to_entries[].value.path)'|cachix push ncaq-dotfiles
-                  echo "Push home-manager"
-                  nix build --print-out-paths '.#homeConfigurations.ncaq.activationPackage'|cachix push ncaq-dotfiles
-                  echo "Push NixOS partial"
-                  nix build --print-out-paths '.#nixosConfigurations.vanitas.config.system.build.toplevel'|cachix push ncaq-dotfiles
-                  nix build --print-out-paths '.#nixosConfigurations.bullet.config.system.build.toplevel'|cachix push ncaq-dotfiles
-                  nix build --print-out-paths '.#nixosConfigurations.SSD0086.config.system.build.toplevel'|cachix push ncaq-dotfiles
-                '';
-              };
-            };
           };
           devShells.default = pkgs.mkShell { };
         };


### PR DESCRIPTION
cachix-pushアプリは削除。
常にクライアントからpushされているキャッシュサーバが存在するのならば、
かなり無理をした汚いスクリプトを維持しておいておく必要性は薄いため。

- push.ymlにhome-managerとnixosのビルドジョブを追加
- flake.nixからcachix-pushアプリを削除
- CIでのビルド確認を強化
