### PR TITLE
feat(home-manager): バックアップ拡張子hm-bakを導入しコマンドを修正

### DIFF
--- a/docs/install/home-manager.md
+++ b/docs/install/home-manager.md
@@ -12,8 +12,8 @@ This guide describes how to install home-manager standalone on non-NixOS systems
 ```zsh
 git clone https://github.com/ncaq/dotfiles.git
 cd dotfiles
-nix run '.#home-manager' -- --flake ".#x86_64-linux" init --switch .
-# or nix run '.#home-manager' -- --flake ".#aarch64-linux" init --switch .
+nix run '.#home-manager' -- --flake ".#x86_64-linux" -b "hm-bak" init --switch .
+# or nix run '.#home-manager' -- --flake ".#aarch64-linux" -b "hm-bak" init --switch .
 ```
 
 ## Notes

--- a/flake.nix
+++ b/flake.nix
@@ -182,6 +182,7 @@
                       { config, ... }:
                       {
                         home-manager = {
+                          backupFileExtension = "hm-bak";
                           useGlobalPkgs = true;
                           useUserPackages = true;
                           extraSpecialArgs = specialArgs // {

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,10 @@ if [ -f /etc/NIXOS ]; then
 else
   case $(uname -m) in
   x86_64)
-    home-manager --flake ".#x86_64-linux" switch
+    home-manager --flake ".#x86_64-linux" -b "hm-bak" switch
     ;;
   aarch64)
-    home-manager --flake ".#aarch64-linux" switch
+    home-manager --flake ".#aarch64-linux" -b "hm-bak" switch
     ;;
   *)
     echo "未対応のプラットフォーム: $(uname -s)-$(uname -m)"


### PR DESCRIPTION
コンフリクトを避けます。

- home-managerのコマンドに-b "hm-bak"オプションを追加
- flake.nixでbackupFileExtensionを"hm-bak"に設定
- インストール手順とスクリプトをhm-bak対応に更新

close #119 