### PR TITLE
feat(emacs): emacsclientの引数を追加

### DIFF
--- a/home/core/emacs.nix
+++ b/home/core/emacs.nix
@@ -15,7 +15,13 @@
 
   services.emacs = {
     enable = true;
-    client.enable = true;
+    client = {
+      enable = true;
+      arguments = [
+        "--reuse-frame"
+        "--alternate-editor=emacs"
+      ];
+    };
     defaultEditor = true;
   };
 


### PR DESCRIPTION
- client.argumentsに--reuse-frameと--alternate-editor=emacsを設定
- 既存のclient.enable構造をclient属性に変更
