### PR TITLE
fix(backlight): clightのautostartサービスの二重起動を防止

### DIFF
--- a/nixos/laptop/backlight.nix
+++ b/nixos/laptop/backlight.nix
@@ -15,4 +15,10 @@ _: {
       };
     };
   };
+  # デフォルトだとclightパッケージが同梱するXDG autostartのdesktopファイルから、
+  # systemd-xdg-autostart-generatorがサービスを生成します。
+  # そうなるとservices.clightが作成するsystemdユーザーサービスと二重起動して競合するため、
+  # autostart側を無効化します。
+  # See: https://github.com/NixOS/nixpkgs/pull/262624
+  systemd.user.services."app-clight@autostart".enable = false;
 }


### PR DESCRIPTION
[nixos/clight: disable autostart service by name-snrl · Pull Request #262624 · NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/pull/262624)
で行われているワークアラウンドとほぼ同等の対応を行いました。
