### PR TITLE
fix: caddyがTailscaleのTLSを取り扱うのをやめる

### DIFF
--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -1,31 +1,15 @@
-{
-  config,
-  ...
-}:
+{ config, ... }:
 let
   atticdAddr = config.containerAddresses.atticd.container;
-  tailscale = config.services.tailscale.package;
-  tailscaleDomain = "seminar.border-saurolophus.ts.net";
-  certDir = "/var/lib/tailscale-cert";
-  certFile = "${certDir}/${tailscaleDomain}.crt";
-  keyFile = "${certDir}/${tailscaleDomain}.key";
 in
 {
   services.caddy = {
     enable = true;
     email = "ncaq@ncaq.net";
-    # tailnet内からのアクセス用。
-    # 分かり易さのためCaddyがまとめてリクエストを管理します。
-    virtualHosts."${tailscaleDomain}".extraConfig = ''
-      tls ${certFile} ${keyFile}
-      handle_path /nix/cache/* {
-        reverse_proxy http://${atticdAddr}:8080
-      }
-      redir /nix/cache /nix/cache/
-    '';
-    # Tailscale Funnelからのリクエストを受けるリバースプロキシ。
-    # Tailscale Funnelはlocalhostへの転送しかサポートしていないため、
-    # コンテナへの転送をするためにCaddyでプロキシします。
+    # Tailscale Serve/Funnelからのリクエストを受けるリバースプロキシ。
+    # tailscaledがTLS終端を行い、ここにHTTPで転送します。
+    # tailnet内からのHTTPSアクセスもtailscaledが処理するため、
+    # Caddyが443をlistenする必要はありません。
     virtualHosts.":8080".extraConfig = ''
       bind 127.0.0.1
       handle_path /nix/cache/* {
@@ -33,37 +17,5 @@ in
       }
       redir /nix/cache /nix/cache/
     '';
-  };
-
-  # Tailscaleドメイン用のTLS証明書を取得・更新するサービス。
-  # Caddyがtailnet内からのアクセスでもTLSを提供できるようにします。
-  systemd.tmpfiles.rules = [
-    "d ${certDir} 0750 caddy caddy -"
-  ];
-  systemd.services.tailscale-cert-for-caddy = {
-    description = "Generate Tailscale TLS certificates for Caddy";
-    requires = [ "tailscaled.service" ];
-    after = [ "tailscaled.service" ];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${tailscale}/bin/tailscale cert --cert-file ${certFile} --key-file ${keyFile} ${tailscaleDomain}";
-      RemainAfterExit = true;
-      User = "caddy";
-      Group = "caddy";
-    };
-  };
-  systemd.timers.tailscale-cert-for-caddy = {
-    description = "Weekly renewal of Tailscale TLS certificates";
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnCalendar = "weekly";
-      Persistent = true;
-    };
-  };
-
-  systemd.services.caddy = {
-    wants = [ "tailscale-cert-for-caddy.service" ];
-    after = [ "tailscale-cert-for-caddy.service" ];
   };
 }

--- a/nixos/host/seminar/tailscale.nix
+++ b/nixos/host/seminar/tailscale.nix
@@ -7,7 +7,6 @@ in
   # 基本的なTailscale有効化は nixos/core/tailscale.nix で行っています。
   services.tailscale = {
     openFirewall = true;
-    permitCertUid = "caddy";
     useRoutingFeatures = "both";
   };
 


### PR DESCRIPTION
tailnetからのアクセスは別途ハンドルする必要があるというのは勘違いだったみたいです。
証明書のハンドルをTailscaleに任せることで、
ポートの取り合いでエラーが発生するのを回避します。
