### PR TITLE
feat: KeepassXC-Browserの設定を調整

### DIFF
--- a/home/native-linux/firefox.nix
+++ b/home/native-linux/firefox.nix
@@ -77,7 +77,6 @@
               autoSubmit = true; # 資格情報を自動送信
               defaultGroupAlwaysAsk = true; # 保存時に常にグループを確認
               downloadFaviconAfterSave = true; # 保存後にfaviconをダウンロード
-              passkeysFallback = false; # Passkeysフォールバック無効
               showOTPIcon = false; # TOTPアイコン非表示
             };
           };


### PR DESCRIPTION
- **feat(firefox): autoFillSingleEntry設定を削除**
- **feat(firefox): TOTP自動入力とアイコン表示を無効化するオプションを追加**
- **style(firefox): keepassxc-browser拡張の設定項目の順序を整理**
- **fix(firefox): passkeysFallbackオプションを削除**
