### PR TITLE
feat(claude-code): commitメッセージへのCo-Authored-Byフッター付与を無効化

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -194,6 +194,9 @@ in
     settings = {
       # その時最適なモデルをデフォルトにします。
       model = "opus";
+      # コミットメッセージにCo-Authored-Byフッターを付与しません。
+      # 私はAIエージェントはテキストエディタの延長線上だと考えているためツール名がコミットに残るのは不適切です。
+      attribution.commit = "";
       # statuslineを設定します。
       # ccstatuslineを使用して豪華な表示にします。
       statusLine = {


### PR DESCRIPTION
- attribution.commitを空文字に設定し、Co-Authored-Byフッターを出力しないよう変更
- AIエージェントをテキストエディタの延長とみなし、ツール名が履歴に残らないよう配慮
