### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
     "dot-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1770725904,
-        "narHash": "sha256-Zmbg6xeIertluJe8ofC7DdDGfN+aMB13lUu2kTtN0vc=",
+        "lastModified": 1771040936,
+        "narHash": "sha256-hg8e9Hsu8/Th2WVOyzqeYzPZDWsg1fADj+DDar1jv7s=",
         "owner": "ncaq",
         "repo": ".emacs.d",
-        "rev": "f9e8542c548da52a14e5cba78482748da342deb7",
+        "rev": "8eb92384df0ea75ad7b82ddd5ef8d3955590d939",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1770602774,
-        "narHash": "sha256-eRcZ279Oaf8ViHtvdWVTpcD9x7bvJ3ipQ1Xq9bd+qlk=",
+        "lastModified": 1771037081,
+        "narHash": "sha256-jCaJSx+FB+peWUXV+ENpwj2yfGJeFWRUpmzARFlRChY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a3d87c21d1464f1069d8125cafe6adb84d200185",
+        "rev": "bbf97d44958a5b17546f9e2da99c05921749aa72",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1770631810,
-        "narHash": "sha256-b7iK/x+zOXbjhRqa+XBlYla4zFvPZyU5Ln2HJkiSnzc=",
+        "lastModified": 1770882871,
+        "narHash": "sha256-nw5g+xl3veea+maxJ2/81tMEA/rPq9aF1H5XF35X+OE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2889685785848de940375bf7fea5e7c5a3c8d502",
+        "rev": "af04cb78aa85b2a4d1c15fc7270347e0d0eda97b",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1770617025,
-        "narHash": "sha256-1jZvgZoAagZZB6NwGRv2T2ezPy+X6EFDsJm+YSlsvEs=",
+        "lastModified": 1770770419,
+        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2db38e08fdadcc0ce3232f7279bab59a15b94482",
+        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
         "type": "github"
       },
       "original": {
@@ -412,11 +412,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770537093,
-        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'dot-emacs':
    'github:ncaq/.emacs.d/f9e8542c548da52a14e5cba78482748da342deb7?narHash=sha256-Zmbg6xeIertluJe8ofC7DdDGfN%2BaMB13lUu2kTtN0vc%3D' (2026-02-10)
  → 'github:ncaq/.emacs.d/8eb92384df0ea75ad7b82ddd5ef8d3955590d939?narHash=sha256-hg8e9Hsu8/Th2WVOyzqeYzPZDWsg1fADj%2BDDar1jv7s%3D' (2026-02-14)
• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/a3d87c21d1464f1069d8125cafe6adb84d200185?narHash=sha256-eRcZ279Oaf8ViHtvdWVTpcD9x7bvJ3ipQ1Xq9bd%2Bqlk%3D' (2026-02-09)
  → 'github:nix-community/emacs-overlay/bbf97d44958a5b17546f9e2da99c05921749aa72?narHash=sha256-jCaJSx%2BFB%2BpeWUXV%2BENpwj2yfGJeFWRUpmzARFlRChY%3D' (2026-02-14)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/2889685785848de940375bf7fea5e7c5a3c8d502?narHash=sha256-b7iK/x%2BzOXbjhRqa%2BXBlYla4zFvPZyU5Ln2HJkiSnzc%3D' (2026-02-09)
  → 'github:NixOS/nixos-hardware/af04cb78aa85b2a4d1c15fc7270347e0d0eda97b?narHash=sha256-nw5g%2Bxl3veea%2BmaxJ2/81tMEA/rPq9aF1H5XF35X%2BOE%3D' (2026-02-12)
• Updated input 'nixpkgs-2511':
    'github:NixOS/nixpkgs/2db38e08fdadcc0ce3232f7279bab59a15b94482?narHash=sha256-1jZvgZoAagZZB6NwGRv2T2ezPy%2BX6EFDsJm%2BYSlsvEs%3D' (2026-02-09)
  → 'github:NixOS/nixpkgs/6c5e707c6b5339359a9a9e215c5e66d6d802fd7a?narHash=sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs%3D' (2026-02-11)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/fef9403a3e4d31b0a23f0bacebbec52c248fbb51?narHash=sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s%3D' (2026-02-08)
  → 'github:NixOS/nixpkgs/2343bbb58f99267223bc2aac4fc9ea301a155a16?narHash=sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8%3D' (2026-02-11)
