### PR TITLE
fix(gpg): Termuxでkeyboxdの残存データを削除し鍵インポート失敗を防止

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -48,7 +48,7 @@ lib.mkMerge [
         home.activation.cleanupGpgKeyboxd =
           lib.hm.dag.entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ]
             ''
-              ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
+              $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
               $DRY_RUN_CMD ${pkgs.trashy}/bin/trash "${config.home.homeDirectory}/.gnupg/public-keys.d/" || true
             '';
         # Termux環境: systemdが使えないためシェル初期化でgpg-agentを起動


### PR DESCRIPTION
- Termux環境でimportGpgKeys前にkeyboxdの古いデータベースをクリーンアップ
- public-keys.d/を削除して冪等性を確保し、鍵インポート失敗を回避
