### PR TITLE
feat: 日本語ロケールをNixOS以外の環境にも指定

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -10,6 +10,9 @@
   home = {
     stateVersion = "25.05";
 
+    # NixOSを使っていない環境向けにも日本語ロケールを指定します。
+    language.base = "ja_JP.UTF-8";
+
     # ユーザ名の制約が強い環境で譲ります。
     username = lib.mkDefault username;
 


### PR DESCRIPTION
- **style(home): home属性のネストを整理し可読性を向上**
- **feat(home): 日本語ロケールをNixOS以外の環境にも指定**

#530 
の一貫。