### PR TITLE
feat(lib): GitHub Actions Ubuntu 24.04互換パッケージリストを追加

### DIFF
--- a/lib/github-actions-runner-packages.nix
+++ b/lib/github-actions-runner-packages.nix
@@ -100,9 +100,7 @@ let
 
     # Container Tools
     buildah
-    docker # Docker CLI + daemon
-    docker-buildx
-    docker-compose
+    docker-client # CLI, buildx, compose。daemonはパッケージ単位で導入するのは望ましくないので除外。
     podman
     skopeo
 


### PR DESCRIPTION
#540
を実装するために、
先に概ね互換性のあるパッケージリストを生成しておきます。
大量にありますが、足りなくて苦労するより少し待つ方が楽です。
どうせhome-managerやNixOSのビルドの方が時間がかかりますし。