### PR TITLE
fix: コンテナvethインターフェースの不要なfirewall信頼設定を削除

### DIFF
--- a/nixos/host/seminar/machine-mapping.nix
+++ b/nixos/host/seminar/machine-mapping.nix
@@ -103,9 +103,5 @@ in
         "vm-+" # microVM TAP interfaces
       ];
     };
-    # Trust container/microVM interfaces for local host-to-guest communication.
-    networking.firewall.trustedInterfaces = [
-      "ve-+" # container veth interfaces
-    ];
   };
 }


### PR DESCRIPTION
ホストからコンテナへの通信(Caddy, Cloudflare Tunnel)は
ホスト側が接続を開始するため、conntrackにより応答パケットは
ESTABLISHEDとして自動許可される。
PostgreSQLはUnixソケットのbind mountで接続しておりネットワーク不使用。
microVMのTAPインターフェース(vm-+)も同様に信頼設定なしで
動作していることからも、この設定が不要であることが裏付けられる。
デプロイして全サービスへの通信が正常であることを確認済み。