### PR TITLE
feat(seminar): コンテナatticdとforgejoをephemeral化

### DIFF
--- a/nixos/host/seminar/atticd.nix
+++ b/nixos/host/seminar/atticd.nix
@@ -24,6 +24,7 @@ in
   environment.systemPackages = [ atticadmWrapper ];
   containers.atticd = {
     autoStart = true;
+    ephemeral = true;
     privateNetwork = true;
     hostAddress = addr.host;
     localAddress = addr.guest;

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -11,6 +11,7 @@ in
   environment.systemPackages = [ forgejoWrapper ];
   containers.forgejo = {
     autoStart = true;
+    ephemeral = true;
     privateNetwork = true;
     hostAddress = addr.host;
     localAddress = addr.guest;


### PR DESCRIPTION
原則としてコンテナはephemeralにするようにします。
永続化データはデータベースかホスト側のファイルシステムに保存します。
意図せぬ設定が永続的に残ることを防止するためです。
