### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769524058,
-        "narHash": "sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE=",
+        "lastModified": 1771469470,
+        "narHash": "sha256-GnqdqhrguKNN3HtVfl6z+zbV9R9jhHFm3Z8nu7R6ml0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "71a3fc97d80881e91710fe721f1158d3b96ae14d",
+        "rev": "4707eec8d1d2db5182ea06ed48c820a86a42dc13",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     "dot-emacs": {
       "flake": false,
       "locked": {
-        "lastModified": 1771040936,
-        "narHash": "sha256-hg8e9Hsu8/Th2WVOyzqeYzPZDWsg1fADj+DDar1jv7s=",
+        "lastModified": 1771477397,
+        "narHash": "sha256-s+tF1k/sAA9LWwcjPLb3YzHiuEYlKVUPkgPio6h5mFg=",
         "owner": "ncaq",
         "repo": ".emacs.d",
-        "rev": "8eb92384df0ea75ad7b82ddd5ef8d3955590d939",
+        "rev": "755572efe888c559df007a4b5a4d7e3766884305",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1771037081,
-        "narHash": "sha256-jCaJSx+FB+peWUXV+ENpwj2yfGJeFWRUpmzARFlRChY=",
+        "lastModified": 1771466830,
+        "narHash": "sha256-qSqKfMPExmgAR6K6WQ8RryKTiWiyWlPc0a2rsxV4l4A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "bbf97d44958a5b17546f9e2da99c05921749aa72",
+        "rev": "48eee0b93306fc0ee4127c6348fad402a811d10a",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1770310890,
-        "narHash": "sha256-lyWAs4XKg3kLYaf4gm5qc5WJrDkYy3/qeV5G733fJww=",
+        "lastModified": 1771365290,
+        "narHash": "sha256-1XJOslVyF7yzf6yd/yl1VjGLywsbtwmQh3X1LuJcLI4=",
         "owner": "microvm-nix",
         "repo": "microvm.nix",
-        "rev": "68c9f9c6ca91841f04f726a298c385411b7bfcd5",
+        "rev": "789c90b164b55b4379e7a94af8b9c01489024c18",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1770882871,
-        "narHash": "sha256-nw5g+xl3veea+maxJ2/81tMEA/rPq9aF1H5XF35X+OE=",
+        "lastModified": 1771423359,
+        "narHash": "sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "af04cb78aa85b2a4d1c15fc7270347e0d0eda97b",
+        "rev": "740a22363033e9f1bb6270fbfb5a9574067af15b",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770657009,
-        "narHash": "sha256-v/LA5ZSJ+JQYzMSKB4sySM0wKfsAqddNzzxLLnbsV/E=",
+        "lastModified": 1771243519,
+        "narHash": "sha256-oeHgjE5GpACBjDeXrTczIl6cKmHltLbk7inNSMgGFFQ=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "5b50ea1aaa14945d4794c80fcc99c4aa1db84d2d",
+        "rev": "a2cb8eeecfbf4a1ce0083e6a32680b1bec8b045c",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1770770419,
-        "narHash": "sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs=",
+        "lastModified": 1771208521,
+        "narHash": "sha256-X01Q3DgSpjeBpapoGA4rzKOn25qdKxbPnxHeMLNoHTU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c5e707c6b5339359a9a9e215c5e66d6d802fd7a",
+        "rev": "fa56d7d6de78f5a7f997b0ea2bc6efd5868ad9e8",
         "type": "github"
       },
       "original": {
@@ -433,11 +433,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770843696,
-        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
+        "lastModified": 1771207753,
+        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
+        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
         "type": "github"
       },
       "original": {
@@ -550,11 +550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770683991,
-        "narHash": "sha256-xVfPvXDf9QN3Eh9dV+Lw6IkWG42KSuQ1u2260HKvpnc=",
+        "lastModified": 1771166946,
+        "narHash": "sha256-UFc4lfGBr+wJmwgDGJDn1cVD6DTr0/8TdronNUiyXlU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8b89f44c2cc4581e402111d928869fe7ba9f7033",
+        "rev": "2d0cf89b4404529778bc82de7e42b5754e0fe4fa",
         "type": "github"
       },
       "original": {
@@ -617,11 +617,11 @@
     "www-ncaq-net": {
       "flake": false,
       "locked": {
-        "lastModified": 1770003128,
-        "narHash": "sha256-i8unN9pO9ivT/jS/7scyHuL1kHOe9gJX+M6qVqFI6w8=",
+        "lastModified": 1771230845,
+        "narHash": "sha256-B9WaxymlZNZnv+ee+Tw4c4PSB04E3atfcCd59l0XKu4=",
         "owner": "ncaq",
         "repo": "www.ncaq.net",
-        "rev": "2617028c09b2115a51674bac6d2b1e2c84aa090a",
+        "rev": "5db144512b3680ed0d480f13c071dad8e0cd30b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/71a3fc97d80881e91710fe721f1158d3b96ae14d?narHash=sha256-zygdD6X1PcVNR2PsyK4ptzrVEiAdbMqLos7utrMDEWE%3D' (2026-01-27)
  → 'github:nix-community/disko/4707eec8d1d2db5182ea06ed48c820a86a42dc13?narHash=sha256-GnqdqhrguKNN3HtVfl6z%2BzbV9R9jhHFm3Z8nu7R6ml0%3D' (2026-02-19)
• Updated input 'dot-emacs':
    'github:ncaq/.emacs.d/8eb92384df0ea75ad7b82ddd5ef8d3955590d939?narHash=sha256-hg8e9Hsu8/Th2WVOyzqeYzPZDWsg1fADj%2BDDar1jv7s%3D' (2026-02-14)
  → 'github:ncaq/.emacs.d/755572efe888c559df007a4b5a4d7e3766884305?narHash=sha256-s%2BtF1k/sAA9LWwcjPLb3YzHiuEYlKVUPkgPio6h5mFg%3D' (2026-02-19)
• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/bbf97d44958a5b17546f9e2da99c05921749aa72?narHash=sha256-jCaJSx%2BFB%2BpeWUXV%2BENpwj2yfGJeFWRUpmzARFlRChY%3D' (2026-02-14)
  → 'github:nix-community/emacs-overlay/48eee0b93306fc0ee4127c6348fad402a811d10a?narHash=sha256-qSqKfMPExmgAR6K6WQ8RryKTiWiyWlPc0a2rsxV4l4A%3D' (2026-02-19)
• Updated input 'microvm':
    'github:microvm-nix/microvm.nix/68c9f9c6ca91841f04f726a298c385411b7bfcd5?narHash=sha256-lyWAs4XKg3kLYaf4gm5qc5WJrDkYy3/qeV5G733fJww%3D' (2026-02-05)
  → 'github:microvm-nix/microvm.nix/789c90b164b55b4379e7a94af8b9c01489024c18?narHash=sha256-1XJOslVyF7yzf6yd/yl1VjGLywsbtwmQh3X1LuJcLI4%3D' (2026-02-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/af04cb78aa85b2a4d1c15fc7270347e0d0eda97b?narHash=sha256-nw5g%2Bxl3veea%2BmaxJ2/81tMEA/rPq9aF1H5XF35X%2BOE%3D' (2026-02-12)
  → 'github:NixOS/nixos-hardware/740a22363033e9f1bb6270fbfb5a9574067af15b?narHash=sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig%3D' (2026-02-18)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/5b50ea1aaa14945d4794c80fcc99c4aa1db84d2d?narHash=sha256-v/LA5ZSJ%2BJQYzMSKB4sySM0wKfsAqddNzzxLLnbsV/E%3D' (2026-02-09)
  → 'github:nix-community/NixOS-WSL/a2cb8eeecfbf4a1ce0083e6a32680b1bec8b045c?narHash=sha256-oeHgjE5GpACBjDeXrTczIl6cKmHltLbk7inNSMgGFFQ%3D' (2026-02-16)
• Updated input 'nixpkgs-2511':
    'github:NixOS/nixpkgs/6c5e707c6b5339359a9a9e215c5e66d6d802fd7a?narHash=sha256-iKZMkr6Cm9JzWlRYW/VPoL0A9jVKtZYiU4zSrVeetIs%3D' (2026-02-11)
  → 'github:NixOS/nixpkgs/fa56d7d6de78f5a7f997b0ea2bc6efd5868ad9e8?narHash=sha256-X01Q3DgSpjeBpapoGA4rzKOn25qdKxbPnxHeMLNoHTU%3D' (2026-02-16)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/2343bbb58f99267223bc2aac4fc9ea301a155a16?narHash=sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8%3D' (2026-02-11)
  → 'github:NixOS/nixpkgs/d1c15b7d5806069da59e819999d70e1cec0760bf?narHash=sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE%3D' (2026-02-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/8b89f44c2cc4581e402111d928869fe7ba9f7033?narHash=sha256-xVfPvXDf9QN3Eh9dV%2BLw6IkWG42KSuQ1u2260HKvpnc%3D' (2026-02-10)
  → 'github:Mic92/sops-nix/2d0cf89b4404529778bc82de7e42b5754e0fe4fa?narHash=sha256-UFc4lfGBr%2BwJmwgDGJDn1cVD6DTr0/8TdronNUiyXlU%3D' (2026-02-15)
• Updated input 'www-ncaq-net':
    'github:ncaq/www.ncaq.net/2617028c09b2115a51674bac6d2b1e2c84aa090a?narHash=sha256-i8unN9pO9ivT/jS/7scyHuL1kHOe9gJX%2BM6qVqFI6w8%3D' (2026-02-02)
  → 'github:ncaq/www.ncaq.net/5db144512b3680ed0d480f13c071dad8e0cd30b9?narHash=sha256-B9WaxymlZNZnv%2Bee%2BTw4c4PSB04E3atfcCd59l0XKu4%3D' (2026-02-16)
