### PR TITLE
fix(github-actions-runner-packages): カテゴリを整理してminimalセットを縮小

### DIFF
--- a/lib/github-actions-runner-packages.nix
+++ b/lib/github-actions-runner-packages.nix
@@ -185,9 +185,12 @@ let
   systemTools = [
     acl
     dbus
-    dpkg
     fakeroot
     haveged
+  ];
+
+  otherDistributionTools = [
+    dpkg
     rpm
   ];
 
@@ -242,6 +245,7 @@ in
     cloudClis
     cliTools
     systemTools
+    otherDistributionTools
     browsers
     databases
     webServers
@@ -253,6 +257,7 @@ in
     basicLanguageAndRuntime
     cppBuildTools
     cliTools
+    systemTools
     devLibraries
   ];
 
@@ -269,6 +274,7 @@ in
     cloudClis
     cliTools
     systemTools
+    otherDistributionTools
     browsers
     databases
     webServers


### PR DESCRIPTION
- **fix(github-actions-runner-packages): minimalセットを更に縮小**
- **fix(github-actions-runner-packages): llvmなどをadvancedに移動**
- **fix(github-actions-runner-packages): systemツール群をsystemToolsへ分離**

relation #543 
