### PR TITLE
feat(claude-code): `gh api *pulls/*/reviews*`の許可を追加

### DIFF
--- a/.claude/agents/pr-conversation-collector.md
+++ b/.claude/agents/pr-conversation-collector.md
@@ -7,6 +7,7 @@ description: |
 tools:
   - Bash(gh api *issues/*/comments*)
   - Bash(gh api *pulls/*/comments*)
+  - Bash(gh api *pulls/*/reviews*)
   - Bash(gh pr view *)
   - mcp__github
 model: sonnet

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,6 +59,7 @@ jobs:
             --model opus --allowed-tools "
             Bash(gh api *issues/*/comments*),
             Bash(gh api *pulls/*/comments*),
+            Bash(gh api *pulls/*/reviews*),
             Bash(gh issue:*),
             Bash(gh pr:*),
             Bash(gh search:*),

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -215,6 +215,7 @@ in
           "Bash(gh *)"
           "Bash(gh api *issues/*/comments*)"
           "Bash(gh api *pulls/*/comments*)"
+          "Bash(gh api *pulls/*/reviews*)"
           "Bash(ghc-pkg describe *)"
           "Bash(ghc-pkg field *)"
           "Bash(ghci *)"


### PR DESCRIPTION
- Claudeエージェント、GitHub Actions、claude-code.nixで、
  `Bash(gh api *pulls/*/reviews*)`コマンドを許可リストに追加
- プルリクエストのレビュー情報取得が幅広くなりました
