### PR TITLE
feat(keybase): Keybaseサービス設定を削除しパッケージのみインストールに統一

### DIFF
--- a/home/core/keybase.nix
+++ b/home/core/keybase.nix
@@ -1,18 +1,4 @@
+{ pkgs, ... }:
 {
-  pkgs,
-  isTermux,
-  ...
-}:
-
-if !isTermux then
-  {
-    services = {
-      keybase.enable = true;
-      kbfs.enable = true;
-    };
-  }
-else
-  {
-    # Termux環境ではserviceが利用できないためパッケージだけ明示的にインストールします。
-    home.packages = with pkgs; [ keybase ];
-  }
+  home.packages = with pkgs; [ keybase ];
+}


### PR DESCRIPTION
現状keybaseのサービスは使わなかったので。
常時プロセスを起動させている価値はない判断しました。
コマンドは使うときもあるのでパッケージはインストールするようにしています。
