### PR TITLE
ci: self-host-runner-arm環境でsetup-nixをgithub-hosted以外に限定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 50
       - uses: ./.github/actions/setup-nix
+        if: runner.environment != 'github-hosted'
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           attic-token: "${{ secrets.ATTIC_TOKEN }}"


### PR DESCRIPTION
GitHubのホステッドランナー環境ならClaude Code Reviewは十分に動くので、
nixの環境セットアップは過剰で時間がかかるだけなため無効化します。
セルフホステッドランナーだとGitHub CLIなども含めて入っていると限らないため、
セットアップを有効にしておきます。
seminarに定義してある環境ではGitHub CLIも入っているので不要なのですが、
汎用的な条件分岐を想定しています。
