### PR TITLE
Revert "fix(network): 20-lanのアドレス範囲を/24から/32に変更"

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-arm64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-arm64.nix
@@ -108,7 +108,7 @@ in
             networks."20-lan" = {
               matchConfig.Type = "ether";
               networkConfig = {
-                Address = "${addr.guest}/32";
+                Address = "${addr.guest}/24";
                 Gateway = addr.host;
                 DNS = [
                   "1.1.1.1"

--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -59,7 +59,7 @@ in
           networks."20-lan" = {
             matchConfig.Type = "ether";
             networkConfig = {
-              Address = "${addr.guest}/32";
+              Address = "${addr.guest}/24";
               Gateway = addr.host;
               DNS = [
                 "1.1.1.1"


### PR DESCRIPTION
This reverts commit 468a65563089b7fc3a490507e6a378f9c687572f.

ゲスト側のアドレス範囲を`/32`にすると動作しなくなる。
まあ通信出来る範囲が狭まるのでそれはそう。
ゲスト側なら隔離されているので衝突することも多分ないはず。
