### PR TITLE
refactor(flake): pkgs.system参照をstdenv.hostPlatform.systemに修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -308,7 +308,7 @@
                   )
                   (
                     nixpkgs.lib.filterAttrs (
-                      _: nixosConfig: nixosConfig.pkgs.system == system
+                      _: nixosConfig: nixosConfig.pkgs.stdenv.hostPlatform.system == system
                     ) top.config.flake.nixosConfigurations
                   );
               # home-manager構成の評価チェック


### PR DESCRIPTION
close #602

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

の警告を解消。
