### PR TITLE
fix(nix): nix-fast-buildラッパーでSQLite競合回避を追加

### DIFF
--- a/home/core/nix.nix
+++ b/home/core/nix.nix
@@ -4,9 +4,8 @@ let
   # nix-fast-buildのラッパー: SQLiteキャッシュの競合のエラーを回避するために評価キャッシュを無効化しています。
   nix-fast-build-wrapper = pkgs.writeShellApplication {
     name = "nix-fast-build";
-    runtimeInputs = [ pkgs.nix-fast-build ];
     text = ''
-      exec nix-fast-build --option eval-cache false "$@"
+      exec ${pkgs.lib.getExe pkgs.nix-fast-build} --option eval-cache false "$@"
     '';
   };
 in


### PR DESCRIPTION
- SQLiteキャッシュ競合によるエラー回避のためnix-fast-buildの評価キャッシュを無効化するラッパーを導入
- home.packagesでnix-fast-buildをラッパー経由で提供
