### PR TITLE
feat: claude-code向けhtnsbfキーバインド追加

### DIFF
--- a/home/core/tmux.nix
+++ b/home/core/tmux.nix
@@ -67,6 +67,20 @@
 
         # プレフィックスなしで直接使えるキーバインド
 
+        # htnsbf形式: ctrl+h/ctrl+sなどを左右矢印などに変換してアプリに渡します
+        # GNU readlineやzleはそれぞれhtnsbf形式を設定済みですが、
+        # claude-codeなどのNode.js TUIアプリはreadlineを使わないためtmuxレベルで変換してやります
+        bind -n C-h send-keys Left
+        bind -n M-h send-keys M-Left
+        bind -n C-t send-keys Up
+        bind -n M-t send-keys M-Up
+        bind -n C-n send-keys Down
+        bind -n M-n send-keys M-Down
+        bind -n C-s send-keys Right
+        bind -n M-s send-keys M-Right
+        bind -n C-b send-keys BSpace
+        bind -n M-b send-keys M-BSpace
+
         # ctrl+alt+o = 新規ウィンドウ(タブ)、同じディレクトリで開始
         bind -n C-M-o new-window -a -c "#{pane_current_path}"
 

--- a/home/linked/.claude/keybindings.json
+++ b/home/linked/.claude/keybindings.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://www.schemastore.org/claude-code-keybindings.json",
+  "$docs": "https://code.claude.com/docs/en/keybindings",
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "ctrl+g": "chat:cancel",
+        "ctrl+l": "chat:externalEditor",
+        "ctrl+/": "chat:undo",
+        "ctrl+t": "history:previous",
+        "ctrl+n": "history:next"
+      }
+    },
+    {
+      "context": "Autocomplete",
+      "bindings": {
+        "ctrl+g": "autocomplete:dismiss",
+        "t": "autocomplete:previous",
+        "n": "autocomplete:next",
+        "ctrl+t": "autocomplete:previous",
+        "ctrl+n": "autocomplete:next"
+      }
+    },
+    {
+      "context": "Settings",
+      "bindings": {
+        "t": "select:previous",
+        "n": "select:next",
+        "ctrl+t": "select:previous",
+        "ctrl+n": "select:next"
+      }
+    },
+    {
+      "context": "Confirmation",
+      "bindings": {
+        "ctrl+g": "confirm:no",
+        "t": "confirm:previous",
+        "n": "confirm:next",
+        "ctrl+t": "confirm:previous",
+        "ctrl+n": "confirm:next"
+      }
+    },
+    {
+      "context": "Transcript",
+      "bindings": {
+        "ctrl+g": "transcript:exit"
+      }
+    },
+    {
+      "context": "HistorySearch",
+      "bindings": {
+        "ctrl+g": "historySearch:accept"
+      }
+    },
+    {
+      "context": "Help",
+      "bindings": {
+        "ctrl+g": "help:dismiss"
+      }
+    },
+    {
+      "context": "Attachments",
+      "bindings": {
+        "ctrl+g": "attachments:exit"
+      }
+    },
+    {
+      "context": "Footer",
+      "bindings": {
+        "ctrl+g": "footer:clearSelection"
+      }
+    },
+    {
+      "context": "MessageSelector",
+      "bindings": {
+        "t": "messageSelector:up",
+        "n": "messageSelector:down",
+        "ctrl+t": "messageSelector:up",
+        "ctrl+n": "messageSelector:down"
+      }
+    },
+    {
+      "context": "DiffDialog",
+      "bindings": {
+        "ctrl+g": "diff:dismiss",
+        "t": "diff:previousFile",
+        "n": "diff:nextFile",
+        "ctrl+t": "diff:previousFile",
+        "ctrl+n": "diff:nextFile"
+      }
+    },
+    {
+      "context": "Select",
+      "bindings": {
+        "ctrl+g": "select:cancel",
+        "t": "select:previous",
+        "n": "select:next",
+        "ctrl+t": "select:previous",
+        "ctrl+n": "select:next"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
close #640

- claude-codeなどNode.js TUIアプリ用にtmuxでhtnsbf形式のキーバインドを追加
- CLI版Emacsなどへの影響は調査して許容範囲と判断、そもそもCLI版Emacsをそこまで使わない
- home/linked/.claude/keybindings.jsonを新規作成し各コンテキストのキーバインドを定義
- Enterで送信せず改行するようにしたかったのですが、仕組み上困難だったので次の機会に回します
