### PR TITLE
fix(claude-code): ~/.local/bin/claudeの警告抑制用リンクを追加

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -395,6 +395,10 @@ in
     };
   };
 
+  # Claude Codeがnativeインストール時に`~/.local/bin/claude`が存在していないと警告を出すため、
+  # シンボリックリンクを作成して警告を抑制します。
+  home.file.".local/bin/claude".source = "${config.programs.claude-code.finalPackage}/bin/claude";
+
   # GitHub MCP Server用のPersonal Access Tokenをsops-nixで管理します。
   # シークレットファイルは `sops secrets/github-mcp-server.yaml` で編集してください。
   # 形式:


### PR DESCRIPTION
- Claude Codeのnativeインストール時に警告が出る問題を修正
- ~/.local/bin/claudeへシンボリックリンクを作成して警告を防止
