### PR TITLE
feat(git): emacsclientにオプションを変更

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -24,7 +24,7 @@ in
         color.ui = true;
         core = {
           autocrlf = false;
-          editor = "emacsclient";
+          editor = "emacsclient --reuse-frame --alternate-editor=emacs";
           quotePath = false;
           symlinks = true;
         };


### PR DESCRIPTION
- editorに--reuse-frameと--alternate-editor=emacsを追加
- emacsclientが起動していない場合でもエディタが開くよう改善
