### PR TITLE
feat: commit.mdにコミットファイル削除手順を追加

### DIFF
--- a/home/prompt/commands/commit.md
+++ b/home/prompt/commands/commit.md
@@ -11,6 +11,7 @@ allowed-tools:
   - Bash(git show:*)
   - Bash(git status:*)
   - Bash(mkdir:*)
+  - Bash(trash:*)
   - Glob
   - Grep
   - Read
@@ -151,6 +152,14 @@ amendで上書きしてください。
 
 ```bash
 git commit --amend -F /tmp/coding-agent-work/repo-name/COMMIT_EDITMSG
+```
+
+## コミットファイルのクリーンアップ
+
+コミットが完了したら一時ファイルを削除してください。
+
+```bash
+trash /tmp/coding-agent-work/repo-name/COMMIT_EDITMSG
 ```
 
 # 完了報告


### PR DESCRIPTION
- コミット完了後に一時ファイルをtrashコマンドで削除する手順を追記
- allowed-toolsにBash(trash:*)を追加
