### PR TITLE
ci(workflows): claude-code-reviewにid-token権限writeを追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
       deployments: read
       discussions: read
+      id-token: write
       issues: read
       packages: read
       pages: read


### PR DESCRIPTION
必要ないと調査結果は言っていましたが、
普通に必要でした。
