### PR TITLE
ci: push.ymlのnix-flake-checkジョブをnix-fast-buildに変更

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read # リポジトリコンテンツの読み取り
 
 jobs:
-  nix-flake-check:
+  nix-fast-build:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -23,7 +23,7 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
           attic-token: "${{ secrets.ATTIC_TOKEN }}"
-      - run: nix flake check
+      - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
 
   build-home-manager:
     # 重たいビルドは未認証のソースからは実行しない。

--- a/flake.nix
+++ b/flake.nix
@@ -366,6 +366,7 @@
               fastfetch
               git
               home-manager
+              nix-fast-build
               qemu-user
               ;
           };


### PR DESCRIPTION
`nix flake check`が律速になっている時がだんだん増えてきたため、
`nix-fast-build`にチェッカーを変更します。
当初は完全にチェックするのか不安だったのでCIでは`nix flake check`を使っていましたが、
`nix-fast-build`も十分に信頼できることがわかってきたので、
変更します。
