### PR TITLE
ci: is-trustedジョブで信頼チェックを共通化しセルフホステッドを優先

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,8 +11,29 @@ permissions:
   contents: read # リポジトリコンテンツの読み取り
 
 jobs:
-  nix-fast-build:
+  is-trusted:
+    # 信頼できるソースからのトリガーかを判定します。
+    # セルフホステッドランナーの利用を制御するために使用します。
     runs-on: ubuntu-24.04
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
+    steps:
+      - run: echo "Trusted source confirmed"
+
+  nix-fast-build:
+    needs: is-trusted
+    # 信頼できるソースの場合はセルフホステッドランナーで高速化し、
+    # それ以外はGitHubランナーで実行します。
+    # is-trustedがスキップされてもこのジョブは実行する必要があるためalways()を使用します。
+    if: always() && !cancelled()
+    runs-on: >-
+      ${{ needs.is-trusted.result == 'success'
+        && fromJSON('["self-hosted", "Linux", "X64"]') || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -26,14 +47,9 @@ jobs:
       - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
 
   build-home-manager:
-    # 重たいビルドは未認証のソースからは実行しない。
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
+    needs: is-trusted
+    # セルフホステッドランナーは未認証のソースからは実行しない。
+    if: needs.is-trusted.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 360
     strategy:
@@ -55,14 +71,9 @@ jobs:
       - run: nix build .#homeConfigurations.${{ matrix.system }}.activationPackage
 
   build-nix-on-droid:
-    # 重たいビルドは未認証のソースからは実行しない。
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
+    needs: is-trusted
+    # セルフホステッドランナーは未認証のソースからは実行しない。
+    if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux, ARM64]
     timeout-minutes: 360
     steps:


### PR DESCRIPTION
`nix-fast-build`はGitHubホステッドランナーを使用しているため、
セルフホステッドランナーで動くx86_64のhome-managerビルドより遅くなるケースがありました。
信頼できるソースからのトリガーの場合はセルフホステッドランナーを使うように変更しました。
また、各ジョブで繰り返していた信頼チェック条件を`is-trusted`ジョブに集約し、
他のジョブは`needs.is-trusted.result`を参照するだけにすることで重複を排除しました。
