### PR TITLE
refactor: Nixモジュールでフラット属性をグループ化してネスト構造に統一

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -430,49 +430,54 @@ in
     };
   };
 
-  # Claude Codeがnativeインストール時に`~/.local/bin/claude`が存在していないと警告を出すため、
-  # シンボリックリンクを作成して警告を抑制します。
-  home.file.".local/bin/claude".source = "${config.programs.claude-code.finalPackage}/bin/claude";
+  home = {
+    # Claude Codeがnativeインストール時に`~/.local/bin/claude`が存在していないと警告を出すため、
+    # シンボリックリンクを作成して警告を抑制します。
+    file.".local/bin/claude".source = "${config.programs.claude-code.finalPackage}/bin/claude";
 
-  # GitHub MCP Server用のPersonal Access Tokenをsops-nixで管理します。
-  # シークレットファイルは `sops secrets/github-mcp-server.yaml` で編集してください。
-  # 形式:
-  # pat: ghp_xxxxxxxxxxxxxxxxxxxxx
-  sops.secrets."github-mcp-server/pat" = {
-    sopsFile = ../../secrets/github-mcp-server.yaml;
-    key = "pat";
-    mode = "0400";
+    # Clone repositories for additionalDirectories if they don't exist
+    activation = {
+      cloneNixpkgs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        if [ ! -d "${config.home.homeDirectory}/Desktop/nixpkgs" ]; then
+          $DRY_RUN_CMD ${pkgs.git}/bin/git clone --depth=50 \
+            https://github.com/NixOS/nixpkgs.git \
+            "${config.home.homeDirectory}/Desktop/nixpkgs"
+        fi
+      '';
+      cloneHomeManager = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        if [ ! -d "${config.home.homeDirectory}/Desktop/home-manager" ]; then
+          $DRY_RUN_CMD ${pkgs.git}/bin/git clone --depth=50 \
+            https://github.com/nix-community/home-manager.git \
+            "${config.home.homeDirectory}/Desktop/home-manager"
+        fi
+      '';
+    };
   };
 
-  # Backlog MCP Server用の認証情報をsops-nixで管理します。
-  # シークレットファイルは `sops secrets/backlog-mcp-server.yaml` で編集してください。
-  # 形式:
-  # domain: your-space.backlog.com
-  # api-key: your-api-key
-  sops.secrets."backlog-mcp-server/domain" = {
-    sopsFile = ../../secrets/backlog-mcp-server.yaml;
-    key = "domain";
-    mode = "0400";
+  sops.secrets = {
+    # GitHub MCP Server用のPersonal Access Tokenをsops-nixで管理します。
+    # シークレットファイルは `sops secrets/github-mcp-server.yaml` で編集してください。
+    # 形式:
+    # pat: ghp_xxxxxxxxxxxxxxxxxxxxx
+    "github-mcp-server/pat" = {
+      sopsFile = ../../secrets/github-mcp-server.yaml;
+      key = "pat";
+      mode = "0400";
+    };
+    # Backlog MCP Server用の認証情報をsops-nixで管理します。
+    # シークレットファイルは `sops secrets/backlog-mcp-server.yaml` で編集してください。
+    # 形式:
+    # domain: your-space.backlog.com
+    # api-key: your-api-key
+    "backlog-mcp-server/domain" = {
+      sopsFile = ../../secrets/backlog-mcp-server.yaml;
+      key = "domain";
+      mode = "0400";
+    };
+    "backlog-mcp-server/api-key" = {
+      sopsFile = ../../secrets/backlog-mcp-server.yaml;
+      key = "api-key";
+      mode = "0400";
+    };
   };
-  sops.secrets."backlog-mcp-server/api-key" = {
-    sopsFile = ../../secrets/backlog-mcp-server.yaml;
-    key = "api-key";
-    mode = "0400";
-  };
-
-  # Clone repositories for additionalDirectories if they don't exist
-  home.activation.cloneNixpkgs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${config.home.homeDirectory}/Desktop/nixpkgs" ]; then
-      $DRY_RUN_CMD ${pkgs.git}/bin/git clone --depth=50 \
-        https://github.com/NixOS/nixpkgs.git \
-        "${config.home.homeDirectory}/Desktop/nixpkgs"
-    fi
-  '';
-  home.activation.cloneHomeManager = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${config.home.homeDirectory}/Desktop/home-manager" ]; then
-      $DRY_RUN_CMD ${pkgs.git}/bin/git clone --depth=50 \
-        https://github.com/nix-community/home-manager.git \
-        "${config.home.homeDirectory}/Desktop/home-manager"
-    fi
-  '';
 }

--- a/home/core/emacs.nix
+++ b/home/core/emacs.nix
@@ -25,23 +25,25 @@
     defaultEditor = true;
   };
 
-  # Emacsが必要とするネイティブパッケージ。
-  home.packages = with pkgs; [
-    copilot-language-server
-  ];
+  home = {
+    # Emacsが必要とするネイティブパッケージ。
+    packages = with pkgs; [
+      copilot-language-server
+    ];
 
-  # Emacsの設定はEmacs Lispで行うのがDSLとして最適化されていて楽なので、
-  # Nix言語ではなく`.emacs.d`で基本的に管理します。
-  # またEmacsの設定は即座に反映したいため、
-  # currentとしてはinputs頼りではなくcloneしたものを直接参照します。
-  # inputsにも入れていますが、
-  # それは外部ライブラリを自動的に入れるためのもので、
-  # あくまでショートカットです。
-  home.activation.cloneEmacsConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${config.home.homeDirectory}/.emacs.d" ]; then
-      $DRY_RUN_CMD ${pkgs.git}/bin/git clone \
-        https://github.com/ncaq/.emacs.d.git \
-        "${config.home.homeDirectory}/.emacs.d"
-    fi
-  '';
+    # Emacsの設定はEmacs Lispで行うのがDSLとして最適化されていて楽なので、
+    # Nix言語ではなく`.emacs.d`で基本的に管理します。
+    # またEmacsの設定は即座に反映したいため、
+    # currentとしてはinputs頼りではなくcloneしたものを直接参照します。
+    # inputsにも入れていますが、
+    # それは外部ライブラリを自動的に入れるためのもので、
+    # あくまでショートカットです。
+    activation.cloneEmacsConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -d "${config.home.homeDirectory}/.emacs.d" ]; then
+        $DRY_RUN_CMD ${pkgs.git}/bin/git clone \
+          https://github.com/ncaq/.emacs.d.git \
+          "${config.home.homeDirectory}/.emacs.d"
+      fi
+    '';
+  };
 }

--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -41,16 +41,6 @@ lib.mkMerge [
       }
     else
       {
-        # Termux環境ではsystemdによるGPGデーモンのライフサイクル管理がないため、
-        # keyboxdのdotlockファイルが残留しsops-nixの復号化を妨げることがあります。
-        # importGpgKeysの前にkeyboxdをkillしてpublic-keys.d/を削除し、
-        # stale lockのない状態で鍵を再インポートします。
-        home.activation.cleanupGpgKeyboxd =
-          lib.hm.dag.entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ]
-            ''
-              $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
-              $DRY_RUN_CMD ${pkgs.trashy}/bin/trash "${config.home.homeDirectory}/.gnupg/public-keys.d/" 2>/dev/null || true
-            '';
         # Termux環境: systemdが使えないためシェル初期化でgpg-agentを起動
         programs.zsh.initContent = ''
           # gpg-agentをSSHサポート付きで起動
@@ -58,17 +48,29 @@ lib.mkMerge [
           gpgconf --launch gpg-agent
           export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
         '';
-        home.file.".gnupg/gpg-agent.conf".text = ''
-          enable-ssh-support
-          pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
-        '';
-        home.file.".gnupg/sshcontrol".text = ''
-          # SSH認証に使用するGPGサブキーのkeygrip
-          ${sshKeygrip}
-        '';
-        home.packages = with pkgs; [
-          pinentry-curses
-        ];
+        home = {
+          file = {
+            ".gnupg/gpg-agent.conf".text = ''
+              enable-ssh-support
+              pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
+            '';
+            ".gnupg/sshcontrol".text = ''
+              # SSH認証に使用するGPGサブキーのkeygrip
+              ${sshKeygrip}
+            '';
+          };
+          # Termux環境ではsystemdによるGPGデーモンのライフサイクル管理がないため、
+          # keyboxdのdotlockファイルが残留しsops-nixの復号化を妨げることがあります。
+          # importGpgKeysの前にkeyboxdをkillしてpublic-keys.d/を削除し、
+          # stale lockのない状態で鍵を再インポートします。
+          activation.cleanupGpgKeyboxd = lib.hm.dag.entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
+            $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
+            $DRY_RUN_CMD ${pkgs.trashy}/bin/trash "${config.home.homeDirectory}/.gnupg/public-keys.d/" 2>/dev/null || true
+          '';
+          packages = with pkgs; [
+            pinentry-curses
+          ];
+        };
       }
   )
 ]

--- a/home/core/haskell.nix
+++ b/home/core/haskell.nix
@@ -31,29 +31,31 @@ let
   };
 in
 {
-  home.packages =
-    (with pkgs; [
-      alex
-      cabal-install
-      cabal2nix
-      fourmolu
-      ghc
-      happy
-      haskell-ci
-      haskell-language-server
-      hlint
-      hpack
-      pandoc
-      stack
-      stylish-haskell
-    ])
-    ++ (with pkgs.haskellPackages; [
-      cabal-fmt
-      cabal-gild
-      cabal-plan
-      implicit-hie
-      uniq-deep
-    ]);
+  home = {
+    packages =
+      (with pkgs; [
+        alex
+        cabal-install
+        cabal2nix
+        fourmolu
+        ghc
+        happy
+        haskell-ci
+        haskell-language-server
+        hlint
+        hpack
+        pandoc
+        stack
+        stylish-haskell
+      ])
+      ++ (with pkgs.haskellPackages; [
+        cabal-fmt
+        cabal-gild
+        cabal-plan
+        implicit-hie
+        uniq-deep
+      ]);
 
-  home.file.".stack/config.yaml".source = yamlFormat.generate "stack-config" stackConfig;
+    file.".stack/config.yaml".source = yamlFormat.generate "stack-config" stackConfig;
+  };
 }

--- a/home/core/zsh.nix
+++ b/home/core/zsh.nix
@@ -32,11 +32,13 @@ in
     autojump.enable = true;
   };
 
-  home.shell.enableZshIntegration = true;
+  home = {
+    shell.enableZshIntegration = true;
 
-  home.activation.cloneZshConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${zshDotDir}" ]; then
-      $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.zsh.d.git "${zshDotDir}"
-    fi
-  '';
+    activation.cloneZshConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -d "${zshDotDir}" ]; then
+        $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.zsh.d.git "${zshDotDir}"
+      fi
+    '';
+  };
 }

--- a/home/native-linux/grive.nix
+++ b/home/native-linux/grive.nix
@@ -23,9 +23,17 @@ let
   });
 in
 {
-  home.packages = [
-    grive2WithScript
-  ];
+  home = {
+    packages = [
+      grive2WithScript
+    ];
+
+    activation.createGoogleDriveDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -d "${config.home.homeDirectory}/GoogleDrive" ]; then
+        $DRY_RUN_CMD mkdir "${config.home.homeDirectory}/GoogleDrive"
+      fi
+    '';
+  };
 
   # 固定パスのサービスを定義することで単純化。
   systemd.user = {
@@ -73,9 +81,4 @@ in
     };
   };
 
-  home.activation.createGoogleDriveDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${config.home.homeDirectory}/GoogleDrive" ]; then
-      $DRY_RUN_CMD mkdir "${config.home.homeDirectory}/GoogleDrive"
-    fi
-  '';
 }

--- a/home/native-linux/xkeysnail.nix
+++ b/home/native-linux/xkeysnail.nix
@@ -5,17 +5,19 @@
   ...
 }:
 {
-  home.packages = with pkgs; [
-    xkeysnail
-  ];
+  home = {
+    packages = with pkgs; [
+      xkeysnail
+    ];
 
-  home.activation.cloneXkeysnailConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if [ ! -d "${config.home.homeDirectory}/.xkeysnail" ]; then
-      $DRY_RUN_CMD ${pkgs.git}/bin/git clone \
-        https://github.com/ncaq/.xkeysnail.git \
-        "${config.home.homeDirectory}/.xkeysnail"
-    fi
-  '';
+    activation.cloneXkeysnailConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -d "${config.home.homeDirectory}/.xkeysnail" ]; then
+        $DRY_RUN_CMD ${pkgs.git}/bin/git clone \
+          https://github.com/ncaq/.xkeysnail.git \
+          "${config.home.homeDirectory}/.xkeysnail"
+      fi
+    '';
+  };
 
   systemd.user.services.xkeysnail = {
     Unit = {

--- a/nixos/host/seminar/atticd.nix
+++ b/nixos/host/seminar/atticd.nix
@@ -42,45 +42,54 @@ in
       { lib, ... }:
       {
         system.stateVersion = "25.05";
-        networking.useHostResolvConf = lib.mkForce false;
-        services.resolved.enable = true;
-        networking.firewall.trustedInterfaces = [ "eth0" ];
-        users.users.atticd = atticdUser;
-        users.groups.atticd.gid = user.gid;
-        services.atticd = {
-          enable = true;
-          environmentFile = "/etc/atticd.env";
-          settings = {
-            listen = "[::]:8080";
-            allowed-hosts = [ "seminar.border-saurolophus.ts.net" ];
-            # 他のホストを指定してもプログラムが自動で設定し直してしまうことがあるため、
-            # tailnet内部からでも外部からでもアクセス可能なエンドポイントを指定。
-            api-endpoint = "https://seminar.border-saurolophus.ts.net/nix/cache/";
-            database.url = "postgresql:///atticd?host=/run/postgresql";
-            storage = {
-              type = "local";
-              path = "/mnt/noa/atticd";
-            };
-            garbage-collection = {
-              interval = "1 day";
-              default-retention-period = "6 months";
+        networking = {
+          useHostResolvConf = lib.mkForce false;
+          firewall.trustedInterfaces = [ "eth0" ];
+        };
+        users = {
+          users.atticd = atticdUser;
+          groups.atticd.gid = user.gid;
+        };
+        services = {
+          resolved.enable = true;
+          atticd = {
+            enable = true;
+            environmentFile = "/etc/atticd.env";
+            settings = {
+              listen = "[::]:8080";
+              allowed-hosts = [ "seminar.border-saurolophus.ts.net" ];
+              # 他のホストを指定してもプログラムが自動で設定し直してしまうことがあるため、
+              # tailnet内部からでも外部からでもアクセス可能なエンドポイントを指定。
+              api-endpoint = "https://seminar.border-saurolophus.ts.net/nix/cache/";
+              database.url = "postgresql:///atticd?host=/run/postgresql";
+              storage = {
+                type = "local";
+                path = "/mnt/noa/atticd";
+              };
+              garbage-collection = {
+                interval = "1 day";
+                default-retention-period = "6 months";
+              };
             };
           };
         };
       };
   };
 
-  users.users.atticd = atticdUser;
-  users.groups.atticd.gid = user.gid;
+  users = {
+    users.atticd = atticdUser;
+    groups.atticd.gid = user.gid;
+  };
 
-  systemd.tmpfiles.rules = [
-    "d /mnt/noa/atticd 0755 atticd atticd -"
-  ];
-
-  # Wait for PostgreSQL to be ready before starting container.
-  systemd.services."container@atticd" = {
-    requires = [ "postgresql.service" ];
-    after = [ "postgresql.service" ];
+  systemd = {
+    tmpfiles.rules = [
+      "d /mnt/noa/atticd 0755 atticd atticd -"
+    ];
+    # Wait for PostgreSQL to be ready before starting container.
+    services."container@atticd" = {
+      requires = [ "postgresql.service" ];
+      after = [ "postgresql.service" ];
+    };
   };
 
   # コンテナ外部から使える管理CLIコマンド。

--- a/nixos/host/seminar/cloudflare.nix
+++ b/nixos/host/seminar/cloudflare.nix
@@ -45,18 +45,20 @@ in
     };
   };
   # Cloudflare認証情報を管理。
-  sops.secrets."cloudflare-cert" = {
-    sopsFile = ../../../secrets/seminar/cloudflare.yaml;
-    key = "cert_pem";
-    owner = "root";
-    group = "root";
-    mode = "0400";
-  };
-  sops.secrets."cloudflare-tunnel-credentials" = {
-    sopsFile = ../../../secrets/seminar/cloudflare.yaml;
-    key = "tunnel_credentials";
-    owner = "root";
-    group = "root";
-    mode = "0400";
+  sops.secrets = {
+    "cloudflare-cert" = {
+      sopsFile = ../../../secrets/seminar/cloudflare.yaml;
+      key = "cert_pem";
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+    "cloudflare-tunnel-credentials" = {
+      sopsFile = ../../../secrets/seminar/cloudflare.yaml;
+      key = "tunnel_credentials";
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
   };
 }

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -187,27 +187,31 @@
       size = 4 * 1024;
     }
   ];
-  boot.kernelModules = [ "bcache" ];
-  boot.initrd.systemd.enable = true;
-  boot.initrd.availableKernelModules = [ "bcache" ];
-  boot.initrd.luks.devices = {
-    "noa0" = {
-      device = "/dev/disk/by-partlabel/disk-noa0-luks";
-      crypttabExtraOpts = [
-        "tpm2-device=auto"
-      ];
-    };
-    "noa1" = {
-      device = "/dev/disk/by-partlabel/disk-noa1-luks";
-      crypttabExtraOpts = [
-        "tpm2-device=auto"
-      ];
-    };
-    "noa2" = {
-      device = "/dev/disk/by-partlabel/disk-noa2-luks";
-      crypttabExtraOpts = [
-        "tpm2-device=auto"
-      ];
+  boot = {
+    kernelModules = [ "bcache" ];
+    initrd = {
+      systemd.enable = true;
+      availableKernelModules = [ "bcache" ];
+      luks.devices = {
+        "noa0" = {
+          device = "/dev/disk/by-partlabel/disk-noa0-luks";
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+          ];
+        };
+        "noa1" = {
+          device = "/dev/disk/by-partlabel/disk-noa1-luks";
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+          ];
+        };
+        "noa2" = {
+          device = "/dev/disk/by-partlabel/disk-noa2-luks";
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+          ];
+        };
+      };
     };
   };
   systemd.tmpfiles.rules = [

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -41,37 +41,43 @@ in
       { config, lib, ... }:
       {
         system.stateVersion = "25.05";
-        networking.useHostResolvConf = lib.mkForce false;
-        services.resolved.enable = true;
-        networking.firewall.trustedInterfaces = [ "eth0" ];
-        users.users.forgejo = forgejoUser;
-        users.groups.forgejo.gid = user.gid;
-        services.forgejo = {
-          enable = true;
-          database = {
-            type = "postgres";
-            # PostgreSQL runs on host, accessed via bindMounted socket.
-            createDatabase = false;
-            socket = "/run/postgresql";
-          };
-          settings = {
-            server = {
-              HTTP_PORT = 8080;
-              SSH_PORT = 2222;
-              DOMAIN = "forgejo.ncaq.net";
-              ROOT_URL = "https://forgejo.ncaq.net/";
-              SSH_DOMAIN = "ssh.forgejo.ncaq.net";
-              START_SSH_SERVER = true;
+        networking = {
+          useHostResolvConf = lib.mkForce false;
+          firewall.trustedInterfaces = [ "eth0" ];
+        };
+        users = {
+          users.forgejo = forgejoUser;
+          groups.forgejo.gid = user.gid;
+        };
+        services = {
+          resolved.enable = true;
+          forgejo = {
+            enable = true;
+            database = {
+              type = "postgres";
+              # PostgreSQL runs on host, accessed via bindMounted socket.
+              createDatabase = false;
+              socket = "/run/postgresql";
             };
-            session = {
-              COOKIE_SECURE = true;
-            };
-            service = {
-              DISABLE_REGISTRATION = true;
-              REQUIRE_SIGNIN_VIEW = true;
-            };
-            repository = {
-              DEFAULT_BRANCH = "master";
+            settings = {
+              server = {
+                HTTP_PORT = 8080;
+                SSH_PORT = 2222;
+                DOMAIN = "forgejo.ncaq.net";
+                ROOT_URL = "https://forgejo.ncaq.net/";
+                SSH_DOMAIN = "ssh.forgejo.ncaq.net";
+                START_SSH_SERVER = true;
+              };
+              session = {
+                COOKIE_SECURE = true;
+              };
+              service = {
+                DISABLE_REGISTRATION = true;
+                REQUIRE_SIGNIN_VIEW = true;
+              };
+              repository = {
+                DEFAULT_BRANCH = "master";
+              };
             };
           };
         };
@@ -80,19 +86,22 @@ in
       };
   };
 
-  users.users.forgejo = forgejoUser;
-  users.groups.forgejo.gid = user.gid;
+  users = {
+    users.forgejo = forgejoUser;
+    groups.forgejo.gid = user.gid;
+  };
 
-  systemd.tmpfiles.rules = [
-    "d /var/lib/forgejo 0750 forgejo forgejo -"
-  ];
+  systemd = {
+    tmpfiles.rules = [
+      "d /var/lib/forgejo 0750 forgejo forgejo -"
+    ];
+    # Wait for PostgreSQL to be ready before starting container.
+    services."container@forgejo" = {
+      requires = [ "postgresql.service" ];
+      after = [ "postgresql.service" ];
+    };
+  };
 
   # コンテナ外部から使える管理CLIコマンド。
   environment.systemPackages = [ forgejoWrapper ];
-
-  # Wait for PostgreSQL to be ready before starting container.
-  systemd.services."container@forgejo" = {
-    requires = [ "postgresql.service" ];
-    after = [ "postgresql.service" ];
-  };
 }

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -94,20 +94,21 @@ in
     groups.garage.gid = user.gid;
   };
 
-  systemd.tmpfiles.rules = [
-    "d /var/lib/garage      0750 garage garage -"
-    "d /var/lib/garage/meta 0750 garage garage -"
-  ];
-
-  # /mnt/noa is owned by ncaq, so systemd-tmpfiles refuses to create
-  # subdirectories owned by garage due to "unsafe path transition" detection.
-  # Use ExecStartPre instead.
-  systemd.services."container@garage".serviceConfig.ExecStartPre = [
-    "+${pkgs.writeShellScript "garage-create-data-dir" ''
-      install -d -m 0750 -o garage -g garage /mnt/noa/garage
-      install -d -m 0750 -o garage -g garage /mnt/noa/garage/data
-    ''}"
-  ];
+  systemd = {
+    tmpfiles.rules = [
+      "d /var/lib/garage      0750 garage garage -"
+      "d /var/lib/garage/meta 0750 garage garage -"
+    ];
+    # /mnt/noa is owned by ncaq, so systemd-tmpfiles refuses to create
+    # subdirectories owned by garage due to "unsafe path transition" detection.
+    # Use ExecStartPre instead.
+    services."container@garage".serviceConfig.ExecStartPre = [
+      "+${pkgs.writeShellScript "garage-create-data-dir" ''
+        install -d -m 0750 -o garage -g garage /mnt/noa/garage
+        install -d -m 0750 -o garage -g garage /mnt/noa/garage/data
+      ''}"
+    ];
+  };
 
   environment.systemPackages = [ garageWrapper ];
 

--- a/nixos/host/seminar/machine-mapping.nix
+++ b/nixos/host/seminar/machine-mapping.nix
@@ -26,80 +26,82 @@ let
   };
 in
 {
-  options.machineAddresses = lib.mkOption {
-    type = lib.types.attrsOf addressType;
-    default = {
-      forgejo = {
-        host = "192.168.100.10";
-        guest = "192.168.100.11";
+  options = {
+    machineAddresses = lib.mkOption {
+      type = lib.types.attrsOf addressType;
+      default = {
+        forgejo = {
+          host = "192.168.100.10";
+          guest = "192.168.100.11";
+        };
+        atticd = {
+          host = "192.168.100.20";
+          guest = "192.168.100.21";
+        };
+        mcp-nixos = {
+          host = "192.168.100.30";
+          guest = "192.168.100.31";
+        };
+        github-runner-x64 = {
+          host = "192.168.100.40";
+          guest = "192.168.100.41";
+        };
+        github-runner-arm64 = {
+          host = "192.168.100.50";
+          guest = "192.168.100.51";
+        };
+        garage = {
+          host = "192.168.100.60";
+          guest = "192.168.100.61";
+        };
       };
-      atticd = {
-        host = "192.168.100.20";
-        guest = "192.168.100.21";
-      };
-      mcp-nixos = {
-        host = "192.168.100.30";
-        guest = "192.168.100.31";
-      };
-      github-runner-x64 = {
-        host = "192.168.100.40";
-        guest = "192.168.100.41";
-      };
-      github-runner-arm64 = {
-        host = "192.168.100.50";
-        guest = "192.168.100.51";
-      };
-      garage = {
-        host = "192.168.100.60";
-        guest = "192.168.100.61";
-      };
+      description = "Network addresses for containers and microVMs";
     };
-    description = "Network addresses for containers and microVMs";
-  };
 
-  options.containerUsers = lib.mkOption {
-    type = lib.types.attrsOf userType;
-    default = {
-      forgejo = {
-        uid = 991;
-        gid = 986;
+    containerUsers = lib.mkOption {
+      type = lib.types.attrsOf userType;
+      default = {
+        forgejo = {
+          uid = 991;
+          gid = 986;
+        };
+        atticd = {
+          uid = 993;
+          gid = 988;
+        };
+        github-runner = {
+          uid = 980;
+          gid = 980;
+        };
+        garage = {
+          uid = 979;
+          gid = 979;
+        };
       };
-      atticd = {
-        uid = 993;
-        gid = 988;
-      };
-      github-runner = {
-        uid = 980;
-        gid = 980;
-      };
-      garage = {
-        uid = 979;
-        gid = 979;
-      };
+      description = "Container user/group IDs (must match between host and container)";
     };
-    description = "Container user/group IDs (must match between host and container)";
-  };
 
-  /**
-    microVMのvsock CID割り当て一覧です。
-    vsock CIDは仮想マシンを識別するための32bit整数値で、
-    以下の値が予約されています:
+    /**
+      microVMのvsock CID割り当て一覧です。
+      vsock CIDは仮想マシンを識別するための32bit整数値で、
+      以下の値が予約されています:
 
-    - 0: ハイパーバイザー
-    - 1: ループバック
-    - 2: ホスト
-    - 0xFFFFFFFF: VMADDR_CID_ANY
+      - 0: ハイパーバイザー
+      - 1: ループバック
+      - 2: ホスト
+      - 0xFFFFFFFF: VMADDR_CID_ANY
 
-    cloud-hypervisorはvsock経由でsystemd-notifyが使えるため、
-    ホストのsystemdがVM内のサービス起動完了を正確に検知できます。
-  */
-  options.microvmCid = lib.mkOption {
-    type = lib.types.attrsOf (lib.types.ints.between 3 4294967294);
-    default = {
-      mcp-nixos = 3;
-      github-runner-arm64 = 4;
+      cloud-hypervisorはvsock経由でsystemd-notifyが使えるため、
+      ホストのsystemdがVM内のサービス起動完了を正確に検知できます。
+    */
+    microvmCid = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.ints.between 3 4294967294);
+      default = {
+        mcp-nixos = 3;
+        github-runner-arm64 = 4;
+      };
+      description = "vsock CID assignments for microVMs (must be >= 3, unique per VM)";
     };
-    description = "vsock CID assignments for microVMs (must be >= 3, unique per VM)";
   };
 
   config = {

--- a/nixos/host/seminar/mackerel.nix
+++ b/nixos/host/seminar/mackerel.nix
@@ -260,19 +260,21 @@ in
       };
     };
   };
-  # Mackerel APIキー(純粋なキー文字列)をsopsで管理
-  sops.secrets."mackerel-api-key" = {
-    sopsFile = ../../../secrets/seminar/mackerel.yaml;
-    key = "api_key";
-    owner = "root";
-    group = "root";
-    mode = "0400";
-  };
-  # sops.templatesでTOML形式の設定ファイルを生成
-  sops.templates."mackerel-api-key.conf" = {
-    content = ''
-      apikey = "${config.sops.placeholder."mackerel-api-key"}"
-    '';
-    mode = "0400";
+  sops = {
+    # Mackerel APIキー(純粋なキー文字列)をsopsで管理
+    secrets."mackerel-api-key" = {
+      sopsFile = ../../../secrets/seminar/mackerel.yaml;
+      key = "api_key";
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+    # sops.templatesでTOML形式の設定ファイルを生成
+    templates."mackerel-api-key.conf" = {
+      content = ''
+        apikey = "${config.sops.placeholder."mackerel-api-key"}"
+      '';
+      mode = "0400";
+    };
   };
 }

--- a/nixos/native-linux/audio.nix
+++ b/nixos/native-linux/audio.nix
@@ -4,8 +4,10 @@
     pulseaudio.enable = false;
     pipewire = {
       enable = true;
-      alsa.enable = true;
-      alsa.support32Bit = true;
+      alsa = {
+        enable = true;
+        support32Bit = true;
+      };
       pulse.enable = true;
       wireplumber = {
         enable = true;

--- a/nixos/wsl/mount-windows-drives.nix
+++ b/nixos/wsl/mount-windows-drives.nix
@@ -10,30 +10,32 @@ let
   gid = toString config.users.groups.${userConfig.group}.gid;
 in
 {
-  # WindowsでマウントされたネットワークドライブをWSL側で自動マウントする
-  systemd.services.mount-windows-network-drives = {
-    description = "Mount Windows network drives in WSL";
-    after = [
-      "local-fs.target"
-      "network.target"
-    ];
-    wantedBy = [ "multi-user.target" ];
+  systemd = {
+    # WindowsでマウントされたネットワークドライブをWSL側で自動マウントする
+    services.mount-windows-network-drives = {
+      description = "Mount Windows network drives in WSL";
+      after = [
+        "local-fs.target"
+        "network.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
 
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      # Sドライブをマウント (Windows側で\\SEMINAR\chihiroが割り当てられている)
-      # 以下のようにWindows側で共有ディレクトリをSドライブに割り当てておく必要があります
-      # ```
-      # net use S: \\SEMINAR\chihiro /persistent:yes
-      # ```
-      ExecStart = "${pkgs.util-linux}/bin/mount -t drvfs 'S:' /mnt/s -o metadata,uid=${uid},gid=${gid},noexec,nosuid";
-      ExecStop = "${pkgs.util-linux}/bin/umount /mnt/s";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        # Sドライブをマウント (Windows側で\\SEMINAR\chihiroが割り当てられている)
+        # 以下のようにWindows側で共有ディレクトリをSドライブに割り当てておく必要があります
+        # ```
+        # net use S: \\SEMINAR\chihiro /persistent:yes
+        # ```
+        ExecStart = "${pkgs.util-linux}/bin/mount -t drvfs 'S:' /mnt/s -o metadata,uid=${uid},gid=${gid},noexec,nosuid";
+        ExecStop = "${pkgs.util-linux}/bin/umount /mnt/s";
+      };
     };
-  };
 
-  # マウントポイントのディレクトリを事前に作成
-  systemd.tmpfiles.rules = [
-    "d /mnt/s 0755 root root -"
-  ];
+    # マウントポイントのディレクトリを事前に作成
+    tmpfiles.rules = [
+      "d /mnt/s 0755 root root -"
+    ];
+  };
 }


### PR DESCRIPTION
各モジュールで`home.packages`, `home.activation`, `sops.secrets`, `systemd.services`など
ドット記法でバラバラに記述していたトップレベル属性を、それぞれのグループにまとめてネスト構造で記述するよう変更しました。

変更対象:
- `home/core/claude-code.nix`: `home`と`sops.secrets`をグループ化
- `home/core/emacs.nix`, `home/core/zsh.nix`, `home/core/haskell.nix`, `home/core/gpg.nix`: `home`配下をグループ化
- `home/native-linux/grive.nix`, `home/native-linux/xkeysnail.nix`: `home`配下をグループ化
- `nixos/host/seminar/atticd.nix`, `forgejo.nix`: `networking`, `users`, `services`, `systemd`をグループ化
- `nixos/host/seminar/cloudflare.nix`, `mackerel.nix`: `sops.secrets`と`sops.templates`をグループ化
- `nixos/host/seminar/disk.nix`: `boot.initrd`配下をグループ化
- `nixos/host/seminar/garage.nix`: `systemd`配下をグループ化
- `nixos/host/seminar/machine-mapping.nix`: `options`配下をグループ化
- `nixos/native-linux/audio.nix`: `services.pipewire.alsa`をグループ化
- `nixos/wsl/mount-windows-drives.nix`: `systemd`配下をグループ化

これにより同じ親属性に属する設定が視覚的にまとまり、可読性が向上します。
