### PR TITLE
feat(claude-code): デフォルトモデルをopusplanからopusに変更

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -111,8 +111,8 @@ in
     settings = {
       # 応答に使う自然言語です。
       language = "japanese";
-      # 設定時に最適な値を切り替えていきます。opusplanはプランはopusで行い、実装はsonnetで行う設定です。
-      model = "opusplan";
+      # 設定時に最適な値を切り替えていきます。
+      model = "opus";
       # メッセージにCo-Authored-Byフッターを付与しません。
       # 私はAIエージェントはテキストエディタの延長線上だと考えているため、
       # ツール名が書かれるのは不自然だと思っています。


### PR DESCRIPTION
opusを節約するために設定していましたが、
思った以上にsonnetの知能が低く、
大量のClaude Code Reviewの負担を他のあまりClaude Code使用していない人に任せることで、
そこまでlimitに達することもないと判断したため、
デフォルトモデルをopusplanからopusに変更しました。
大量の単純な変更を行う時のみsonnetで実行します。
