### PR TITLE
feat(cifs): seminarのchihiro共有を手動マウントするCIFS設定を追加

### DIFF
--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -33,7 +33,7 @@ lib.mkIf (hostName != "seminar") {
       "nosuid"
       # パフォーマンス
       "noatime"
-      # タイムアウトを短く設定しハング防止
+      # systemd経由でマウントしたときのタイムアウトを短く設定してハングを防ぐ
       "x-systemd.device-timeout=5s"
       "x-systemd.mount-timeout=5s"
     ];


### PR DESCRIPTION
`fileSystems`で宣言的に定義し、`sudo mount /mnt/chihiro`で手動マウントできる。
`noauto`と`nofail`により自動マウントは行わず、失敗時もブートをブロックしない。
過去のハング問題を踏まえ`x-systemd.device-timeout`と`x-systemd.mount-timeout`を5秒に設定。
seminarホスト自身は`lib.mkIf (hostName != "seminar")`で除外。
認証情報はsops-nixで管理し、既存の`secrets/samba.yaml`のパスワードを共用する。

close #715 