### PR TITLE
refactor(seminar): コンテナのファイアウォール設定を明示的なポート指定に変更

### DIFF
--- a/nixos/host/seminar/atticd.nix
+++ b/nixos/host/seminar/atticd.nix
@@ -44,7 +44,7 @@ in
         system.stateVersion = "25.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
-          firewall.trustedInterfaces = [ "eth0" ];
+          firewall.allowedTCPPorts = [ 8080 ];
         };
         users = {
           users.atticd = atticdUser;

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -43,7 +43,10 @@ in
         system.stateVersion = "25.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
-          firewall.trustedInterfaces = [ "eth0" ];
+          firewall.allowedTCPPorts = [
+            2222 # ssh
+            8080 # http
+          ];
         };
         users = {
           users.forgejo = forgejoUser;

--- a/nixos/host/seminar/github-runner/github-runner-arm64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-arm64.nix
@@ -100,7 +100,7 @@ in
         nix.settings = config.nix.settings;
         networking = {
           hostName = "github-runner-arm64";
-          firewall.trustedInterfaces = [ "eth0" ];
+          firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中に任意のポートでリッスンするため全許可
         };
         systemd = {
           network = {

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -40,8 +40,7 @@ in
         nix.settings = config.nix.settings;
         networking = {
           useHostResolvConf = lib.mkForce false;
-          # ネットワーク通信の受け入れを許可します。
-          firewall.trustedInterfaces = [ "eth0" ];
+          firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中に任意のポートでリッスンするため全許可
         };
         services = {
           resolved.enable = true;


### PR DESCRIPTION
`firewall.trustedInterfaces = [ "eth0" ]`はeth0上の全ポートを信頼済みとして扱うため過剰な許可になっていました。
forgejoとatticdはリッスンするポートが固定されているため、`firewall.allowedTCPPorts`で明示的に指定するように変更しました。

GitHub Runnerコンテナ・VMはCIジョブ中に任意のポートでサービスが起動する可能性があるため、引き続き`trustedInterfaces`を使用します。
その理由をインラインコメントとして記載しました。
