### PR TITLE
ci(setup-nix): accept-flake-configを廃止してキャッシュサーバを明示指定

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -20,8 +20,20 @@ runs:
   steps:
     - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
       with:
-        extra_nix_config: |
-          accept-flake-config = true
+        extra_nix_config: >
+          extra-substituters =
+          https://cache.nixos.org/
+          https://nix-community.cachix.org/
+          https://nix-on-droid.cachix.org/
+          https://microvm.cachix.org/
+          https://ncaq-dotfiles.cachix.org/
+
+          extra-trusted-public-keys =
+          cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+          nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU=
+          microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys=
+          ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws=
     - name: Setup Cachix cache
       if: inputs.cachix-auth-token != '' && inputs.cachix-name != ''
       uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16


### PR DESCRIPTION
`accept-flake-config = true`はflake.nixの`nixConfig`セクションの設定を自動的に信頼するものですが、
セキュリティ上の観点から許可するキャッシュを明示的に列挙する方が望ましい。
`flake.nix`の`nixConfig`に定義されている、
`extra-substituters`と`extra-trusted-public-keys`の全エントリをGitHub Actionsの設定に直接記載します。
行長制限を考慮してYAMLのフォールドスカラー(`>`)を使用し、
1エントリ1行で改行しながら最終的に空白区切りの1行に展開されるよう工夫しました。
