### PR TITLE
feat(removable-crypt): リムーバブルディスクのbtrfsスナップショットの自動管理を追加

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -20,8 +20,20 @@ runs:
   steps:
     - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
       with:
-        extra_nix_config: |
-          accept-flake-config = true
+        extra_nix_config: >
+          extra-substituters =
+          https://cache.nixos.org/
+          https://nix-community.cachix.org/
+          https://nix-on-droid.cachix.org/
+          https://microvm.cachix.org/
+          https://ncaq-dotfiles.cachix.org/
+
+          extra-trusted-public-keys =
+          cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+          nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU=
+          microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys=
+          ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws=
     - name: Setup Cachix cache
       if: inputs.cachix-auth-token != '' && inputs.cachix-name != ''
       uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16


### PR DESCRIPTION
- マウント時にsnapperでスナップショット作成とtimelineクリーンアップを実施
- アンマウント時にもスナップショット作成を追加し、失敗時は警告を表示
- 普段はマウントしていないのでTIMELINE_CREATEを無効化し、TIMELINE_CLEANUPのみ有効化
- snapper.nixにgideonとtwo-thousandのサブボリューム設定を追加

close #449