### PR TITLE
feat(github-runner): overlayのイメージサイズを50GBから100GBに拡大

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-arm64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-arm64.nix
@@ -88,7 +88,7 @@ in
             {
               image = "nix-store-overlay.img";
               mountPoint = "/nix/.rw-store";
-              size = 50 * 1024; # 50GB
+              size = 100 * 1024; # 100GB
               label = "nix-rw";
             }
           ];


### PR DESCRIPTION
早くも40GB以上食いつくくしてきたため、
拡大してある程余裕を持たせることにしました。
ディスク容量には余裕がありますし、
なんなら別に買い替えても良いため問題ありません。