### PR TITLE
feat(obs-studio): obs-studioのCUDAサポートとプラグインを有効化

### DIFF
--- a/home/native-linux/obs-studio.nix
+++ b/home/native-linux/obs-studio.nix
@@ -1,5 +1,24 @@
-_: {
+{
+  pkgs,
+  osConfig ? null,
+  ...
+}:
+let
+  hasNvidia = osConfig != null && (osConfig.hardware.nvidia.enabled or false);
+in
+{
   programs.obs-studio = {
     enable = true;
+    package = pkgs.obs-studio.override {
+      cudaSupport = hasNvidia;
+    };
+    plugins = with pkgs.obs-studio-plugins; [
+      obs-backgroundremoval
+      obs-gstreamer
+      obs-pipewire-audio-capture
+      obs-vaapi
+      obs-vkcapture
+      wlrobs
+    ];
   };
 }


### PR DESCRIPTION
デフォルトの状態でnvencを使えると思っていましたが、
それは勘違いで明示的に有効にしないと使えませんでした。
`osConfig.hardware.nvidia.enabled`を参照して`hasNvidia`フラグを導出し、
`cudaSupport`をNVIDIA GPUが存在するホストでのみ`true`にするよう変更しました。
`nvtop.nix`と同じパターンですが、
まだ二回目の出現シンプルなパターンなのでロジックの共通化はまだ行いません。
それとついでにNixOS wikiがデフォルト状態で推薦するプラグインを追加しています。
