### PR TITLE
refactor(flake): nixpkgsのfollows設定を削除しurlを直接指定

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,7 +352,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-2511": {
+    "nixpkgs": {
       "locked": {
         "lastModified": 1772822230,
         "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
@@ -517,10 +517,7 @@
         "nix-on-droid": "nix-on-droid",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": [
-          "nixpkgs-2511"
-        ],
-        "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "dotfiles, NixOS and home-manager.";
 
   inputs = {
-    nixpkgs.follows = "nixpkgs-2511";
-    nixpkgs-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
昔のチャンネルを古いパッケージのため併用して持っていたとき、
LLMが昔のチャンネルを今使っていると勘違いするからこの形式にしましたが、
そういうのはコメントで対処するべきで、
間接参照のわかりにくさのほうが問題だと思ったので、
直接URLを指定する形式に変更しました。
