### PR TITLE
feat(claude-code): git checkoutコマンドの自動許可を追加

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -234,6 +234,7 @@ in
           "Bash(git -C * show *)"
           "Bash(git -C * status *)"
           "Bash(git add:*)"
+          "Bash(git checkout:*)"
           "Bash(git clone:*)"
           "Bash(git diff:*)"
           "Bash(git fetch:*)"


### PR DESCRIPTION
自分自身はもうgit switchやgit restoreを使うので、
git checkoutは使わないのですが、
Claude Codeがgit checkoutを使うことがかなりあるので、
自動許可することにしました。
機能的にはほぼ等価なので問題ないと思います。
