### PR TITLE
ci: aarch64のhome-manager検証を削除

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,15 +50,8 @@ jobs:
     needs: is-trusted
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 360
-    strategy:
-      matrix:
-        include:
-          - system: x86_64-linux
-            runner: [self-hosted, Linux, X64]
-          - system: aarch64-linux
-            runner: [self-hosted, Linux, ARM64]
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -68,7 +61,7 @@ jobs:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
           attic-token: "${{ secrets.ATTIC_TOKEN }}"
-      - run: nix build .#homeConfigurations.${{ matrix.system }}.activationPackage
+      - run: nix build .#homeConfigurations.x86_64-linux.activationPackage
 
   build-nix-on-droid:
     needs: is-trusted


### PR DESCRIPTION
aarch64のデスクトップ向けhome-managerの検証はついでに行っていましたが、
QEMU経由のチェックはあまりにも遅く、
サーバのリソースを圧迫するまで至ってしまっています。
Nix-on-Droidでは利用するから`aarch64-linux`の検証自体は必要ですが、
別に普通のLinuxデスクトップ向けの検証を行う必要性は極めて薄いので、
削除しておきます。
仮に私がARMのシングルボードコンピュータとか買ってそこにNixOSをぶちこむとかするのであれば、
そのときに改めて検証環境を整えることにします。
またQEMUエミュレーションを想定しなくて良いため、
タイムアウトを大幅に短縮します。
