### PR TITLE
ci: atticのキャッシュ設定をCIから除去する

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: Cachix cache name
     required: false
     default: ""
-  attic-token:
-    description: Attic cache authentication token
-    required: false
-    default: ""
   niks3-push:
     description: Enable pushing to niks3-public cache (disable for untrusted sources)
     required: false
@@ -55,13 +51,6 @@ runs:
         # store scanはクライアント側で動作するため両環境で問題なく使えます。
         # 一貫性のために多少のパフォーマンスより設定を統一して両方の環境で`useDaemon`を`false`にしています。
         useDaemon: false
-    - name: Setup Attic cache
-      if: inputs.attic-token != ''
-      uses: ryanccn/attic-action@1887fd507f03327c96c64cca30118c96eb17fdad # v0.4.1
-      with:
-        endpoint: https://seminar.border-saurolophus.ts.net/nix/cache/
-        cache: private
-        token: "${{ inputs.attic-token }}"
     - name: Setup niks3-public push
       if: inputs.niks3-push == 'true'
       uses: ./.github/actions/niks3-push

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
-          attic-token: "${{ secrets.ATTIC_TOKEN }}"
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
-          attic-token: "${{ secrets.ATTIC_TOKEN }}"
           niks3-push: "${{ needs.is-trusted.result == 'success' }}"
       - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
 
@@ -67,7 +66,6 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
-          attic-token: "${{ secrets.ATTIC_TOKEN }}"
           niks3-push: "true"
       - run: nix build .#homeConfigurations.x86_64-linux.activationPackage
 
@@ -88,7 +86,6 @@ jobs:
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           cachix-name: ncaq-dotfiles
-          attic-token: "${{ secrets.ATTIC_TOKEN }}"
           niks3-push: "true"
       # Nix-on-Droidのビルドはimpureモードで行う必要があります
       - run: nix build .#nixOnDroidConfigurations.default.activationPackage --impure

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -7,7 +7,6 @@ let
     { pkgs, ... }:
     with pkgs;
     [
-      attic-client
       cachix
     ];
   # GitHub Actionsランナーの並列数。


### PR DESCRIPTION
close #748

atticサーバーをCIのバイナリキャッシュとして利用していたが、
niks3-publicへの移行が完了したため不要になった設定を除去する。

- `setup-nix`アクションから`attic-token`入力パラメータとAttic cacheセットアップステップを削除
- `push.yml`の全ジョブ(nix-fast-build, build-home-manager, build-nix-on-droid)から`attic-token`パラメータを削除
- `claude-code-review.yml`から`attic-token`パラメータを削除
- セルフホステッドランナーのパッケージリストから`attic-client`を削除
