### PR TITLE
fix(mackerel): github-runner-arm64の`max_check_attempts`を3に変更

### DIFF
--- a/nixos/host/seminar/mackerel.nix
+++ b/nixos/host/seminar/mackerel.nix
@@ -276,6 +276,10 @@ in
             }
           );
           inherit check_interval;
+          # エミュレートされた仮想マシンで起動が遅いのと、
+          # GitHub側がランナーの起動を待ってくれるため、
+          # ある程度の沈黙を許容します。
+          max_check_attempts = 3;
         };
       };
     };


### PR DESCRIPTION
- 仮想マシンの起動遅延に対応するため
- 一時的な沈黙を許容し、不要なアラートを抑制
