### PR TITLE
feat(seminar): Tailscale Funnelを取り除く

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,10 +163,6 @@ Tailnetを通じるとインターネットからもアクセス可能です。
 
 Cloudflare Tunnelでインターネットからアクセス可能なサービスを公開しています。
 
-Tailscale Funnelでもインターネットからアクセス可能なサービスを公開しています。
-Cloudflare Tunnelを使わずTailscale Funnelを使う場合がある理由は、
-Cloudflare TunnelはHTTPリクエストに厳しいサイズ制限があるためです。
-
 各種サービスは隔離が容易かつ隔離する意味のあるものは、
 [NixOS Containers](https://wiki.nixos.org/wiki/NixOS_Containers)か、
 [microvm.nix](https://github.com/microvm-nix/microvm.nix)で隔離しています。

--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -9,13 +9,6 @@ in
   services.caddy = {
     enable = true;
     email = "ncaq@ncaq.net";
-    # Tailscale Serve/Funnelからのリクエストを受けるリバースプロキシ。
-    # tailscaledがTLS終端を行い、ここにHTTPで転送します。
-    # tailnet内からのHTTPSアクセスもtailscaledが処理するため、
-    # Caddyが443をlistenする必要はありません。
-    virtualHosts.":8080".extraConfig = ''
-      bind 127.0.0.1
-    '';
     # niks3コンテナからGarageへのTLS termination proxy。
     # Cloudflare Tunnel経由だとContent-Encoding: zstdが透過的に解凍され、
     # niks3のreadProxyがS3上のzstd圧縮narinfoを正しく読めなくなる。
@@ -34,8 +27,6 @@ in
     };
     # Tailscale Serve(tailnet専用)からのリクエストを受けるリバースプロキシ。
     # Tailscale ServeがTLS終端し、ここにHTTPで転送する。
-    # Funnelの:8080とは別ポートにすることで、
-    # tailnet専用サービスがパブリックインターネットに露出しない。
     # Caddy v2では`localhost`はlocal CAによる自動HTTPSの対象になるため、
     # `localhost:8081`だとHTTPSが有効化され、Tailscale ServeからのHTTPプロキシが失敗する。
     # `:8081`(ホスト名なし)にしてbind 127.0.0.1でHTTPのみに限定する。

--- a/nixos/host/seminar/tailscale.nix
+++ b/nixos/host/seminar/tailscale.nix
@@ -10,54 +10,27 @@ in
     useRoutingFeatures = "both";
   };
 
-  # Tailscale Funnel/Serveの設定。
-  # [ncaq/infra.ncaq.net: Infrastructure as Code for ncaq.net](https://github.com/ncaq/infra.ncaq.net/)
-  # でFunnelを有効化しています。
-  systemd.services = {
-    # Funnelはパブリックインターネットに公開する。
-    # Caddy :8080がパス毎に公開サービスをルーティングする。
-    tailscale-funnel = {
-      description = "Configure Tailscale Funnel";
-      requires = [
-        "caddy.service"
-        "tailscaled.service"
-      ];
-      after = [
-        "caddy.service"
-        "tailscaled.service"
-      ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        ExecStart = "${tailscale}/bin/tailscale funnel --bg http://127.0.0.1:8080";
-        ExecStop = "${tailscale}/bin/tailscale funnel --bg off";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "10s";
-      };
-    };
-    # Serveはtailnet内のみに公開する(Funnelではない)。
-    # Caddy :8081がパス毎にtailnet専用サービスをルーティングする。
-    tailscale-serve = {
-      description = "Configure Tailscale Serve";
-      requires = [
-        "caddy.service"
-        "tailscaled.service"
-      ];
-      after = [
-        "caddy.service"
-        "tailscale-funnel.service"
-        "tailscaled.service"
-      ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        ExecStart = "${tailscale}/bin/tailscale serve --bg --https=8443 http://127.0.0.1:8081";
-        ExecStop = "${tailscale}/bin/tailscale serve --https=8443 off";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "10s";
-      };
+  # Tailscale Serveの設定。
+  # Serveはtailnet内のみに公開する。
+  # Caddy :8081がパス毎にtailnet専用サービスをルーティングする。
+  systemd.services.tailscale-serve = {
+    description = "Configure Tailscale Serve";
+    requires = [
+      "caddy.service"
+      "tailscaled.service"
+    ];
+    after = [
+      "caddy.service"
+      "tailscaled.service"
+    ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${tailscale}/bin/tailscale serve --bg --https=8443 http://127.0.0.1:8081";
+      ExecStop = "${tailscale}/bin/tailscale serve --https=8443 off";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "10s";
     };
   };
 


### PR DESCRIPTION
atticサーバを廃止したことでFunnelで公開するサービスがなくなったため、
`tailscale-funnel`サービスと関連設定を削除しました。

- `tailscale-funnel` systemdサービスを削除
- Caddy `:8080` virtualHost(Funnel用)を削除
- `tailscale-serve`から`tailscale-funnel.service`への依存を除去
- copilot-instructions.md/CLAUDE.mdのTailscale Funnel関連の記述を削除

close #765
