### PR TITLE
feat(locate): updatedbの除外リストにbackup.encryptedを追加

### DIFF
--- a/nixos/core/locate.nix
+++ b/nixos/core/locate.nix
@@ -37,6 +37,7 @@
       "_cache"
       "_site"
       "appcache"
+      "backup.encrypted"
       "cache"
       "cache2"
       "cached"


### PR DESCRIPTION
ファイルシステム上の暗号化ディレクトリは、
長大なランダムなファイル名を持つため、
locateのノイズに強くなります。
特定のファイルディレクトリ狙い撃ちですが、
現状自分の環境ではこれで構わないので、
updatedbの除外リストにbackup.encryptedを追加します。
