### PR TITLE
feat(containers): seminarの全コンテナにprivateUsers = "identity"を追加

### DIFF
--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -18,6 +18,7 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;
     forwardPorts = [

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -40,6 +40,7 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;
     bindMounts = {

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -21,6 +21,7 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;
     bindMounts = {

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -18,6 +18,7 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;
     bindMounts = {

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -18,6 +18,7 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;
     bindMounts = {


### PR DESCRIPTION
コンテナからのエスケープ時にホストのroot権限を取得されにくくするため、
user namespaceによるcapability分離を有効化する。
`identity`モードはUID/GIDのマッピングは1:1のまま維持するため、
PostgreSQLのpeer認証やbindMountのファイル所有権に影響しない。
コンテナ内のプロセスはuser namespace内でしかcapabilityを持てないため、
mount/pid/networkなど他のnamespaceをエスケープしてもホストでroot権限を行使できない。
