### PR TITLE
feat(nix-cache): ncaq-dotfilesからncaqへキャッシュ切替

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -24,18 +24,18 @@ runs:
           extra-substituters =
           https://cache.nixos.org/
           https://niks3-public.ncaq.net/
+          https://ncaq.cachix.org/
           https://nix-community.cachix.org/
           https://nix-on-droid.cachix.org/
           https://microvm.cachix.org/
-          https://ncaq-dotfiles.cachix.org/
 
           extra-trusted-public-keys =
           cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
           niks3-public.ncaq.net-1:e/B9GomqDchMBmx3IW/TMQDF8sjUCQzEofKhpehXl04=
+          ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE=
           nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU=
           microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys=
-          ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws=
     - name: Setup Cachix cache
       if: inputs.cachix-auth-token != '' && inputs.cachix-name != ''
       uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
         if: runner.environment != 'github-hosted'
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          cachix-name: ncaq-dotfiles
+          cachix-name: ncaq
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@5d0cc745cd0cce4c0e9e0b3511de26c3bc285eb5 # v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          cachix-name: ncaq-dotfiles
+          cachix-name: ncaq
           niks3-push: "${{ needs.is-trusted.result == 'success' }}"
       - run: nix run '.#nix-fast-build' -- --option eval-cache false --no-link --skip-cached --no-nom
 
@@ -65,7 +65,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          cachix-name: ncaq-dotfiles
+          cachix-name: ncaq
           niks3-push: "true"
       - run: nix build .#homeConfigurations.x86_64-linux.activationPackage
 
@@ -85,7 +85,7 @@ jobs:
       - uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          cachix-name: ncaq-dotfiles
+          cachix-name: ncaq
           niks3-push: "true"
       # Nix-on-Droidのビルドはimpureモードで行う必要があります
       - run: nix build .#nixOnDroidConfigurations.default.activationPackage --impure

--- a/flake.nix
+++ b/flake.nix
@@ -383,18 +383,18 @@
     extra-substituters = [
       "https://cache.nixos.org/"
       "https://niks3-public.ncaq.net/"
+      "https://ncaq.cachix.org/"
       "https://nix-community.cachix.org/"
       "https://nix-on-droid.cachix.org/"
       "https://microvm.cachix.org/"
-      "https://ncaq-dotfiles.cachix.org/"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "niks3-public.ncaq.net-1:e/B9GomqDchMBmx3IW/TMQDF8sjUCQzEofKhpehXl04="
+      "ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU="
       "microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys="
-      "ncaq-dotfiles.cachix.org-1:oEM1SL5sNteDM16I23/rFZwKl+Anca/PnEWp6LWUrws="
     ];
   };
 }

--- a/nixos/core/nix-settings.nix
+++ b/nixos/core/nix-settings.nix
@@ -8,12 +8,14 @@ _: {
       "https://cache.nixos.org/"
       "https://niks3-public.ncaq.net/"
       "https://seminar.border-saurolophus.ts.net:8443/niks3/private/"
+      "https://ncaq.cachix.org/"
       "https://nix-community.cachix.org/"
     ];
     trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
       "niks3-public.ncaq.net-1:e/B9GomqDchMBmx3IW/TMQDF8sjUCQzEofKhpehXl04="
       "niks3-private.ncaq.net-1:YWkzGum1FwpNpWndvuWOrTFCFtDRAYLWFCeH9h78/u0="
+      "ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
     cores = 0;


### PR DESCRIPTION
キャッシュ効率のために、
Cachixのパブリックキャッシュサーバは統一していこうと思うので、
ncaq-dotfilesからncaqへキャッシュ切替を行います。
