### PR TITLE
feat(claude-code): remote-controlを全セッションで常に有効化

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -175,6 +175,10 @@ in
         type = "command";
         command = lib.getExe ccstatusline;
       };
+      # 全てのセッションでremote-controlを有効にします。
+      remoteControl = {
+        enabled = true;
+      };
       sandbox = {
         # sandboxは通常無効にします。
         # sandboxであることが由来のトラブルが多すぎるためです。


### PR DESCRIPTION
宣言的に管理したいのでコードで有効化。
configで設定する場合直接的には`~/.claude.json`で管理されているので効かないかもしれません。
