### PR TITLE
feat(github-runner): runner数とリソース制限を8スレッドに増加

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -22,8 +22,7 @@ let
   # 複数立ち上げてもサーバのリソース量が破綻する心配はあまりありません。
   # またNixを使っている今のワークロードは殆どはIO待ちなので、
   # コンカレントに処理させたほうが効率的です。
-  # このサーバのCPUの物理コア数と合わせています。
-  runnerNum = 6;
+  runnerNum = 8;
   # runnerが使うTypeScriptコードをビルドしてGitHub Actionsで利用できるようにします。
   # 吐き出されるコードはピュアなJavaScriptなのでアーキテクチャ非依存です。
   dotfiles-github-runner = pkgs.buildNpmPackage {

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -107,9 +107,9 @@ in
       '';
       serviceConfig = {
         # CIジョブがホストのリソースを過剰に消費しないよう制限します。
-        # CPUQuotaはコア数×100%で指定するため、6スレッド制限にします。
-        CPUQuota = "600%";
-        MemoryMax = "16G";
+        # CPUQuotaはコア数×100%で指定するため、8スレッド制限にします。
+        CPUQuota = "800%";
+        MemoryMax = "20G";
       };
     };
   };


### PR DESCRIPTION
armの仮想マシンが無くなったのでマシンリソースに余裕が出来ました。
コンテナは仮想マシンと比べてリソースの調整能力が高いので、
雑に増やしてもあまり問題ないと判断しています。

- runnerNumを6から8に変更し並列処理能力を向上
- CPUQuotaを800%に、MemoryMaxを20Gに拡張しリソース制限を調整
