### PR TITLE
ci: CIからmatrix戦略を廃止し内部並列実行に変更

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,7 +67,7 @@ jobs:
         run: >-
           nix eval --json .#nixosConfigurations --apply builtins.attrNames |
           jq -r '.[] | ".#nixosConfigurations.\(.).config.system.build.toplevel"' |
-          xargs nix build -L
+          xargs nix build -L --keep-going
 
   boot-test-nixos:
     needs: is-trusted
@@ -89,7 +89,7 @@ jobs:
         run: >-
           nix eval --json .#nixosBootTests --apply builtins.attrNames |
           jq -r '.[] | ".#nixosBootTests.\(.)"' |
-          xargs nix build -L
+          xargs nix build -L --keep-going
 
   build-home-manager:
     needs: is-trusted


### PR DESCRIPTION
`list-nixos-hosts`ジョブを削除し、
`build-nixos`と`boot-test-nixos`のmatrix戦略を廃止しました。
代わりに`nix eval --json`で全ホスト名を取得し、
jqでinstallableパスを生成して`xargs nix build`に渡す方式に変更しています。
matrixジョブごとにsetup-nix(Nixインストール、Cachix設定、niks3設定)が重複実行される問題を解消します。
特にniks3を毎回`nix build`する際のGitHubレートリミット問題を回避します。
セルフホステッドランナー上でのみ実行されるため、
matrixで分離する必要性がありませんでした。
nixコマンドが内部的に並列実行するので、
全体のビルド時間は変わらないかむしろ短縮されることが期待されます。
