### PR TITLE
feat: GitHub Actionsの静的解析ツールzizmorを追加

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   inputs,
   ...
 }:
@@ -52,7 +53,9 @@ in
         "Thumbs.db"
       ];
     };
-    gh.enable = true;
     git-hooks.enable = true;
+
+    gh.enable = true;
   };
+  home.packages = with pkgs; [ zizmor ];
 }


### PR DESCRIPTION
GitHub Actionsワークフローのセキュリティ問題やベストプラクティス違反を検出するツールです。
プロジェクトに追加していくものですが、
追加されていないプロジェクトでもサクッと使いたいので、
ghと同じくGitHub関連ツールとして`git.nix`に配置しました。
GitとGitHubは同じものではありませんが、
既にgh(GitHub CLI)が追加されているので今更だと判断しました。
そんなにソースの分量も多くないですし。
GitHub関係設定が大量に増えてきたら分割します。
