### PR TITLE
fix(claude-code): MCP権限のプレフィックスをプラグイン経由の名前に修正

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -460,7 +460,7 @@ in
           "mcp__github__search_pull_requests"
           "mcp__github__search_repositories"
           "mcp__github__search_users"
-          "mcp__nixos"
+          "mcp__plugin_nix-tasuke_nixos"
         ];
         ask = [
           "Bash(docker compose rm:*)"


### PR DESCRIPTION
nix-tasukeプラグインのMCPサーバーは`mcp__plugin_nix-tasuke_nixos__*`という名前空間で登録されるため、
旧来の`mcp__nixos`ではプラグイン経由のツールにマッチしませんでした。
