### PR TITLE
docs: LICENSEファイルを原文に戻し、著作権表示をNOTICEファイルに分離

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 ncaq
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2019 ncaq
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,13 +1,1 @@
 Copyright 2019 ncaq
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.


### PR DESCRIPTION
## Summary

- LICENSEファイルのAppendix内プレースホルダを著作権者情報に書き換えていたのを原文に戻しました
- 著作権表示はNOTICEファイルで提供するようにしました

## 背景

Apache公式の[Applying the Apache license, version 2.0](https://www.apache.org/legal/apply-license.html)はLICENSEファイルにLICENSE-2.0.txtの内容をそのままコピーすることを指示しています。
Appendix内の`[yyyy] [name of copyright owner]`はソースファイルのヘッダー用の雛形であり、LICENSEファイル自体を編集する指示ではありません。

著作権者情報はNOTICEファイルに記載することで、利用者がApache-2.0の帰属表示義務(4条d項)を果たす際の参照先を提供します。