### PR TITLE
ci: nix-daemonにGitHubアクセストークンを設定してrate limitを回避

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -94,6 +94,10 @@ in
 
   # nix-daemonの環境変数としてGitHubのアクセストークンを渡します。
   # 内部で`nix profile add`などを実行した際のGitHubのAPI rate limitを回避するために必要です。
+  # nix-daemonはホスト全体で共有されるため、このトークンは全ユーザのビルドに適用されます。
+  # しかし自分のアカウントの、
+  # Publicリポジトリを読み込めるだけの権限のトークンを設定しているだけなので、
+  # 全体に適用されても無害であると考えています。
   systemd.services.nix-daemon.serviceConfig.EnvironmentFile = [
     config.sops.templates."nix-daemon-github-env".path
   ];

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -110,8 +110,9 @@ in
     };
     secrets = {
       # 最小権限のPATで`access-tokens`を設定します。
-      # `access-tokens`は`fetchSettings`に属しクライアントからdaemonに転送されないため、
-      # [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
+      # `access-tokens`はクライアントからdaemonに転送されない設定のため、
+      # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
+      # 関連: [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
       # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
       "read-token" = {
         sopsFile = ../../../../secrets/seminar/github-runner.yaml;

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -92,11 +92,39 @@ in
   # コンテナ側ではなくホストレベルで設定が必要です。
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
-  sops.secrets."github-runner" = {
-    sopsFile = ../../../../secrets/seminar/github-runner.yaml;
-    key = "pat";
-    owner = "github-runner";
-    group = "github-runner";
-    mode = "0400";
+  # nix-daemonの環境変数としてGitHubのアクセストークンを渡します。
+  # 内部で`nix profile add`などを実行した際のGitHubのAPI rate limitを回避するために必要です。
+  systemd.services.nix-daemon.serviceConfig.EnvironmentFile = [
+    config.sops.templates."nix-daemon-github-env".path
+  ];
+
+  sops = {
+    # systemdの`EnvironmentFile`で読み込むGitHubのアクセストークンを定義します。
+    templates."nix-daemon-github-env" = {
+      content = ''
+        NIX_CONFIG=access-tokens = github.com=${config.sops.placeholder."read-token"}
+      '';
+    };
+    secrets = {
+      # 最小権限のPATで`access-tokens`を設定します。
+      # `access-tokens`は`fetchSettings`に属しクライアントからdaemonに転送されないため、
+      # [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
+      # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
+      "read-token" = {
+        sopsFile = ../../../../secrets/seminar/github-runner.yaml;
+        key = "read-token";
+        owner = "github-runner";
+        group = "github-runner";
+        mode = "0400";
+      };
+      # セルフホストランナーがGitHub Actionsに自身を登録するためのトークン。
+      "runner-registration-token" = {
+        sopsFile = ../../../../secrets/seminar/github-runner.yaml;
+        key = "runner-registration-token";
+        owner = "github-runner";
+        group = "github-runner";
+        mode = "0400";
+      };
+    };
   };
 }

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -104,6 +104,9 @@ in
       content = ''
         NIX_CONFIG=access-tokens = github.com=${config.sops.placeholder."read-token"}
       '';
+      owner = "root";
+      group = "root";
+      mode = "0400";
     };
     secrets = {
       # 最小権限のPATで`access-tokens`を設定します。

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -113,7 +113,6 @@ in
       # `access-tokens`はクライアントからdaemonに転送されない設定のため、
       # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
       # 関連: [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
-      # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
       "read-token" = {
         sopsFile = ../../../../secrets/seminar/github-runner.yaml;
         key = "read-token";

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -113,8 +113,8 @@ in
       "read-token" = {
         sopsFile = ../../../../secrets/seminar/github-runner.yaml;
         key = "read-token";
-        owner = "github-runner";
-        group = "github-runner";
+        owner = "root";
+        group = "root";
         mode = "0400";
       };
       # セルフホストランナーがGitHub Actionsに自身を登録するためのトークン。

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -25,8 +25,8 @@ in
     hostAddress = addr.host;
     localAddress = addr.guest;
     bindMounts = {
-      "/etc/github-runner-token" = {
-        hostPath = config.sops.secrets."github-runner".path;
+      "/etc/runner-registration-token" = {
+        hostPath = config.sops.secrets."runner-registration-token".path;
         isReadOnly = true;
       };
     };
@@ -60,7 +60,7 @@ in
                   extraLabels = [ "NixOS" ];
                   extraPackages =
                     (githubActionsRunnerPackages { inherit pkgs; }).all ++ selfHostRunnerPackages { inherit pkgs; };
-                  tokenFile = "/etc/github-runner-token";
+                  tokenFile = "/etc/runner-registration-token";
                   url = "https://github.com/ncaq/dotfiles";
                   extraEnvironment = {
                     ACTIONS_RUNNER_HOOK_JOB_STARTED = "${dotfiles-github-runner}/job-started-hook.js";

--- a/secrets/seminar/github-runner.yaml
+++ b/secrets/seminar/github-runner.yaml
@@ -1,7 +1,8 @@
-pat: ENC[AES256_GCM,data:uB6UPBIns+qwAKFiG7mSKcfJSCqVAhDj/nYeVvGtJKUJaVlPoQsB0U3tK0sHNs3QGf1Zs4qRB7pQ0Kw1QuSPu5/JpOSaSNE6ik/YJXCTGjQz1C7QfMQyykwXjT7S,iv:SrWVMKo4D5SXr156rLVf4szCpxraBB+09Cvmvzw1c1A=,tag:9iuXdRYBA2rBFwKKa1Bkig==,type:str]
+read-token: ENC[AES256_GCM,data:ZpTiRuvwy1iRKe20qJ8JQNrl1vuQjV21GqDiEVXWM+HVBl5vPhJihwAOj0JCDIwFq/RyVRqLFtyAiqJVJmh+mqbnSR0i2apqWRNxM/PP/NMRek6lVwJPeqRmlcGd,iv:mVVccurNSOj7NBDLKU7Ux8Be/f2MKCgk/oB+PkmNHdU=,tag:KreecD4jXvL6VeDetqhqiw==,type:str]
+runner-registration-token: ENC[AES256_GCM,data:efv/jtv7LdSuRFSIyvKVFtOmhIoOlbk0+EJAJrk5czLd2sg3nr82wAk9emZMys02KpwPngu7t249JGdar+h2oyFMHmP1xu/kaOy70xkd3OKOzJyzUQIgbOCWCbJl,iv:DUWAbA7HDBmYbOsRAS/jsd9m4KsMyhXJRUBYuNBbi5w=,tag:nY4vrnbsbeK7UhT0WvSWoQ==,type:str]
 sops:
-  lastmodified: "2026-02-18T08:37:56Z"
-  mac: ENC[AES256_GCM,data:UEK9OTl0+3zSp7TVzXF92Vx0HZjmK92CDDSBR+NGYZlxllaYYHnnXytkAToLqbPFLenUlve+oEVRpVdeijJbJr8hzjgABpzh7wIxmu0LY8L1FQyAoY8MvdrMLdtEAAY6yfAiTZdKBFiObXDYRY/hnM13pjS4XosPmzkCnyUzBWU=,iv:hJuKelOW1ZdDXgwvuFv9x+nMNchG8c6mdLEtrl6W6IU=,tag:IOlS0bVhCiTqsHBsTDvnNQ==,type:str]
+  lastmodified: "2026-04-12T05:01:39Z"
+  mac: ENC[AES256_GCM,data:NS+6wwVOURcDqVBbB8s0+d442O8JX1lZ/EWTx8yqufIzHNcAGZQlkDjqtN9kOApNIDhVof0kfeZAgYchGBJDMXYOqnjFWWHRH58mxLAov7RmwKg4Q5nHp4m3MSGQIf768PnisaAvyYoNeKO836D90rEFXzUWxSMZmDL/hsLZn+0=,iv:/sd7pzJ+BB5/fZMoe82C9kbWRbXEB6lCmcdO+VYUyEo=,tag:VH3lSFj2NBO1vlfhjkN/Nw==,type:str]
   pgp:
     - created_at: "2026-02-18T08:09:30Z"
       enc: |-
@@ -15,4 +16,4 @@ sops:
         -----END PGP MESSAGE-----
       fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.12.1


### PR DESCRIPTION
セルフホストランナーでflake inputsのダウンロード時にGitHubのAPI rate limit(未認証60req/h)に
引っかかっていたため、最小権限のPATを`access-tokens`として設定しました。
`access-tokens`は`fetchSettings`に属しtrusted userからもdaemonに転送されないため、
[Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
sops-nixのtemplateで生成した環境変数ファイルをnix-daemonの`EnvironmentFile`として渡しています。

併せて既存のsops secretキーを`pat`から`runner-registration-token`にリネームし、
用途を明確にしました。

close #882
