### PR TITLE
ci: nix-fast-buildとbuild-home-managerはGitHubホステッドランナーで実行

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -51,7 +51,7 @@ runs:
         # 現在ホストしているNixOSコンテナや、
         # 他の場所のUbuntu上のセルフホステッドランナーでdaemonを無効化しないと動作しないことを確認しています。
         # store scanはクライアント側で動作するため両環境で問題なく使えます。
-        useDaemon: ${{ runner.environment != 'github-hosted' }}
+        useDaemon: ${{ runner.environment == 'github-hosted' }}
 
     # niks3-action v0.4.2ではskip-pushがpost-build hookに反映されないバグがあり、
     # push失敗時にビルド全体が巻き込まれて失敗する。
@@ -66,4 +66,4 @@ runs:
         push-flake-inputs: true
         # セルフホステッドランナーではNixOSコンテナのためpost-build-hookが動作しないので、
         # store-scan(差分計算)モードを使用します。
-        use-daemon: ${{ runner.environment != 'github-hosted' }}
+        use-daemon: ${{ runner.environment == 'github-hosted' }}

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -49,7 +49,8 @@ runs:
         # post-build-hookのパスがデーモンから到達できなかったりするため、
         # デーモンモードは使用できません。
         # 現在ホストしているNixOSコンテナや、
-        # 他の場所のUbuntu上のセルフホステッドランナーでdaemonを無効化しないと動作しないことを確認しています。
+        # 他の場所のUbuntu上のセルフホステッドランナーでdaemonを無効化しないと、
+        # 動作しないことを確認しています。
         # store scanはクライアント側で動作するため両環境で問題なく使えます。
         useDaemon: ${{ runner.environment == 'github-hosted' }}
 

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -42,15 +42,16 @@ runs:
         authToken: "${{ inputs.cachix-auth-token }}"
         # フォークからのPRのみキャッシュへのプッシュをスキップ
         skipPush: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-        # デーモンのpost-build-hookではなくstore scanによるクライアント側pushを使用します。
+        # セルフホステッドランナーでは、
+        # デーモンのpost-build-hookではなく、
+        # store scanによるクライアント側pushを使用します。
         # 通常セルフホステッドランナーでは、
         # post-build-hookのパスがデーモンから到達できなかったりするため、
         # デーモンモードは使用できません。
         # 現在ホストしているNixOSコンテナや、
         # 他の場所のUbuntu上のセルフホステッドランナーでdaemonを無効化しないと動作しないことを確認しています。
         # store scanはクライアント側で動作するため両環境で問題なく使えます。
-        # 一貫性のために多少のパフォーマンスより設定を統一して両方の環境で`useDaemon`を`false`にしています。
-        useDaemon: false
+        useDaemon: ${{ runner.environment != 'github-hosted' }}
 
     # niks3-action v0.4.2ではskip-pushがpost-build hookに反映されないバグがあり、
     # push失敗時にビルド全体が巻き込まれて失敗する。
@@ -65,4 +66,4 @@ runs:
         push-flake-inputs: true
         # セルフホステッドランナーではNixOSコンテナのためpost-build-hookが動作しないので、
         # store-scan(差分計算)モードを使用します。
-        use-daemon: false
+        use-daemon: ${{ runner.environment != 'github-hosted' }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,11 +32,14 @@ jobs:
 
   nix-fast-build:
     name: nix-fast-build
+    needs: is-trusted
     permissions:
       contents: read
       id-token: write # niks3-publicへのOIDC認証に必要
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    # セルフホステッドランナーは未認証のソースからは実行しない。
+    if: needs.is-trusted.result == 'success'
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,17 +32,10 @@ jobs:
 
   nix-fast-build:
     name: nix-fast-build
-    needs: is-trusted
     permissions:
       contents: read
       id-token: write # niks3-publicへのOIDC認証に必要
-    # 信頼できるソースの場合はセルフホステッドランナーで高速化し、
-    # それ以外はGitHubランナーで実行します。
-    # is-trustedがスキップされてもこのジョブは実行する必要があるためalways()を使用します。
-    if: always() && !cancelled()
-    runs-on: >-
-      ${{ needs.is-trusted.result == 'success'
-        && fromJSON('["self-hosted", "Linux"]') || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -101,17 +94,10 @@ jobs:
 
   build-home-manager:
     name: build-home-manager
-    needs: is-trusted
     permissions:
       contents: read
       id-token: write # niks3-publicへのOIDC認証に必要
-    # 信頼できるソースの場合はセルフホステッドランナーで高速化し、
-    # それ以外はGitHubランナーで実行します。
-    # is-trustedがスキップされてもこのジョブは実行する必要があるためalways()を使用します。
-    if: always() && !cancelled()
-    runs-on: >-
-      ${{ needs.is-trusted.result == 'success'
-        && fromJSON('["self-hosted", "Linux"]') || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
CPUの性能的には自宅サーバとGitHubホステッドランナーはほぼ同等。
ディスク領域が大量に必要になるわけでもないジョブは、
GitHubホステッドランナーで実行することにして、
自宅サーバのリソースを節約します。
