### PR TITLE
ci: セルフホストランナーのPR許可を内部PRのみに統一

### DIFF
--- a/nixos/host/seminar/github-runner/job-started-hook.ts
+++ b/nixos/host/seminar/github-runner/job-started-hook.ts
@@ -11,9 +11,22 @@ import { readFile } from "node:fs/promises";
 interface GitHubEvent {
   readonly pull_request?: {
     readonly author_association?: string;
+    readonly head?: {
+      readonly repo?: {
+        readonly full_name?: string;
+      };
+    };
+    readonly base?: {
+      readonly repo?: {
+        readonly full_name?: string;
+      };
+    };
     readonly user?: {
       readonly login?: string;
     };
+  };
+  readonly repository?: {
+    readonly full_name?: string;
   };
   readonly sender?: {
     readonly login?: string;
@@ -35,32 +48,30 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // PRイベントはオーナーまたは信頼できるbotのみ許可
+  // PRイベントは内部PRのみ許可
   const prEvents = new Set(["pull_request", "pull_request_target"]);
 
   if (prEvents.has(eventName)) {
     const content = await readFile(eventPath, "utf-8");
     const event = JSON.parse(content) as GitHubEvent;
-    const authorAssociation = event.pull_request?.author_association ?? "UNKNOWN";
-    const userLogin = event.pull_request?.user?.login ?? "UNKNOWN";
     const sender = event.sender?.login ?? "UNKNOWN";
-    console.log(`PR author_association=${authorAssociation} user.login=${userLogin} sender=${sender}`);
+    const prHeadRepoFullName = event.pull_request?.head?.repo?.full_name ?? "UNKNOWN";
+    const prBaseRepoFullName = event.pull_request?.base?.repo?.full_name ?? event.repository?.full_name ?? "UNKNOWN";
+    const isInternalPullRequest =
+      prHeadRepoFullName !== "UNKNOWN" && prBaseRepoFullName !== "UNKNOWN" && prHeadRepoFullName === prBaseRepoFullName;
+    console.log(
+      `PR head.repo.full_name=${prHeadRepoFullName} base.repo.full_name=${prBaseRepoFullName} ` +
+        `internal=${String(isInternalPullRequest)} sender=${sender}`,
+    );
 
-    if (authorAssociation === "OWNER") {
-      console.log("PR author is OWNER, allowed.");
-      process.exit(0);
-    }
-
-    // 信頼できるbotからのPRを許可
-    const trustedBots = new Set(["dependabot[bot]", "renovate[bot]"]);
-    if (trustedBots.has(userLogin)) {
-      console.log(`PR from trusted bot '${userLogin}', allowed.`);
+    if (isInternalPullRequest) {
+      console.log("Internal PR, allowed.");
       process.exit(0);
     }
 
     console.error(
-      `ERROR: Untrusted PR (author_association=${authorAssociation}, ` +
-        `user.login=${userLogin}, sender=${sender}). Rejecting job.`,
+      `ERROR: External PR is not allowed on self-hosted runner (sender=${sender}, ` +
+        `head.repo.full_name=${prHeadRepoFullName}, base.repo.full_name=${prBaseRepoFullName}). Rejecting job.`,
     );
     process.exit(1);
   }

--- a/nixos/host/seminar/github-runner/job-started-hook.ts
+++ b/nixos/host/seminar/github-runner/job-started-hook.ts
@@ -54,11 +54,11 @@ async function main(): Promise<void> {
   if (prEvents.has(eventName)) {
     const content = await readFile(eventPath, "utf-8");
     const event = JSON.parse(content) as GitHubEvent;
-    const sender = event.sender?.login ?? "UNKNOWN";
-    const prHeadRepoFullName = event.pull_request?.head?.repo?.full_name ?? "UNKNOWN";
-    const prBaseRepoFullName = event.pull_request?.base?.repo?.full_name ?? event.repository?.full_name ?? "UNKNOWN";
+    const sender = event.sender?.login;
+    const prHeadRepoFullName = event.pull_request?.head?.repo?.full_name;
+    const prBaseRepoFullName = event.pull_request?.base?.repo?.full_name ?? event.repository?.full_name;
     const isInternalPullRequest =
-      prHeadRepoFullName !== "UNKNOWN" && prBaseRepoFullName !== "UNKNOWN" && prHeadRepoFullName === prBaseRepoFullName;
+      prHeadRepoFullName != null && prBaseRepoFullName != null && prHeadRepoFullName === prBaseRepoFullName;
     console.log(
       `PR head.repo.full_name=${prHeadRepoFullName} base.repo.full_name=${prBaseRepoFullName} ` +
         `internal=${String(isInternalPullRequest)} sender=${sender}`,


### PR DESCRIPTION
ワークフロー側でforkでないPRはセルフホストランナー実行を許可する方針にしたため。
多層防御のランナー側フックも同じ基準に合わせて内部PRなら作者やbotに関係なく許可するため。
owner判定やbotの許可リストは方針と不一致になりやすく保守負担も増えるため削除する。
外部PRは引き続きセルフホストランナーでは拒否して防御境界を明確にする。