### PR TITLE
feat: moshを設定する

### DIFF
--- a/home/core/ssh.nix
+++ b/home/core/ssh.nix
@@ -18,4 +18,5 @@
       };
     };
   };
+  home.packages = with pkgs; [ mosh ];
 }

--- a/nixos/host/seminar/ssh.nix
+++ b/nixos/host/seminar/ssh.nix
@@ -7,6 +7,7 @@
       PasswordAuthentication = false;
     };
   };
+  programs.mosh.enable = true;
   users.users.${username}.openssh.authorizedKeys.keys = [
     # 公開鍵は全世界に公開することが前提として設計されているので、dotfilesに含めて問題ない。
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGYLEhh/AfM0TcAn15SgUcXZGtS3DxE/7xQmuxApawWg openpgp:0x79E75544"


### PR DESCRIPTION
seminarサーバに`programs.mosh.enable = true`を追加してmoshサーバを有効化する。 ファイアウォールのUDP 60000-61000はデフォルトで自動開放される。

クライアント側はhome-managerのSSH設定ファイルにmoshパッケージを追加する。
全home-manager管理環境(NixOS・Nix-on-Droid・WSL等)で`mosh seminar`が使えるようになる。 moshは`~/.ssh/config`のseminarエントリを自動的に参照するため、SSH設定の追加変更は不要。