### PR TITLE
feat: globalなgitignoreに`.codex`を追加

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -50,6 +50,7 @@ in
       ignores = [
         "**/.claude/settings.local.json"
         ".DS_Store"
+        ".codex"
         "Thumbs.db"
       ];
     };


### PR DESCRIPTION
codexの更新でプロジェクトに`.codex`ファイルが生成されるようになったため。
