### PR TITLE
build(deps): update konoka plugin to v5.0.2

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v4.2.0"
+        "ref": "v5.0.2"
       }
     }
   },

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -166,7 +166,7 @@ in
           source = {
             source = "github";
             repo = "ncaq/konoka";
-            ref = "v4.2.0";
+            ref = "v5.0.2";
           };
         };
       };
@@ -193,7 +193,6 @@ in
         # konokaプラグイン。
         "bump-cabal-index-state@konoka" = true;
         "commit@konoka" = true;
-        "dependency-update-report@konoka" = true;
         "kyosei@konoka" = true;
         "log-analyzer@konoka" = true;
         "nix-tasuke@konoka" = true;


### PR DESCRIPTION
dependency-update-report plugin was merged into kyosei in v5.0.0,
so remove the separate enabledPlugins entry.
