### PR TITLE
chore: enableAllProjectMcpServersを有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,7 @@
     "nix-tasuke@konoka": true,
     "web-tasuke@konoka": true
   },
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": ["Bash(./install.sh:*)"],
     "additionalDirectories": [


### PR DESCRIPTION
最初は一回C-mを押して承認するだけだから別に良いかと思いましたが、
プロジェクトと差分がなくてもlocalのsettingsが生成されるのが鬱陶しいので、
リポジトリのmcpサーバを自動承認します。
セキュリティリスクは上がりません。
どうせリポジトリに悪意のあるコードを取り込まされた時点で終わりなので。
そもそもpopupもどうせ見ずに承認するだろうから意味がありません。
