### PR TITLE
fix(boot): configurationLimitを100から50に減少

### DIFF
--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -10,7 +10,7 @@
         enable = true;
         consoleMode = "auto";
         xbootldrMountPoint = "/boot";
-        configurationLimit = 100;
+        configurationLimit = 50;
       };
     };
     initrd = {

--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -10,7 +10,7 @@
         enable = true;
         consoleMode = "auto";
         xbootldrMountPoint = "/boot";
-        configurationLimit = 100;
+        configurationLimit = 50;
       };
     };
     initrd = {


### PR DESCRIPTION
100ではカーネルの更新が多かったりするとcreepでギリギリ足りなかった。
別に100も残す必要性はないと思うので50に減らします。
bulletがマルチブートの都合上grubなので設定ファイルが1本化できない。
別に2つの箇所程度で小さな設定ファイルを管理しているのは致命的ではないと思うので許容しています。
