### PR TITLE
fix(locate): 衝突しやすい`pruneNames`をフルパスの`prunePaths`に移行

### DIFF
--- a/nixos/core/locate.nix
+++ b/nixos/core/locate.nix
@@ -1,9 +1,14 @@
-{ pkgs, ... }:
+{ pkgs, username, ... }:
 {
   services.locate = {
     enable = true;
     package = pkgs.plocate;
     interval = "hourly";
+    prunePaths = [
+      "/home/${username}/.claude/plugins"
+      "/home/${username}/.claude/projects"
+      "/nix/store"
+    ];
     pruneNames = [
       "$Recycle.Bin"
       ".Trash"
@@ -50,11 +55,8 @@
       "file-backup"
       "htmlcache"
       "node_modules"
-      "plugins" # claude code
-      "projects" # claude code
       "site-packages"
       "steam-runtime"
-      "store"
       "target"
       "texmf-dist"
       "undo-tree"

--- a/nixos/core/locate.nix
+++ b/nixos/core/locate.nix
@@ -1,28 +1,28 @@
-{ pkgs, username, ... }:
+{
+  lib,
+  pkgs,
+  username,
+  ...
+}:
 {
   services.locate = {
     enable = true;
     package = pkgs.plocate;
     interval = "hourly";
-    prunePaths = [
+    prunePaths = lib.mkOptionDefault [
       "/home/${username}/.claude/plugins"
       "/home/${username}/.claude/projects"
-      "/nix/store"
     ];
-    pruneNames = [
+    pruneNames = lib.mkOptionDefault [
       "$Recycle.Bin"
       ".Trash"
       ".Trash-1000"
-      ".bzr"
       ".cabal"
-      ".cache"
       ".cargo"
       ".dub"
       ".gem"
       ".ghcup"
-      ".git"
       ".go"
-      ".hg"
       ".julia"
       ".metals"
       ".npm"
@@ -35,7 +35,6 @@
       ".stack-work-fast"
       ".stack-work-profile"
       ".stack-work-test"
-      ".svn"
       "Trash"
       "WinSxS"
       "__pycache__"


### PR DESCRIPTION
`store`, `plugins`, `projects`は一般的な名前のため、
`pruneNames`で指定するとプロジェクト内の正当なディレクトリまで除外されてしまいます。
除外したい対象はそれぞれ`/nix/store`, `~/.claude/plugins`, `~/.claude/projects`の1箇所だけなので、
`prunePaths`でフルパス指定に変更しました。
