### PR TITLE
ci(renovate): GitHub ActionsでRenovateを毎日実行する

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -9,6 +9,6 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* * * * *"]
+    "schedule": ["at any time"]
   }
 }

--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "onboarding": false,
+  "requireConfig": "ignored",
+  "repositories": ["ncaq/dotfiles"],
+  "extends": ["github>ncaq/renovate-config"],
+  "ignorePresets": [
+    "github>ncaq/renovate-config//preset/lock-file-maintenance"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* * * * *"]
+  }
+}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
@@ -85,7 +85,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
@@ -108,7 +108,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
@@ -147,7 +147,7 @@ jobs:
     runs-on: [self-hosted, Linux]
     timeout-minutes: 360 # キャッシュが切れている時は時間がかかる上QEMUエミュレーションでのビルドになるため長めに設定。
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,7 +17,7 @@ jobs:
   renovate:
     name: renovate
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,28 @@
+name: Renovate
+
+on:
+  schedule:
+    # UTC 22:00 is JST 07:00.
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: renovate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10
+        with:
+          configurationFile: .github/renovate-config.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Hosted Renovate無効化用。実設定は`.github/renovate-config.json`、実行は`.github/workflows/renovate.yml`から。",
   "enabled": false
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ncaq/renovate-config"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["after 6am and before 7am"]
-  }
+  "enabled": false
 }


### PR DESCRIPTION
Renovateのscheduleは実行時刻を指定するものではなく、
Renovateが起動した時にbranch作成を許可する時間帯を制限するものでした。

Hosted Renovate任せだと実行タイミングが許可時間に入らない日があり、
lock file maintenanceが毎日作られることを期待できません。

GitHub ActionsのcronでJST 07:00にRenovateを起動するようにして、
lock file maintenanceの更新確認を毎日確実に試行できるようにします。

Mend-hosted Renovate Appはall repositoriesでinstallしたままにしたいため、
repo直下のrenovate.jsonではこのrepoのHosted Renovateを無効化します。

Actions版Renovateは別のglobal configを読み、
repo内のrenovate.jsonを無視して動かします。
