### PR TITLE
ci: renovateのマネージドモードを再度有効化

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "onboarding": false,
   "requireConfig": "ignored",
+  "branchPrefix": "renovate-action/",
   "repositories": ["ncaq/dotfiles"],
   "extends": ["github>ncaq/renovate-config"],
   "ignorePresets": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Hosted Renovate(App)とGitHub Actions版の2系統運用。Hostedはissue dashboardからのマニュアル更新用。Actions設定は`.github/renovate-config.json`、実行は`.github/workflows/renovate.yml`。",
   "extends": ["github>ncaq/renovate-config"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Hosted Renovate無効化用。実設定は`.github/renovate-config.json`、実行は`.github/workflows/renovate.yml`から。",
-  "enabled": false
+  "extends": ["github>ncaq/renovate-config"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Hosted Renovate(App)とGitHub Actions版の2系統運用。Hostedはissue dashboardからのマニュアル更新用。Actions設定は`.github/renovate-config.json`、実行は`.github/workflows/renovate.yml`。",
+  "description": "Hosted Renovate(App)とGitHub Actions版の2系統運用。Hostedはdependency dashboard可視化およびissue dashboardからの手動トリガ用途。Actionsは`.github/renovate-config.json`+`.github/workflows/renovate.yml`で日次自動実行。自動PR重複は許容。",
   "extends": ["github>ncaq/renovate-config"]
 }


### PR DESCRIPTION
issueのboardとかからマニュアル更新出来るのは便利なのでマネージドな方も無効化しない。
GitHub Actionsで動かす方とで多少のPRの重複が生じる可能性はありますが、
そこは許容することにします。
