### PR TITLE
fix: nixのGitHubのrate limitを回避するためのトークンをクライアント側でも設定

### DIFF
--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -1,4 +1,5 @@
-_: {
+{ config, ... }:
+{
   nix = {
     settings = {
       experimental-features = [
@@ -34,6 +35,47 @@ _: {
     optimise = {
       automatic = true;
       dates = "Fri *-*-* 12:30:00";
+    };
+    # nix-daemonにGitHubのアクセストークンを渡します。
+    # `nix profile add`などを実行した際のGitHubのAPI rate limitを回避するために有用です。
+    # `access-tokens`はクライアントからdaemonに転送されない設定のため、
+    # 直接設定する必要があります。
+    # nix-daemonはホスト全体で共有されるため、
+    # このトークンは全ユーザのビルドに適用されます。
+    # 本当は構造化された`access-tokens`フィールドを使いたいけれど、
+    # sopsのファイルをパスで読み込ませる方法が分からないため、
+    # nix.confのフラグメントをsopsで生成して読み込む方法で回避します。
+    # 関連: [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
+    extraOptions = ''
+      !include ${config.sops.templates."github-nix-avoid-rate-limit-token.conf".path}
+    '';
+  };
+
+  sops = {
+    # nix.confのfragmentを生成することでクライアント側にも読める設定ファイルにします。
+    # 自分のアカウントだけのFine-grained personal access tokensで、
+    # Fine-grainedの最小限の権限であるPublic Repository権限だけを持ちます。
+    # なので万が一漏れても大した問題はないので、
+    # 権限は緩めで問題ありません。
+    templates."github-nix-avoid-rate-limit-token.conf" = {
+      content = ''
+        access-tokens = github.com=${config.sops.placeholder."github-nix-avoid-rate-limit-token"}
+      '';
+      owner = "root";
+      group = "wheel"; # 信頼できるとしたユーザも読めるようにしておきます。
+      mode = "0440"; # グループ所属のユーザも読み取れます。
+    };
+    secrets = {
+      # 最小権限の権限で`access-tokens`を設定します。
+      # こちらはtemplatesが作れれば良いため、
+      # rootさえ読めれば問題ありません。
+      "github-nix-avoid-rate-limit-token" = {
+        sopsFile = ../../secrets/github-nix-avoid-rate-limit.yaml;
+        key = "nix-avoid-rate-limit";
+        owner = "root";
+        group = "root";
+        mode = "0400";
+      };
     };
   };
 }

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -92,38 +92,8 @@ in
   # コンテナ側ではなくホストレベルで設定が必要です。
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
-  # nix-daemonの環境変数としてGitHubのアクセストークンを渡します。
-  # 内部で`nix profile add`などを実行した際のGitHubのAPI rate limitを回避するために必要です。
-  # nix-daemonはホスト全体で共有されるため、このトークンは全ユーザのビルドに適用されます。
-  # しかし自分のアカウントの、
-  # Publicリポジトリを読み込めるだけの権限のトークンを設定しているだけなので、
-  # 全体に適用されても無害であると考えています。
-  systemd.services.nix-daemon.serviceConfig.EnvironmentFile = [
-    config.sops.templates."nix-daemon-github-env".path
-  ];
-
   sops = {
-    # systemdの`EnvironmentFile`で読み込むGitHubのアクセストークンを定義します。
-    templates."nix-daemon-github-env" = {
-      content = ''
-        NIX_CONFIG=access-tokens = github.com=${config.sops.placeholder."read-token"}
-      '';
-      owner = "root";
-      group = "root";
-      mode = "0400";
-    };
     secrets = {
-      # 最小権限のPATで`access-tokens`を設定します。
-      # `access-tokens`はクライアントからdaemonに転送されない設定のため、
-      # daemonプロセスの`NIX_CONFIG`環境変数で直接設定する必要があります。
-      # 関連: [Specify access token via file · Issue #6536 · NixOS/nix](https://github.com/NixOS/nix/issues/6536)
-      "read-token" = {
-        sopsFile = ../../../../secrets/seminar/github-runner.yaml;
-        key = "read-token";
-        owner = "root";
-        group = "root";
-        mode = "0400";
-      };
       # セルフホストランナーがGitHub Actionsに自身を登録するためのトークン。
       "runner-registration-token" = {
         sopsFile = ../../../../secrets/seminar/github-runner.yaml;

--- a/secrets/github-nix-avoid-rate-limit.yaml
+++ b/secrets/github-nix-avoid-rate-limit.yaml
@@ -1,0 +1,18 @@
+nix-avoid-rate-limit: ENC[AES256_GCM,data:NuS1/I1MVl4/kZzVugOscvGRKd1+Qi7IGX/MtbjONxnkOpKVAqjNAy8TVk5TNP0dBQREaRNOYI+fwJRXgZZen5r0zH/SaPWuF+rNJdR17Jl47jz/whUIPAQxYJpl,iv:pevdNj7fIpr2z6Nu90JB0s4IJ3+LWnaTskOscW5AvO0=,tag:oX7kY0XU8P2O3KYtdreyRQ==,type:str]
+sops:
+  lastmodified: "2026-04-24T01:45:45Z"
+  mac: ENC[AES256_GCM,data:ZeC6hqmIOO8NMI96lAv4mqEwKbtKZohcMCsuoxuZlAho6osdFnSkOSdRl8oosdXbvS6qa8h5AqiGgLMwr0FgOetv9ZiJ7bRN1NJE52/LlQnEG6HccqZWIq0FQTASTf+blQSRueyei7xPSMIA5h0a/qfFeCrJpzMgg5GgStNhMFw=,iv:YLFG12mhK3gS0CxtNvAz/eB9eRGOCk9PKpy1ZEKD8hw=,tag:IfZ6KxTTbKITcK1C+njJQA==,type:str]
+  pgp:
+    - created_at: "2026-04-24T01:45:30Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4Dxlt1nl1bPpUSAQdAoApNegkr+zRwTm8p1tixhlXl8opKE9dPOKWSXfcH7Dcw
+        Kph3Z1D1QsZ2E3UTrL1CzN4pcxWM8Awyw4dIqpjM2Z8ufUxRv6cUybPGwnDDSePh
+        0l4BFU90aRJuUn12fbK/UffvSYU6zQPf5adFmYrSwZxRXzlI5uI0CR9onkSxjM3d
+        LXjId6raKDl8WutO4p0tPim1ih7YVg8sJzXGWZjMEGinVj4LXehGyahf5pZjhnlJ
+        =5+i5
+        -----END PGP MESSAGE-----
+      fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/seminar/github-runner.yaml
+++ b/secrets/seminar/github-runner.yaml
@@ -1,18 +1,17 @@
-read-token: ENC[AES256_GCM,data:ZpTiRuvwy1iRKe20qJ8JQNrl1vuQjV21GqDiEVXWM+HVBl5vPhJihwAOj0JCDIwFq/RyVRqLFtyAiqJVJmh+mqbnSR0i2apqWRNxM/PP/NMRek6lVwJPeqRmlcGd,iv:mVVccurNSOj7NBDLKU7Ux8Be/f2MKCgk/oB+PkmNHdU=,tag:KreecD4jXvL6VeDetqhqiw==,type:str]
-runner-registration-token: ENC[AES256_GCM,data:efv/jtv7LdSuRFSIyvKVFtOmhIoOlbk0+EJAJrk5czLd2sg3nr82wAk9emZMys02KpwPngu7t249JGdar+h2oyFMHmP1xu/kaOy70xkd3OKOzJyzUQIgbOCWCbJl,iv:DUWAbA7HDBmYbOsRAS/jsd9m4KsMyhXJRUBYuNBbi5w=,tag:nY4vrnbsbeK7UhT0WvSWoQ==,type:str]
+runner-registration-token: ENC[AES256_GCM,data:FyrMCJDKpIK5lWYucaEv3J1LwhFNjatDCZxiS+GONw+1LWoDzQ84ojbd5fMoRSgxMyuwsIag3VMBd+oCtdZanNKS3ebI3+MC564VhEMNr04UVTAuPbSbRLNThpIJ,iv:hKKDVuJv7zCGKCE7CRRh1lzlQe6VsKC4UYRYB7QoYmM=,tag:F0Imcwa3i+C66ST+jcCyQg==,type:str]
 sops:
-  lastmodified: "2026-04-12T05:01:39Z"
-  mac: ENC[AES256_GCM,data:NS+6wwVOURcDqVBbB8s0+d442O8JX1lZ/EWTx8yqufIzHNcAGZQlkDjqtN9kOApNIDhVof0kfeZAgYchGBJDMXYOqnjFWWHRH58mxLAov7RmwKg4Q5nHp4m3MSGQIf768PnisaAvyYoNeKO836D90rEFXzUWxSMZmDL/hsLZn+0=,iv:/sd7pzJ+BB5/fZMoe82C9kbWRbXEB6lCmcdO+VYUyEo=,tag:VH3lSFj2NBO1vlfhjkN/Nw==,type:str]
+  lastmodified: "2026-04-24T01:50:26Z"
+  mac: ENC[AES256_GCM,data:/6Cum9lnTpUkwm/7wSPZr6T0oGTiOQwTycU61ZJDdMtkwhX9gMh2kVKBLJCcTmbfv454UU/pcBBevINQ/S8P3Asi/xT1fbhMi0krZTTYnP6j9qCcQElzxPZgCrE+SrsK3N6swSfoYNtPhTrDQFRujM6aKWJ8vg9aADKLCnKgxi0=,iv:9uZevzvM8+U2ripS0GAYhQY+5fQa22G0QKkcstOaFiw=,tag:mmFiFNoB99+x2x01fvgHEg==,type:str]
   pgp:
-    - created_at: "2026-02-18T08:09:30Z"
+    - created_at: "2026-04-24T01:50:26Z"
       enc: |-
         -----BEGIN PGP MESSAGE-----
 
-        hF4Dxlt1nl1bPpUSAQdAM5leYXjveZDkGJPk61JGiWGDyLl1BsiSODCELDZShWMw
-        eTEPdvR90o5uDGtC6AOoRPP3BtKU/ME9xaH+DF8nz4DhS1JVKtYHcKdBD0bkenF+
-        0l4BdM+A8ow3ihD09/n8M1zDRkAXkN7lcjzwEhwWaPPoKB8vF8ihXFwc+Oo6D7z8
-        x29is2XpkQ4lXA0hh75mAjK5GnP7OMy0yi6Sxvbs7atzOWnPPud/KJc6rbxXK5wj
-        =mPVS
+        hF4Dxlt1nl1bPpUSAQdAHRcTzemR455vo61kqjKAcDGt0/X8GeKxoXn8cLESkisw
+        I5z/+rmFt//OicCCrxALda9VSwP+BTi2XoaA8PeaKySHmtSnjdT5y9fY1xfIGBU7
+        0l4BT0BHVRbtZmo2wmA/1sGunUQE9gUJ3Ypyb5b1bndZSILxIsbxWVUYfzVw33Gt
+        OLnrpfZ7haYDe+zXuN86bUmeAuoHMIwob2AVTg+Aqeeo5Q1P6BbpTeWfBL+EHwFd
+        =LvXY
         -----END PGP MESSAGE-----
       fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
   unencrypted_suffix: _unencrypted


### PR DESCRIPTION
nix flake updateとかを繰り返していたら、
クライアント側でも制限を食らったため。
認証するだけでほぼ問題なくなるため、
全体のクライアントで認証することにします。
非NixOS環境はとりあえずは考慮していません。
