### PR TITLE
fix(flake): `nixpkgs-unstable`の参照先を`nixos-unstable`ブランチに変更

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,16 +459,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
NixOSシステムで使用する場合は`nixos-unstable`の方が適切です。
`nixpkgs-unstable`はNixOS固有のテストを含まない非NixOS環境向けのブランチであり、
NixOS環境では`nixos-unstable`(NixOS VMテストなどを通過したもの)を使うべきでした。

close #938 

nixpkgsのstableが更新されてないのは普通に更新がされてないだけっぽい。