### PR TITLE
fix(renovate): `lockFileMaintenance`を毎日実行するため`:maintainLockFilesWeekly`も無視する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ncaq/renovate-config"],
   "ignorePresets": [
-    "github>ncaq/renovate-config//preset/lock-file-maintenance"
+    "github>ncaq/renovate-config//preset/lock-file-maintenance",
+    ":maintainLockFilesWeekly"
   ],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
`config:best-practices`が内部で`:maintainLockFilesWeekly`を継承しており、
これが`schedule:weekly`(月曜午前4時前)を強制していたため、
`schedule:daily`を指定しても週次スケジュールが勝って月曜のみ実行されていました。

`:maintainLockFilesWeekly`も`ignorePresets`に追加して、
ユーザー指定の`schedule:daily`を有効にします。

close #937
