### PR TITLE
refactor(renovate): 削除されたカスタムプリセットの参照を整理

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ncaq/renovate-config"],
-  "ignorePresets": [
-    "github>ncaq/renovate-config//preset/lock-file-maintenance",
-    ":maintainLockFilesWeekly"
-  ],
+  "ignorePresets": [":maintainLockFilesWeekly", ":maintainLockFilesMonthly"],
   "lockFileMaintenance": {
     "enabled": true,
     "extends": ["schedule:daily"]


### PR DESCRIPTION
ncaq/renovate-config#42でカスタムの`preset/lock-file-maintenance`が削除され、
代わりに公式の`:maintainLockFilesMonthly`が継承されるようになりました。

存在しないプリセットへの参照を削除し、
`schedule:daily`で上書きするために新たに継承された`:maintainLockFilesMonthly`も
`ignorePresets`に追加します。
