### PR TITLE
feat: alacrittyのフォントサイズを12に変更

### DIFF
--- a/home/core/alacritty.nix
+++ b/home/core/alacritty.nix
@@ -28,6 +28,7 @@ in
         normal = {
           family = "FirgeNerd Console";
         };
+        size = 12;
       };
       # Windows環境で起動したときはWSLのシェルを起動するようにします。
       # WSLのalacrittyを起動することはあまり考慮していません。


### PR DESCRIPTION
デフォルトが小数点数の`11.25`であまり好みの指定方法ではなかったため、
近いサイズの`12`に変更しました。
少し大きいほうが日本語表示が多い環境には合っています。
