### PR TITLE
ci: PRにnvdでパッケージ差分を自動投稿するワークフローを追加

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,7 @@ jobs:
     needs: is-trusted
     permissions:
       contents: read
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
@@ -79,7 +79,7 @@ jobs:
     needs: is-trusted
     permissions:
       contents: read
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
@@ -102,7 +102,7 @@ jobs:
     needs: is-trusted
     permissions:
       contents: read
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
@@ -124,7 +124,7 @@ jobs:
     name: build-home-manager
     permissions:
       contents: read
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     runs-on: ubuntu-24.04
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
@@ -141,7 +141,7 @@ jobs:
     needs: is-trusted
     permissions:
       contents: read
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -20,10 +20,11 @@ jobs:
   nvd-diff:
     name: nvd-diff
     # check成功時のPRトリガのみ対象。
-    # フォークPRはworkflow_run.pull_requestsが空になるので自動的に除外されます。
+    # フォークPRは除外されます。
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.pull_requests[0] != null
     permissions:
       contents: read # リポジトリコンテンツの読み取り

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -36,7 +36,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0 # base refのworktree展開に全ログが必要。そこまで重いリポジトリでもないので問題なし。
+          # base refのworktree展開のために全オブジェクトを要求。
+          # 履歴の浅さに依存しない安全側に倒しています。
+          # そこまで重いリポジトリでもないのでフルに要求しても問題はありません。
+          fetch-depth: 0
           persist-credentials: false
       - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
         with:

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read # リポジトリコンテンツの読み取り
       pull-requests: write # PRコメントのupsert
-      id-token: write # niks3-publicへのOIDC認証に必要
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -1,0 +1,48 @@
+name: nvd-diff
+
+# checkワークフローの完了後に動かし、
+# ビルドキャッシュのヒット率を高めます。
+on:
+  # zizmor: ignore[dangerous-triggers] -- workflow_runはhead_shaのチェックアウト + 内部PR限定のガードで安全に使います。
+  workflow_run:
+    workflows: [check]
+    types: [completed]
+
+permissions: {}
+
+# 最新の差分が見れていれば十分なので、
+# 同一ブランチでの複数のPRは古い方をキャンセルします。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  nvd-diff:
+    name: nvd-diff
+    # check成功時のPRトリガのみ対象。
+    # フォークPRはworkflow_run.pull_requestsが空になるので自動的に除外されます。
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] != null
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      pull-requests: write # PRコメントのupsert
+      id-token: write # niks3-publicへのOIDC認証に必要
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0 # base refのworktree展開に全ログが必要。そこまで重いリポジトリでもないので問題なし。
+          persist-credentials: false
+      - uses: ncaq/nix-composite-action@6e28cd44693083d063bed5baf36e912c6807a151 # v1.1.1
+        with:
+          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - name: Run nvd-pr-diff
+        env:
+          BASE_REF: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: nix run .#nvd-pr-diff

--- a/flake.nix
+++ b/flake.nix
@@ -373,6 +373,20 @@
               zizmor.enable = true;
             };
             settings.formatter = {
+              awk-lint = {
+                # gawk --lint=fatalで.awkファイルを静的検査する。
+                # 標準入力を空にし標準出力を破棄してBEGIN/ENDの副作用を抑える。
+                command = pkgs.writeShellApplication {
+                  name = "awk-lint";
+                  runtimeInputs = with pkgs; [ gawk ];
+                  text = ''
+                    for f in "$@"; do
+                      gawk --lint=fatal -f "$f" </dev/null >/dev/null
+                    done
+                  '';
+                };
+                includes = [ "*.awk" ];
+              };
               editorconfig-checker = {
                 command = pkgs.editorconfig-checker;
                 includes = [ "*" ];
@@ -390,6 +404,8 @@
               nix-fast-build
               qemu-user
               ;
+            # PRコメントにnvd diffを投稿するスクリプト。
+            nvd-pr-diff = pkgs.callPackage ./pkgs/nvd-pr-diff { };
           };
           devShells.default = pkgs.mkShell {
             buildInputs = with pkgs; [

--- a/pkgs/nvd-pr-diff/default.nix
+++ b/pkgs/nvd-pr-diff/default.nix
@@ -1,0 +1,53 @@
+# PRコメントにnvd diffを投稿するスクリプト。
+# スクリプト本体(nvd-pr-diff.sh)と、
+# awkフォーマット整形(format-for-markdown.awk)を、
+# 同一ディレクトリにインストールし、
+# 実行時に相対パスで参照します。
+{
+  lib,
+  runCommand,
+  makeWrapper,
+  shellcheck,
+  coreutils,
+  gawk,
+  gh,
+  git,
+  jq,
+  nix,
+  nvd,
+}:
+let
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./format-for-markdown.awk
+      ./nvd-pr-diff.sh
+    ];
+  };
+in
+runCommand "nvd-pr-diff"
+  {
+    nativeBuildInputs = [
+      makeWrapper
+      shellcheck
+    ];
+    meta.mainProgram = "nvd-pr-diff";
+  }
+  ''
+    shellcheck ${src}/nvd-pr-diff.sh
+    gawk --lint=fatal -f ${src}/format-for-markdown.awk </dev/null >/dev/null
+    install -Dm755 ${src}/nvd-pr-diff.sh $out/libexec/nvd-pr-diff/nvd-pr-diff.sh
+    install -Dm644 ${src}/format-for-markdown.awk $out/libexec/nvd-pr-diff/format-for-markdown.awk
+    makeWrapper $out/libexec/nvd-pr-diff/nvd-pr-diff.sh $out/bin/nvd-pr-diff \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gawk
+          gh
+          git
+          jq
+          nix
+          nvd
+        ]
+      }
+  ''

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -42,7 +42,9 @@ BEGIN { section = ""; has_content = 0; closure = "" }
 }
 
 END {
-  if (has_content == 0) print "no version changes"
+  if (has_content == 0) {
+    print "no package version changes"
+  }
   if (closure != "") {
     print ""
     print "Closure size: " closure

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -19,8 +19,10 @@ BEGIN { section = ""; has_content = 0; closure = "" }
 /^(<<<|>>>)/  { next }
 
 {
+  if ($3 ~ /^nixos-system-/) {
+    next
+  }
   if (section == "change") {
-    if ($3 ~ /^nixos-system-/) next
     type = substr($1, 2, 2)
     pkg = $3
     from = $4
@@ -30,7 +32,6 @@ BEGIN { section = ""; has_content = 0; closure = "" }
     print "- [" type "] " pkg ": " from " -> " to
     has_content = 1
   } else if (section == "added" || section == "removed") {
-    if ($3 ~ /^nixos-system-/) next
     type = substr($1, 2, 2)
     pkg = $3
     ver = ""

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -1,0 +1,49 @@
+# nvd diffの標準出力をMarkdownリストに整形するawkスクリプト。
+# Version changesセクションのnixos-system-*行は除外します。
+# nixos-system-*行はdotfiles更新で必ず変わるのでノイズになるためです。
+
+BEGIN { section = ""; has_content = 0; closure = "" }
+
+/^Version changes:/  { section = "change"; next }
+/^Removed packages:/ { section = "removed"; next }
+/^Added packages:/   { section = "added";   next }
+
+/^Closure size:/ {
+  section = ""
+  closure = $0
+  sub(/^Closure size:[[:space:]]*/, "", closure)
+  next
+}
+
+/^[[:space:]]*$/ { next }
+/^<<<|^>>>/ { next }
+
+{
+  if (section == "change") {
+    if ($3 ~ /^nixos-system-/) next
+    type = substr($1, 2, 1)
+    pkg = $3
+    from = $4
+    # $5 is "->"
+    to = ""
+    for (i = 6; i <= NF; i++) to = to (i == 6 ? "" : " ") $i
+    print "- [" type "] " pkg ": " from " -> " to
+    has_content = 1
+  } else if (section == "added" || section == "removed") {
+    if ($3 ~ /^nixos-system-/) next
+    type = substr($1, 2, 1)
+    pkg = $3
+    ver = ""
+    for (i = 4; i <= NF; i++) ver = ver (i == 4 ? "" : " ") $i
+    print "- [" type "] " pkg ": " ver
+    has_content = 1
+  }
+}
+
+END {
+  if (has_content == 0) print "no version changes"
+  if (closure != "") {
+    print ""
+    print "Closure size: " closure
+  }
+}

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -21,7 +21,7 @@ BEGIN { section = ""; has_content = 0; closure = "" }
 {
   if (section == "change") {
     if ($3 ~ /^nixos-system-/) next
-    type = substr($1, 2, 1)
+    type = substr($1, 2, 2)
     pkg = $3
     from = $4
     # $5 is "->"
@@ -31,7 +31,7 @@ BEGIN { section = ""; has_content = 0; closure = "" }
     has_content = 1
   } else if (section == "added" || section == "removed") {
     if ($3 ~ /^nixos-system-/) next
-    type = substr($1, 2, 1)
+    type = substr($1, 2, 2)
     pkg = $3
     ver = ""
     for (i = 4; i <= NF; i++) ver = ver (i == 4 ? "" : " ") $i

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -1,5 +1,5 @@
 # nvd diffの標準出力をMarkdownリストに整形するawkスクリプト。
-# Version changesセクションのnixos-system-*行は除外します。
+# nixos-system-*行は除外します。
 # nixos-system-*行はdotfiles更新で必ず変わるのでノイズになるためです。
 
 BEGIN { section = ""; has_content = 0; closure = "" }

--- a/pkgs/nvd-pr-diff/format-for-markdown.awk
+++ b/pkgs/nvd-pr-diff/format-for-markdown.awk
@@ -16,7 +16,7 @@ BEGIN { section = ""; has_content = 0; closure = "" }
 }
 
 /^[[:space:]]*$/ { next }
-/^<<<|^>>>/ { next }
+/^(<<<|>>>)/  { next }
 
 {
   if (section == "change") {

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -35,8 +35,32 @@ git worktree add --detach "$base_tree" -- "origin/$BASE_REF"
 host="seminar"
 attr=".#nixosConfigurations.\"$host\".config.system.build.toplevel"
 
-before=$(cd "$base_tree" && nix build --no-link --print-out-paths "$attr")
-after=$(nix build --no-link --print-out-paths "$attr")
+# wall-clockを短縮するためbase/PRのnix buildを並列実行します。
+# 評価フェーズで一時的にメモリ使用量が増えますが、
+# Nixデーモンが共有のロック機構を持っているのでビルド競合は起きません。
+# stderrの進捗表示は混ざりますが致命的ではないのでそのままにします。
+(cd "$base_tree" && nix build --no-link --print-out-paths "$attr" >"$workdir/before") &
+before_pid=$!
+nix build --no-link --print-out-paths "$attr" >"$workdir/after" &
+after_pid=$!
+
+# `set -e`下での`wait`の挙動はバージョン依存があるため、
+# 両方とも明示的にステータスを取って判定します。
+before_status=0
+after_status=0
+wait "$before_pid" || before_status=$?
+wait "$after_pid" || after_status=$?
+if [ "$before_status" -ne 0 ]; then
+  echo "Error: base nix build failed with status $before_status" >&2
+  exit "$before_status"
+fi
+if [ "$after_status" -ne 0 ]; then
+  echo "Error: PR nix build failed with status $after_status" >&2
+  exit "$after_status"
+fi
+
+before=$(<"$workdir/before")
+after=$(<"$workdir/after")
 
 MARKER='<!-- nvd-pr-diff -->'
 body_file="$workdir/body.md"

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -65,12 +65,13 @@ after=$(<"$workdir/after")
 MARKER='<!-- nvd-pr-diff -->'
 body_file="$workdir/body.md"
 
-if ! raw=$(nvd diff "$before" "$after" 2>&1); then
-  echo "Warning: nvd diff failed: $raw" >&2
+# stderrはキャプチャせずにそのまま継承し、CIログ側で確認できるようにします。
+if ! raw=$(nvd diff "$before" "$after"); then
+  echo "Warning: nvd diff failed" >&2
   {
     printf '%s\n' "$MARKER"
     printf '## nvd diff: %s\n\n' "$host"
-    printf 'nvd diff failed: %s\n' "$raw"
+    printf 'nvd diff failed. See workflow logs for details.\n'
   } >"$body_file"
 else
   listed=$(printf '%s\n' "$raw" | awk -f "$script_dir/format-for-markdown.awk")

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -62,10 +62,17 @@ fi
 # やむを得ず`gh api`を使用します。
 # 使用する機能がある程度固定化されているため、
 # そう危険ではないはずです。
-existing_id=$(gh api --paginate \
-  "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-  --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | startswith(\"$MARKER\")) | .id" |
-  head -n1)
+existing_id=$(gh api --paginate --slurp \
+  "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" |
+  jq -r "
+    first(
+      .[]
+      | .[]
+      | select(.user.login == \"github-actions[bot]\")
+      | select(.body | startswith(\"$MARKER\"))
+      | .id
+    ) // empty
+  ")
 
 if [ -n "$existing_id" ]; then
   jq -n --rawfile body "$body_file" '{body: $body}' |

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# base(master)とPR側のNix評価結果をnvdで比較し、
+# 差分をMarkdownリストに整形してPRコメントとしてupsertします。
+#
+# 必須環境変数:
+#   BASE_REF           PRのベースブランチ名 (例: master)
+#   PR_NUMBER          PR番号
+#   GITHUB_REPOSITORY  owner/repo
+#   GH_TOKEN           PRコメント投稿権限を持つGitHubトークン
+#
+# 依存しているコマンドを用意すれば単独でも実行可能です。
+
+: "${BASE_REF:?required: base branch}"
+: "${PR_NUMBER:?required: PR number}"
+: "${GITHUB_REPOSITORY:?required: owner/repo}"
+: "${GH_TOKEN:?required: GitHub API token}"
+
+script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+base_tree="$workdir/base"
+
+# base側をworktreeで別ディレクトリに展開します。
+git fetch origin "$BASE_REF"
+git worktree add --detach "$base_tree" "origin/$BASE_REF"
+
+# 評価対象はseminarのみ。
+# 他ホスト分はノイズが多いため当面は含めません。
+# home-managerはseminarのNixOSトップレベルに包含されるため別途は出しません。
+host="seminar"
+attr=".#nixosConfigurations.\"$host\".config.system.build.toplevel"
+
+before=$(cd "$base_tree" && nix build --no-link --print-out-paths "$attr")
+after=$(nix build --no-link --print-out-paths "$attr")
+
+MARKER='<!-- nvd-pr-diff -->'
+body_file="$workdir/body.md"
+
+if ! raw=$(nvd diff "$before" "$after" 2>&1); then
+  echo "Warning: nvd diff failed: $raw" >&2
+  {
+    printf '%s\n' "$MARKER"
+    printf '## nvd diff: %s\n\n' "$host"
+    printf 'nvd diff failed: %s\n' "$raw"
+  } >"$body_file"
+else
+  listed=$(printf '%s\n' "$raw" | awk -f "$script_dir/format-for-markdown.awk")
+  {
+    printf '%s\n' "$MARKER"
+    printf '## nvd diff: %s (base: %s)\n\n' "$host" "$BASE_REF"
+    printf '%s\n' "$listed"
+  } >"$body_file"
+fi
+
+# 既存コメントを検索してupsertします。
+# `gh pr comment`にはコメント編集機能がないため、
+# やむを得ず`gh api`を使用します。
+# 使用する機能がある程度固定化されているため、
+# そう危険ではないはずです。
+existing_id=$(gh api --paginate \
+  "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+  --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" |
+  head -n1)
+
+if [ -n "$existing_id" ]; then
+  jq -n --rawfile body "$body_file" '{body: $body}' |
+    gh api --method PATCH \
+      "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" \
+      --input - >/dev/null
+  echo "Updated comment $existing_id"
+else
+  gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file "$body_file"
+  echo "Created new comment"
+fi

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -64,7 +64,7 @@ fi
 # そう危険ではないはずです。
 existing_id=$(gh api --paginate \
   "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-  --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" |
+  --jq ".[] | select(.user.login == \"github-actions[bot]\") | select(.body | startswith(\"$MARKER\")) | .id" |
   head -n1)
 
 if [ -n "$existing_id" ]; then

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -24,8 +24,10 @@ trap 'rm -rf "$workdir"' EXIT
 base_tree="$workdir/base"
 
 # base側をworktreeで別ディレクトリに展開します。
-git fetch origin "$BASE_REF"
-git worktree add --detach "$base_tree" "origin/$BASE_REF"
+# private repoとかで失敗してもGitHub Actionsで取っていれば大丈夫なのでfallbackします。
+git fetch --no-tags origin -- "$BASE_REF" || true
+# こちらのworktreeは必要なので失敗したら全体失敗です。
+git worktree add --detach "$base_tree" -- "origin/$BASE_REF"
 
 # 評価対象はseminarのみ。
 # 他ホスト分はノイズが多いため当面は含めません。

--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -68,11 +68,8 @@ body_file="$workdir/body.md"
 # stderrはキャプチャせずにそのまま継承し、CIログ側で確認できるようにします。
 if ! raw=$(nvd diff "$before" "$after"); then
   echo "Warning: nvd diff failed" >&2
-  {
-    printf '%s\n' "$MARKER"
-    printf '## nvd diff: %s\n\n' "$host"
-    printf 'nvd diff failed. See workflow logs for details.\n'
-  } >"$body_file"
+  printf 'nvd diff failed. See workflow logs for details.\n' >&2
+  exit 1
 else
   listed=$(printf '%s\n' "$raw" | awk -f "$script_dir/format-for-markdown.awk")
   {


### PR DESCRIPTION
Renovateなどによる更新PRで具体的にどのパッケージが更新されたかが分からない問題を解消します。
LLMは使わず、Nixバイナリキャッシュと`nvd diff`のテキスト出力から差分を抽出します。

新ワークフロー`nvd-diff.yml`は`check`ワークフローの完了を`workflow_run`でトリガに動かし、
ビルドキャッシュのヒット率を高めます。
セルフホストランナーは不要なため`ubuntu-24.04`で動作させ、
`workflow_run.pull_requests[0]`のガードでフォークPRを自動的に除外します。

評価対象は当面`seminar`ホストのみとし、
`Version changes`セクションのうち`nixos-system-*`はdotfiles更新で必ず変わるノイズなので除外します。
home-managerはNixOSトップレベルに包含されるため別途は出しません。

スクリプト本体は`pkgs/nvd-pr-diff/`に分離し、
シェル(`nvd-pr-diff.sh`)とawk整形ロジック(`format-for-markdown.awk`)を独立ファイルとして同梱します。
`runCommand`と`lib.fileset.toSource`で配置、
`makeWrapper`でPATHを通した`$out/bin/nvd-pr-diff`を生成し、
ビルド時に`shellcheck`と`gawk --lint=fatal`で静的検査も行います。

合わせて`treefmt`に`awk-lint`フォーマッタを追加し、
リポジトリ内の`.awk`ファイルを継続的にlintできるようにしました。

close #923
