### PR TITLE
ci: kyoseiのdisplay_reportを有効にする

### DIFF
--- a/.github/workflows/kyosei.yml
+++ b/.github/workflows/kyosei.yml
@@ -17,5 +17,7 @@ jobs:
       contents: read # Read repository contents for checkout
       id-token: write # GitHub App token exchange via OIDC (needed regardless of Claude API auth method)
     uses: ncaq/kyosei-action/.github/workflows/review.yml@49fc39967b97b97710e092a79c84e6d10d446670 # v1.5.1
+    with:
+      display_report: "true" # もともと大して危険ではないし、kyoseiの動きを見るために有効にします。
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
このよくkyoseiを動かすリポジトリで`display_report`を有効にして、
バグっぽい挙動が発生したときにレポートを見れるようにします。
元々対して危険な代物ではなく、
このリポジトリのGitHub Actions Secretsには、
キャッシュにアップロードするためのトークンか、
Claude Codeにログインするためのトークンぐらいしか入っていないので、
キャッシュは内容をwipeしてトークンをrevokeすれば良く、
Claude Codeのトークンもrevokeすれば良いので、
もしGitHub ActionsのSecretが漏れても致命的な問題にはなりません。
