### PR TITLE
feat(alacritty): modus_vivendiテーマを上流参照で有効化

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "alacritty-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777042535,
+        "narHash": "sha256-hmzuxCD492TptCPOzpnLJTDhmBxoxUDuKM7euccoEwA=",
+        "owner": "alacritty",
+        "repo": "alacritty-theme",
+        "rev": "c378fd7f31a202170b03427838a9f4a49ab746d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "alacritty",
+        "repo": "alacritty-theme",
+        "type": "github"
+      }
+    },
     "claude-desktop": {
       "inputs": {
         "flake-utils": [
@@ -544,6 +560,7 @@
     },
     "root": {
       "inputs": {
+        "alacritty-theme": "alacritty-theme",
         "claude-desktop": "claude-desktop",
         "disko": "disko",
         "dot-emacs": "dot-emacs",

--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,15 @@
       url = "github:ncaq/firge-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # nixpkgs側にまだ求めている更新がないため、
+    # 上流から直接最新のテーマを取得します。
+    # nixpkgsのalacritty-theme derivationを`overrideAttrs`で再利用するので、
+    # `flake = false`で生のソースだけを参照します。
+    alacritty-theme = {
+      url = "github:alacritty/alacritty-theme";
+      flake = false;
+    };
   };
 
   outputs =

--- a/home/core/alacritty.nix
+++ b/home/core/alacritty.nix
@@ -7,18 +7,28 @@
   ...
 }:
 let
-  alacrittyConfigFile = config.xdg.configFile."alacritty/alacritty.toml".source;
   inherit (osConfig.wsl) windowsAppData;
+  # UNIX環境で最優先される設定パスの場所は`$XDG_CONFIG_HOME/alacritty/alacritty.toml`です。
+  alacrittyConfigFile = config.xdg.configFile."alacritty/alacritty.toml".source;
+  # Windows環境(WSLではなく)では設定パスの場所は`%APPDATA%\alacritty\alacritty.toml`です。
   windowsAlacrittyConfigFile = "${windowsAppData}/alacritty/alacritty.toml";
 in
 {
   programs.alacritty = {
+    # WSL環境ではホストのWindowsのAlacrittyを使用したほうが良いため、
+    # 本来はWSL環境では有効にする必要はありません。
+    # しかし有効にしないと設定ファイルも生成されないため、
+    # ややこしくなります。
+    # よって全ての環境で`enable`にしています。
+    # 軽量なパッケージなのでインストールの負担にはあまりなりません。
+    # WindowsホストのAlacrittyはwingetでインストールすることを想定しています。
     enable = true;
-    package = pkgs.alacritty-graphics; # 画像表示対応版を選択。
-    # TODO: themeにmodus-vivendiを追加して設定します。
+    # 画像表示対応版を選択。
+    package = pkgs.alacritty-graphics;
+    # TODO: themeにmodus_vivendiを追加して設定します。
+    # theme = "modus_vivendi";
+    # themePackage = pkgs.alacritty-themes;
 
-    # UNIX環境で最優先されるパスは`$XDG_CONFIG_HOME/alacritty/alacritty.toml`であり、
-    # Windows環境(WSLではなくWindowsネイティブの話)では`%APPDATA%\alacritty\alacritty.toml`です。
     settings = {
       window = {
         decorations = "None"; # タイトルバーを消す。
@@ -31,10 +41,7 @@ in
         size = 12;
       };
       # Windows環境で起動したときはWSLのシェルを起動するようにします。
-      # WSLのalacrittyを起動することはあまり考慮していません。
-      # 話を単純にするために全ての環境でenableにしているだけなので。
-      # 軽量なパッケージなのでインストールの負担にもあまりなりません。
-      # Windowsのalacrittyはwingetでインストールすることを想定しています。
+      # WSLのalacrittyを起動することは考慮していません。
       terminal = lib.mkIf isWSL {
         shell = {
           program = "wsl.exe";
@@ -62,6 +69,11 @@ in
   };
 
   home.activation.deployAlacrittyConfigToWindows = lib.mkIf isWSL (
+    # WSL環境ではホストのWindows環境に設定ファイルを書き込みます。
+    # ブートストラップ問題は、
+    # これのインストール時ぐらいは、
+    # Windows Terminalとか適当なターミナルをを使えばいいので、
+    # 深刻に考えていません。
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       if [ -d ${lib.escapeShellArg windowsAppData} ]; then
         $DRY_RUN_CMD mkdir -p "$(dirname ${lib.escapeShellArg windowsAlacrittyConfigFile})"

--- a/home/core/alacritty.nix
+++ b/home/core/alacritty.nix
@@ -4,6 +4,7 @@
   config,
   isWSL,
   osConfig,
+  inputs,
   ...
 }:
 let
@@ -12,6 +13,15 @@ let
   alacrittyConfigFile = config.xdg.configFile."alacritty/alacritty.toml".source;
   # Windows環境(WSLではなく)では設定パスの場所は`%APPDATA%\alacritty\alacritty.toml`です。
   windowsAlacrittyConfigFile = "${windowsAppData}/alacritty/alacritty.toml";
+  # `modus_vivendi`はnixpkgsピン時点ではまだ含まれていないため、
+  # 上流リポジトリの最新版を直接参照したテーマパッケージを構築します。
+  # nixpkgsのderivationを`overrideAttrs`で再利用して`installPhase`等の重複を避けます。
+  # flake input側に`name`属性が無いため、`sourceRoot`も明示的に上書きします。
+  alacrittyThemeLatest = pkgs.alacritty-theme.overrideAttrs (_: {
+    version = "0-unstable-${inputs.alacritty-theme.shortRev}";
+    src = inputs.alacritty-theme;
+    sourceRoot = "source/themes";
+  });
 in
 {
   programs.alacritty = {
@@ -25,9 +35,8 @@ in
     enable = true;
     # 画像表示対応版を選択。
     package = pkgs.alacritty-graphics;
-    # TODO: themeにmodus_vivendiを追加して設定します。
-    # theme = "modus_vivendi";
-    # themePackage = pkgs.alacritty-themes;
+    theme = "modus_vivendi";
+    themePackage = alacrittyThemeLatest;
 
     settings = {
       window = {


### PR DESCRIPTION
alacritty/alacritty-theme`の`modus_vivendi.toml`を追加するPRはマージ済みですが(2026-04-24)、
nixpkgsの`alacritty-theme`は2025-11-16ピンのままで、stableにもunstableにも反映されていません。
nixpkgsの取り込みを待たずに最新テーマを使うため、上流リポジトリを直接参照する構造に切り替えます。

`alacritty-theme`を`flake = false`のflake inputとして追加し、
`pkgs.alacritty-theme.overrideAttrs`で`src`を差し替える形にしました。
nixpkgs側のderivation(themesディレクトリの`*.toml`を`$out/share/alacritty-theme/`にコピーするだけ)を再利用するので、
`installPhase`を独自に書く必要がなく差分が最小です。
flake input側には`name`属性が無く元の`sourceRoot = "${self.src.name}/themes"`が解決できないため、
`sourceRoot`は`source/themes`に明示的に上書きしています。

flake inputにすることで、Renovateの`lock-file maintenance`で自動的にrev/hashが更新されます。
将来nixpkgs本体に取り込まれたら、このoverride自体を削除して`pkgs.alacritty-theme`に戻せます。
