### PR TITLE
feat(git): グローバルignoreに`scheduled_tasks.lock`を追加

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -48,6 +48,7 @@ in
         github.user = "ncaq";
       };
       ignores = [
+        "**/.claude/scheduled_tasks.lock"
         "**/.claude/settings.local.json"
         ".DS_Store"
         ".codex"


### PR DESCRIPTION
Claude Codeがバックグラウンドタスクやスケジュール機構の排他制御に使う`.claude/scheduled_tasks.lock`を、 グローバルなgitignoreに追加します。
プロジェクトに紛れ込むことがあるため、各リポジトリで個別にignoreするより一括で除外する方が便利です。