### PR TITLE
fix(nvd-pr-diff): パッケージ行をインラインコードで囲んでGitHubの誤オートリンクを抑止

### DIFF
--- a/pkgs/nvd-pr-diff/nvd-pr-diff.sh
+++ b/pkgs/nvd-pr-diff/nvd-pr-diff.sh
@@ -91,7 +91,7 @@ fi
     'Closure size:'*) printf '%s\n' "$line" ;;
     '') printf '\n' ;;
     *nixos-system-*) ;;
-    *) printf -- '- %s\n' "$line" ;;
+    *) printf -- "- \`%s\`\n" "$line" ;;
     esac
   done <<<"$diff_output"
 } >"$body_file"


### PR DESCRIPTION
`nvd diff`の出力にはバージョン文字列の一部として`#1`のような文字列が含まれており、
そのままMarkdownに流すとGitHubがissueなどへのリンクとして自動リンク化してしまい、
PRに無関係なissue/PRリンクが大量に貼られる問題がありました。
パッケージ行をバッククォートで囲んでインラインコード化することでオートリンクを抑止します。

shellcheckのSC2016誤検知を避けるためフォーマット文字列はダブルクォートにし、
バッククォートを`\``でエスケープしています。
