### PR TITLE
ci: build-home-managerをセルフホステッドランナーで動かすようにする

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,10 +122,13 @@ jobs:
 
   build-home-manager:
     name: build-home-manager
+    needs: is-trusted
     permissions:
       contents: read
       id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
-    runs-on: ubuntu-24.04
+    # セルフホステッドランナーは未認証のソースからは実行しない。
+    if: needs.is-trusted.result == 'success'
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -21,7 +21,7 @@ let
   # あまりCPUを使い切れなくても、
   # Nixが動く時は大抵はキャッシュダウンロードのIO待ちなので、
   # 並列動作したほうが効率的です。
-  runnerNum = 4;
+  runnerNum = 5;
   # runnerが使うTypeScriptコードをビルドしてGitHub Actionsで利用できるようにします。
   # 吐き出されるコードはピュアなJavaScriptなのでアーキテクチャ非依存です。
   dotfiles-github-runner = pkgs.buildNpmPackage {


### PR DESCRIPTION
home-managerのビルドなら比較的軽いからディスクが無くなることはないだろうと思ったのですが、
大幅にキャッシュが切れると普通にディスクが足りなくなります。
キャッシュのダウンロード速度による実行待ち時間も結構あるので、
セルフホストランナーによる実行に戻します。
全体のボトルネックになっているのが`build-home-manager`から、
おそらく`test-nixos-boot`になり、
チェックが通るまでの速度が改善されるはずです。

またそれに伴い、
セルフホストランナーの並列インスタンス数を1つ増やしました。
