### PR TITLE
ci(nvd-diff): セルフホストランナーでビルドキャッシュを共有

### DIFF
--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read # リポジトリコンテンツの読み取り
       pull-requests: write # PRコメントのupsert
       id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
`nvd-diff`ワークフローは`ubuntu-24.04`のGitHubホステッドランナーで動いていたため、
`build-nixos`ジョブがseminar上の`/nix/store`に既に積み上げたクロージャを、
cachix/niks3経由で再ダウンロードする必要があり、
キャッシュヒット前提の想定よりも実行時間が大幅に伸びていました。

`runs-on`を`[self-hosted, Linux]`に切り替え、
build-nixosと同じseminarホスト上で動かすようにします。
self-hostedランナーはephemeralですがNixストアはホスト側で共有されるため、
build-nixosの成果物がそのまま再利用されダウンロードはほぼ不要になります。

`workflow_run`トリガによるワークフロー分離は維持しているので、
checkとnvd-diffの論理的な区分けは保たれます。
フォーク除外などは既存の`workflow_run.head_repository.full_name == github.repository`ガードで引き続き担保されます。
