### PR TITLE
build(deps-dev): programming-tasukeスキルを有効にする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
   "enabledPlugins": {
     "kyosei@konoka": true,
     "nix-tasuke@konoka": true,
+    "programming-tasuke@konoka": true,
     "web-tasuke@konoka": true
   },
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
konoka v6.3.0で追加されたprogramming-tasukeスキルを有効にします。