### PR TITLE
fix(cifs): SMBダイアレクトを明示指定して警告を抑止

### DIFF
--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -54,6 +54,11 @@ lib.mkMerge [
             "nosuid"
             # パフォーマンス
             "noatime"
+            # SMBダイアレクトを明示的に指定。
+            # 未指定だとkernelが`No dialect specified on mount`の警告を出す。
+            # `vers=3`はSMB3.0以上を意味し、ネゴシエーションで3.x系の最新版が選択される。
+            # SMB1/SMB2系を排除しつつ、将来のマイナーバージョン更新にも自動追従する。
+            "vers=3"
           ];
           mountConfig = {
             TimeoutSec = 30;


### PR DESCRIPTION
`mount.cifs`に`vers=`オプションを指定しないと、
kernelが`CIFS: No dialect specified on mount.`の警告を出します。
デフォルトの自動ネゴシエーション挙動を利用者に通知する目的の警告です。

`vers=3`を追加することで明示的にSMB3.0以上を要求しつつ、
ネゴシエーションで3.x系の最新版が選択されるようにします。
`vers=3.1.1`のようにフルバージョンを固定すると、
プロトコルにセキュリティ修正を含むマイナーアップデートが入っても、
古い版を使い続けるリスクがあるため、
家族版指定を採用します。
renovateなどが管理してくれるならフルバージョン指定で構わないのですが、
そうではないので互換性だけを気にして最新バージョンを指定します。
SMB1/SMB2系は排除されるためセキュリティ的にも妥当です。
