### PR TITLE
feat: switch from trashy to trash-cli

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -29,7 +29,7 @@ lib.mkMerge [
     home.activation.cleanupGpgStaleLocks =
       lib.hm.dag.entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ]
         ''
-          $DRY_RUN_CMD ${pkgs.trashy}/bin/trash "${config.programs.gpg.homedir}/gnupg_spawn_agent_sentinel.lock" 2>/dev/null || true
+          $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash "${config.programs.gpg.homedir}/gnupg_spawn_agent_sentinel.lock" 2>/dev/null || true
         '';
     home.packages = with pkgs; [ paperkey ];
   }
@@ -73,7 +73,7 @@ lib.mkMerge [
           # stale lockのない状態で鍵を再インポートします。
           activation.cleanupGpgKeyboxd = lib.hm.dag.entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
             $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
-            $DRY_RUN_CMD ${pkgs.trashy}/bin/trash "${config.home.homeDirectory}/.gnupg/public-keys.d/" 2>/dev/null || true
+            $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash "${config.home.homeDirectory}/.gnupg/public-keys.d/" 2>/dev/null || true
           '';
           packages = with pkgs; [
             pinentry-curses

--- a/home/core/misc.nix
+++ b/home/core/misc.nix
@@ -6,7 +6,7 @@
     plantuml
     sqlite
     strace
-    trashy
+    trash-cli
     wl-clipboard
   ];
 }


### PR DESCRIPTION
`trash empty`が正常に働かないバグが存在しています。
上流のリポジトリの、
[oberblastmeister/trashy: a cli system trash manager, alternative to rm and trash-cli](https://github.com/oberblastmeister/trashy)
を見ても二年ぐらい放置されているため、
むしろ広く使われているtrash-cliに戻すことにしました。
そもそも前はtrash-cliを使っていたのですが、
なぜtrashyに切り替えたのかは覚えていません。
