### PR TITLE
ci(renovate): lockFileMaintenanceのscheduleをat any timeに変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
   "ignorePresets": [":maintainLockFilesWeekly", ":maintainLockFilesMonthly"],
   "lockFileMaintenance": {
     "enabled": true,
-    "extends": ["schedule:daily"]
+    "schedule": ["at any time"]
   }
 }


### PR DESCRIPTION
`schedule:daily`プリセットは`* 0-3 * * *`(JST 0-3時)に展開されますが、
Mend Renovate cloudの実行タイミングがその時間帯に入るとは限らないため、
`not-scheduled`でPR作成がスキップされてlockfileが更新されない状態でした。

`at any time`にすることでRenovateは任意のタイミングで動作して、
`lockFileMaintenance`内部のクールダウンによってdaily相当の頻度で更新されます。
