### PR TITLE
feat(claude-code): deny `git rm`

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -454,6 +454,7 @@ in
           "Bash(gh * delete:*)"
           "Bash(gh repo archive:*)"
           "Bash(gh repo rename:*)"
+          "Bash(git rm:*)"
           "Bash(rm:*)"
         ];
       };


### PR DESCRIPTION
`git rm`も`rm`と同じく復元不可能な削除を行うコマンドなので拒否することにします。
副作用として`git rm --cached`も禁止してしまいますが、
トラッキングから外す処理は稀なので、
そういう稀に必要な時は手動で行うことにします。

ref https://github.com/ncaq/konoka/issues/215
