### PR TITLE
fix(ccstatusline): 2.2.12に更新してthinking effort表示を修正

### DIFF
--- a/pkgs/ccstatusline.nix
+++ b/pkgs/ccstatusline.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation rec {
   pname = "ccstatusline";
-  version = "2.2.7";
+  version = "2.2.12";
 
   src = fetchurl {
     url = "https://registry.npmjs.org/${pname}/-/${pname}-${version}.tgz";
-    hash = "sha256-vMAoLVLSpY+cov1doxX7247c79H+3fQlxUAffYqfD/Q=";
+    hash = "sha256-m1bXfJlf0CJWmGlFzf980FRLMugVKwtotn36i0dCcgw=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
`2.2.7`では`xhigh`等のthinking effortを正しく解釈できず、
常に`medium`と誤って表示される問題がありました。
`2.2.12`にはstatus JSONからthinking effortを読み取る修正と、
`/effort`コマンドによる変更検出の修正、
`xhigh`サポートの追加が含まれています。

close #993
