### PR TITLE
feat: remove license-generator

### DIFF
--- a/home/core/misc.nix
+++ b/home/core/misc.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    license-generator
     openssl
     plantuml
     sqlite


### PR DESCRIPTION
ライセンスを正しく適用しているかは難しい話。
例えばApache-2.0はライセンスファイルを改変しないはずですが、
署名を改変してしました。
ではバグ報告をするべきと言うと本当に改変しないのか自信がありません。
個別に処理していくべき話なので、
このジェネレータは安易に使わないように削除することにします。
