### PR TITLE
test: ブートテストのCPUとメモリの割り当てを増やす

### DIFF
--- a/nixos/test/vm-override.nix
+++ b/nixos/test/vm-override.nix
@@ -16,8 +16,8 @@ lib.mkMerge [
     # 多めに設定していても破綻はしませんが、
     # リソース制限をわかりやすくするためにこちらでも記述しておきます。
     virtualisation = {
-      cores = 6;
-      memorySize = 4096;
+      cores = 11; # CPUは奪い合っても問題ないリソースなので12スレッドのうち11スレッド割り当てます。
+      memorySize = 6 * 1024; # 6GB。並列に動かすことを考えて控えめにします。
     };
 
     # NixOSテストフレームワークがrootに`hashedPasswordFile`を自動設定するため、


### PR DESCRIPTION
CPUは割と雑に設定しても問題ないリソースで、
メモリももう少し多めに割り当てても良いのでキャッシュヒットとかを増やして高速に動いてほしいので、
割り当て量を増やします。
