### PR TITLE
fix: swapサイズを抑えてOOM Killerが働く状態にする

### DIFF
--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -184,7 +184,7 @@ _: {
   swapDevices = [
     {
       device = "/swap/swapfile";
-      size = 32 * 1024;
+      size = 8 * 1024;
     }
   ];
   boot = {

--- a/nixos/native-linux/zram.nix
+++ b/nixos/native-linux/zram.nix
@@ -1,3 +1,12 @@
 _: {
-  zramSwap.enable = true;
+  zramSwap = {
+    enable = true;
+    # swapサイズが大きすぎるせいか、
+    # 異常にメモリを消費する動作が起きると、
+    # OOM Killerも動かずにシステム全体が固まってしまうことがあります。
+    # なのでzramにより設定されるswapサイズを制限します。
+    # `memoryPercent`か`memoryMax`のうち小さいほうがサイズになります。
+    memoryPercent = 20;
+    memoryMax = 8 * 1024 * 1024 * 1024; # 8GB
+  };
 }

--- a/nixos/native-linux/zram.nix
+++ b/nixos/native-linux/zram.nix
@@ -7,6 +7,6 @@ _: {
     # なのでzramにより設定されるswapサイズを制限します。
     # `memoryPercent`か`memoryMax`のうち小さいほうがサイズになります。
     memoryPercent = 20;
-    memoryMax = 8 * 1024 * 1024 * 1024; # 8GB
+    memoryMax = 6 * 1024 * 1024 * 1024; # 6GB
   };
 }


### PR DESCRIPTION
zramと物理swapfileのサイズがいずれも過剰だったため、
swapが大量に消費されている間にOOM Killerが動作せず、
システム全体が固まる挙動を引き起こしていました。

zramについては`memoryPercent`と`memoryMax`の小さい方が採用される仕様を利用し、
20%かつ最大6GBに制限します。
seminarホストの物理swapfileについても、
サーバ用途とはいえ32GBは過剰だったため8GBに縮小します。

これでも足りないケースが出たら、
そのときに再度見直します。
