### PR TITLE
feat: tmuxの設定から使っていない・邪魔な要素を整理

### DIFF
--- a/home/core/tmux.nix
+++ b/home/core/tmux.nix
@@ -86,11 +86,9 @@ in
         set -g set-titles on
         set -g set-titles-string "#{pane_title}"
 
-        # ステータスバー右の時刻表記をISO 8601形式にします
-        set -g status-right-length 60 # 日時で24文字でタイトルで30文字なので24+30=54なので余裕を持って60にします。
-        set -g status-right " \"#{=30:pane_title}\" %Y-%m-%dT%H:%M:%S%z"
-        # tmuxの秒更新のデフォルトは15秒なので、秒表示をしたいので1秒更新にします
-        set -g status-interval 1
+        # ステータスバー右にはペインタイトルを表示
+        set -g status-right-length 40
+        set -g status-right " \"#{=30:pane_title}\""
 
         # ウィンドウ名にはディレクトリとプロセスを表示
         set -g allow-rename on

--- a/home/core/tmux.nix
+++ b/home/core/tmux.nix
@@ -1,40 +1,7 @@
-{ pkgs, lib, ... }:
-let
-  tmux-trash-window = pkgs.writeShellApplication {
-    name = "tmux-trash-window";
-    runtimeInputs = [ pkgs.tmux ];
-    text = ''
-      if [ "$(tmux display-message -p '#{session_windows}')" -eq 1 ]; then
-        tmux new-window -d
-      fi
-      if ! tmux has-session -t trash 2>/dev/null; then
-        tmux new-session -d -s trash
-      fi
-      tmux move-window -t trash:
-    '';
-  };
-
-  tmux-restore-window = pkgs.writeShellApplication {
-    name = "tmux-restore-window";
-    runtimeInputs = with pkgs; [
-      fzf
-      gawk
-      tmux
-    ];
-    text = ''
-      window=$(tmux list-windows -t trash -F '#{window_index} #{b:pane_current_path}/#{pane_current_command}' 2>/dev/null |
-        fzf-tmux -p --prompt='restore window> ')
-      if [ -n "$window" ]; then
-        idx=$(echo "$window" | awk '{print $1}')
-        tmux move-window -a -s "trash:$idx" -t .
-      fi
-    '';
-  };
-in
+{ pkgs, ... }:
 {
-  # テキストの容量は大したことがないと考えているため、
-  # 履歴は大きめに取り、
-  # セッションの状態も積極的に保存する設定にしています。
+  # テキストの容量は現代では大したことがないと考えているため、
+  # 履歴は大きめに取る設定にしています。
   programs = {
     tmux = {
       enable = true;
@@ -77,11 +44,6 @@ in
         # クリップボードを連携
         set -g set-clipboard on
 
-        # セッションをなるべく維持する
-        set -g detach-on-destroy off
-        set -g remain-on-exit on
-        set-hook -g pane-died 'if -F "#{&&:#{==:#{session_windows},1},#{==:#{window_panes},1}}" "respawn-pane" ""'
-
         # プログラムが設定したタイトルを許可
         set -g set-titles on
         set -g set-titles-string "#{pane_title}"
@@ -114,12 +76,8 @@ in
         # ctrl+alt+o = 新規ウィンドウ(タブ)、同じディレクトリで開始
         bind -n C-M-o new-window -a -c "#{pane_current_path}"
 
-        # ctrl+alt+q = ウィンドウをゴミ箱セッションに退避(復元可能)
-        # セッション最後のウィンドウの場合は先に新しいウィンドウを作成してから退避する
-        bind -n C-M-q run-shell "${lib.getExe tmux-trash-window}"
-
-        # alt+o = ゴミ箱セッションからウィンドウをfzfで選択して復元
-        bind -n M-o run-shell "${lib.getExe tmux-restore-window}"
+        # ctrl+alt+q = ウィンドウを閉じる
+        bind -n C-M-q kill-window
 
         # ウィンドウ移動
         bind -n C-M-n next-window

--- a/home/core/tmux.nix
+++ b/home/core/tmux.nix
@@ -18,8 +18,6 @@
       terminal = "tmux-256color";
       shell = "${pkgs.zsh}/bin/zsh";
 
-      tmuxp.enable = true;
-
       plugins = with pkgs.tmuxPlugins; [
         continuum
         resurrect


### PR DESCRIPTION
tmuxの設定を見直し、画面領域を無駄に消費する要素や使っていない機能、
プロセスがいつまでも残ることに違和感のあった機構を整理します。

ステータスバー右の日時表示は他から確認できることが多く必須情報ではなく、
特にAndroid端末などの狭い画面では無視できない領域を取ってしまっていたため削除しました。
合わせて秒単位更新のために設定していた`status-interval 1`もデフォルトに戻しています。

ゴミ箱セッションへ移動して後で復元する独自のウィンドウ退避機構は、
プロセスがずっと残り続けることに気味の悪さを感じるようになったため撤廃します。
`remain-on-exit on`や`pane-died`フックでプロセス終了後もペインを維持する振る舞いも同様に削除します。
`C-M-q`は機能的に同じ「ウィンドウを閉じる」役割として`kill-window`に置き換えて残しています。

実質的に使っていなかった`tmuxp`の有効化も撤回しました。
