### PR TITLE
fix(flake): niks3のflake-partsのoverrideを削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
       url = "github:Mic92/niks3";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-parts.follows = "flake-parts";
         treefmt-nix.follows = "treefmt-nix";
       };
     };


### PR DESCRIPTION
向こう側で使うことが無くなったので、
無駄にoverrideしていると警告が出ます。
