### PR TITLE
feat(seminar): swapファイルサイズを64GiBに拡張

### DIFF
--- a/home/prompt/environment/hardware.md
+++ b/home/prompt/environment/hardware.md
@@ -146,10 +146,11 @@ ThinkPadですが指紋センサーはありません。
 - Vulkan: 1.4.318 - radv [Mesa 25.2.6]
 - OpenGL: 4.6 (Compatibility Profile) Mesa 25.2.6
 - Memory: 61.89 GiB
-- Swap: 24.00 GiB
-- Disk (/): 367.78 GiB / 929.51 GiB (40%) - btrfs
+- Swap: 72.00 GiB
+- Disk (/): 402.35 GiB / 929.51 GiB (43%) - btrfs
 - Disk (/mnt/noa): 2.61 TiB / 12.73 TiB (20%) - btrfs
 - Output
+- Sound: Dummy Output (100%)
 - Input
 
 ## スマートデバイス

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -186,7 +186,7 @@ _: {
   swapDevices = [
     {
       device = "/swap/swapfile";
-      size = 16 * 1024;
+      size = 64 * 1024; # 物理メモリのサイズと合わせています。
     }
   ];
   boot = {


### PR DESCRIPTION
サーバに限ってswapサイズを大幅に拡張し直します。

並列度の高い処理を行うと、
メモリに空きは残したままswapをマックスまですぐに使い切る挙動が頻発するからです。

swapを大量に使った後メモリに戻さずにすぐswapがクリアされるので、
まともにアクセスしないメモリが大量に確保されて破棄されているのでしょう。
そういう処理にはswapが有効のはずです。

クライアントPCで物理swapを有効にしていないのは、
メモリとswapを使いまくるような暴走した処理はさっさとOOM Killerに殺されるべきだからです。
しかしサーバでは処理が多少暴走したとしても殺されると困りますし、
しばらく動作が遅くなることが許容できるので、
応答が多少遅延したとしても処理の完遂を優先させます。
