### PR TITLE
feat(starship): シェルプロンプトのstatus表示位置を一行目の最後に移動

### DIFF
--- a/home/core/starship.nix
+++ b/home/core/starship.nix
@@ -4,7 +4,7 @@ _: {
 
     settings = {
       # 2行で表示する。
-      # 1行目には情報をあるだけたくさん表示する。
+      # 1行目には情報をあるだけたくさん表示する。`$status`は一番右側に表示する。
       # 2行目にはDebian風のシンプルなプロンプトを表示する。
       # 2行目をシンプルにしているのは、他の人やLLMに例示する時に誤解されにくいようにするため。
       format = "$time$all\n$username$hostname$directory$character";

--- a/home/core/starship.nix
+++ b/home/core/starship.nix
@@ -9,7 +9,7 @@ _: {
       # 2行目をシンプルにしているのは、他の人やLLMに例示する時に誤解されにくいようにするため。
       format = "$time$all\n$username$hostname$directory$character";
       line_break = {
-        # allの中に含まれてしまっているので、
+        # `$line_break`が`$all`の中に含まれてしまっているので、
         # 自分で改行を制御するために無効化します。
         disabled = true;
       };

--- a/home/core/starship.nix
+++ b/home/core/starship.nix
@@ -7,11 +7,21 @@ _: {
       # 1行目には情報をあるだけたくさん表示する。
       # 2行目にはDebian風のシンプルなプロンプトを表示する。
       # 2行目をシンプルにしているのは、他の人やLLMに例示する時に誤解されにくいようにするため。
-      format = "$time$status$all$username$hostname$directory$character";
+      format = "$time$all\n$username$hostname$directory$character";
+      line_break = {
+        # allの中に含まれてしまっているので、
+        # 自分で改行を制御するために無効化します。
+        disabled = true;
+      };
       time = {
         format = "[$time]($style) ";
         time_format = "%Y-%m-%dT%H:%M:%S";
         disabled = false;
+      };
+      status = {
+        disabled = false;
+        map_symbol = true;
+        pipestatus = true;
       };
       username = {
         format = "[$user]($style)@";
@@ -24,9 +34,6 @@ _: {
       directory = {
         truncation_length = 100;
         truncate_to_repo = false;
-      };
-      status = {
-        disabled = false;
       };
     };
   };


### PR DESCRIPTION
コマンド実行結果が小さいところに入り込むと、
実行結果が成功したのか失敗したのかわかりにくいため。

`$status`は`$all`のデフォルトのフォーマットに入っています。

starshipの重複させないロジックの都合上、
`$all`の前に置いたら前のごちゃっとしたところに表示されます。

デフォルトのフォーマットでは改行の後に表示されてしまうため、
`line_break`モジュールを無効化して、
`$status`が表示された後に改行されるようにしました。

またformatのデフォルト設定が変わったら、
それはその時に考えます。

またstatusの設定を追加して、
追加絵文字で失敗原因をわかりやすく表示するようにしました。
