### PR TITLE
feat(javascript): JSパッケージマネージャでリリース後3日のクールダウンを設定

### DIFF
--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -1,4 +1,9 @@
 { pkgs, ... }:
+let
+  releaseAgeDays = 3;
+  releaseAgeMinutes = releaseAgeDays * 24 * 60;
+  releaseAgeSeconds = releaseAgeMinutes * 60;
+in
 {
   # サプライチェーン攻撃のリスク低減として、
   # 各JavaScriptパッケージマネージャで、
@@ -11,26 +16,26 @@
   # npm CLIの`min-release-age`(単位: 日)。
   # home-managerには`programs.npm`がないため`home.file`で直接生成します。
   home.file.".npmrc".text = ''
-    min-release-age=3
+    min-release-age=${toString releaseAgeDays}
   '';
 
   # pnpmはhome-manager専用モジュールがないため設定ファイルを直接書きます。
   # pnpmは`~/.config/pnpm/config.yaml`を読みます(単位: 分)。
   xdg.configFile."pnpm/config.yaml".text = ''
-    minimumReleaseAge: 4320
+    minimumReleaseAge: ${releaseAgeSeconds}
   '';
 
   # Yarn Berryの`npmMinimalAgeGate`(単位: 分)。
   programs = {
     yarn = {
       enable = true;
-      settings.npmMinimalAgeGate = 4320;
+      settings.npmMinimalAgeGate = releaseAgeMinutes;
     };
 
     # Bunの`minimumReleaseAge`(単位: 秒)。
     bun = {
       enable = true;
-      settings.install.minimumReleaseAge = 259200;
+      settings.install.minimumReleaseAge = releaseAgeSeconds;
     };
   };
 

--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -6,8 +6,9 @@
   # 悪意あるパッケージがpublishされてから検出・取り下げされるまでの猶予を確保する目的です。
   # 各PMで設定キー名・単位が異なる点に注意。
 
+  # Denoはユーザグローバルの設定ファイルを公式にはサポートしていないので未対応です。
+
   # npm CLIの`min-release-age`(単位: 日)。
-  # denoも`~/.npmrc`の`min-release-age`を読むため一括で効果があります。
   # home-managerには`programs.npm`がないため`home.file`で直接生成します。
   home.file.".npmrc".text = ''
     min-release-age=3

--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -1,5 +1,39 @@
 { pkgs, ... }:
 {
+  # サプライチェーン攻撃のリスク低減として、
+  # 各JavaScriptパッケージマネージャで、
+  # リリース後3日経過したバージョンをインストールするように設定します。
+  # 悪意あるパッケージがpublishされてから検出・取り下げされるまでの猶予を確保する目的です。
+  # 各PMで設定キー名・単位が異なる点に注意。
+
+  # npm CLIの`min-release-age`(単位: 日)。
+  # denoも`~/.npmrc`の`min-release-age`を読むため一括で効果があります。
+  # home-managerには`programs.npm`がないため`home.file`で直接生成します。
+  home.file.".npmrc".text = ''
+    min-release-age=3
+  '';
+
+  # pnpmはhome-manager専用モジュールがないため設定ファイルを直接書きます。
+  # pnpmは`~/.config/pnpm/config.yaml`を読みます(単位: 分)。
+  xdg.configFile."pnpm/config.yaml".text = ''
+    minimumReleaseAge: 4320
+  '';
+
+  # Yarn Berryの`npmMinimalAgeGate`(単位: 分)。
+  programs = {
+    yarn = {
+      enable = true;
+      settings.npmMinimalAgeGate = 4320;
+    };
+
+    # Bunの`minimumReleaseAge`(単位: 秒)。
+    bun = {
+      enable = true;
+      settings.install.minimumReleaseAge = 259200;
+    };
+  };
+
+  # グローバルにインストールするJavaScript関連ツール。
   home.packages = with pkgs; [
     corepack
     nodejs

--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -21,9 +21,9 @@ in
 
   # pnpmはhome-manager専用モジュールがないため設定ファイルを直接書きます。
   # pnpmは`~/.config/pnpm/config.yaml`を読みます(単位: 分)。
-  xdg.configFile."pnpm/config.yaml".text = ''
-    minimumReleaseAge: ${releaseAgeSeconds}
-  '';
+  xdg.configFile."pnpm/config.yaml".source = (pkgs.formats.yaml { }).generate "pnpm-config.yaml" {
+    minimumReleaseAge = releaseAgeMinutes;
+  };
 
   # Yarn Berryの`npmMinimalAgeGate`(単位: 分)。
   programs = {


### PR DESCRIPTION
サプライチェーン攻撃のリスクを低減するため、
npm/pnpm/yarn/bunの各JavaScriptパッケージマネージャで、
リリース後3日経過したバージョンのみインストールするようグローバル設定を追加します。

悪意あるパッケージがpublishされてから、
検出・取り下げされるまでの猶予を確保することが目的です。

各PMで設定キー名や単位が異なるため、
それぞれ3日相当の値を設定します。

- npm: `min-release-age`(単位: 日)
- pnpm: `minimumReleaseAge`(単位: 分)
- yarn: `npmMinimalAgeGate`(単位: 分)
- bun: `install.minimumReleaseAge`(単位: 秒)

home-managerにはまだ`programs.npm`や`programs.pnpm`が存在しません。

そのため`~/.npmrc`は`home.file`で、
`~/.config/pnpm/config.yaml`は`xdg.configFile`で直接生成しています。
