### PR TITLE
feat(python): PyPIパッケージのインストール猶予期間を設定

### DIFF
--- a/home/core/python.nix
+++ b/home/core/python.nix
@@ -1,9 +1,40 @@
 { pkgs, ... }:
+let
+  releaseAgeDays = 3;
+  isoDuration = "P${toString releaseAgeDays}D";
+in
 {
+  # サプライチェーン攻撃のリスク低減として、
+  # PyPI系パッケージマネージャでリリース後3日経過したバージョンをインストールするように設定します。
+  # 悪意あるパッケージがpublishされてから検出・取り下げされるまでの猶予を確保する目的です。
+  # 各PMで設定キー名・単位・要求バージョンが異なる点に注意。
+
   programs = {
-    poetry.enable = true;
+    # `solver.min-release-age`(単位: 日)。
+    poetry = {
+      enable = true;
+      settings.solver.min-release-age = releaseAgeDays;
+    };
+    # uvの`exclude-newer`は、
+    # RFC 3339、ISO 8601、フレンドリーな期間文字列(`"3 days"`)を受け付けます。
+    uv = {
+      enable = true;
+      settings.exclude-newer = isoDuration;
+    };
   };
 
+  # pipの`uploaded-prior-to`(ISO 8601の`P<日数>D`形式のみ)。
+  # pipenvやpipxは内部でpipを呼ぶため、
+  # pip本体が機能を持てばこれらの経由のインストールにも波及します。
+  # pipenvの`cool-down-period`は`Pipfile`内でのみ設定可能で、
+  # ユーザグローバル設定の手段が公式には存在しません。
+  # pipenv経由の防御はpipの設定に依存する形になります。
+  xdg.configFile."pip/pip.conf".text = ''
+    [install]
+    uploaded-prior-to = ${isoDuration}
+  '';
+
+  # グローバルにインストールするPython関連ツール。
   home.packages = with pkgs; [
     black
     isort


### PR DESCRIPTION
poetryとuvとpipで新規リリースから3日経過後のみインストール可能に設定。

nixpkgsのstableバージョンで設定を有効に出来るのは現在uvのみですが、
公式の最新リリースではこのキーになっています。

未知のキーは無視されるので現在から設定していても問題ありません。
今から有効にしておけばnixpkgsのstableでのバージョンが上がった時、
設定が有効になります。

ref #1066
のnpmjs向けの設定と同様にすることで、
npmjsとPyPIというよくサプライチェーン攻撃の標的になるエコシステム両方に対して、
同様の防御策を講じることができます。
