### PR TITLE
fix(github-runner): post-build-hookをホストのnix-daemonから到達可能にする

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -29,6 +29,17 @@ in
         hostPath = config.sops.secrets."runner-registration-token".path;
         isReadOnly = true;
       };
+      # ホストのnix-daemonがランナーのワークディレクトリ配下に書かれた、
+      # `post-build-hook`を実行できるようにします。
+      # Mic92/niks3-actionなどはhookのshimを、
+      # `${RUNNER_TEMP}/niks3/`(= `/run/github-runner/<name>/_temp/niks3/`)に置き、
+      # nixデーモンはホスト側からその絶対パスを開きます。
+      # コンテナの`/run`tmpfsのままではホストからは見えないため、
+      # 同一パスで両側から到達できるようにbind-mountを張ります。
+      "/run/github-runner" = {
+        hostPath = "/run/github-runner";
+        isReadOnly = false;
+      };
     };
     config =
       { lib, ... }:
@@ -42,7 +53,7 @@ in
         nix.settings = ciNixSettings;
         networking = {
           useHostResolvConf = lib.mkForce false;
-          firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中に任意のポートでリッスンするため全許可
+          firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中にリッスンするため全許可
         };
         services = {
           resolved.enable = true;
@@ -93,6 +104,14 @@ in
         { Destination = "${addr.guest}/32"; }
       ];
     };
+
+    # bindMountsのhostPathは起動時に存在している必要があります。
+    # `/run`はtmpfsで毎boot消えるため再生成します。
+    # 所有者はrootだけにして、
+    # コンテナ内systemdのroot権限で配下のサービスディレクトリ作成を担います。
+    tmpfiles.rules = [
+      "d /run/github-runner 0700 root root -"
+    ];
 
     services."container@github-runner-x64" = {
       # NixOSコンテナモジュールが生成するpostStartは`ip addr add`/`ip route add`を使うため、

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -107,10 +107,14 @@ in
 
     # bindMountsのhostPathは起動時に存在している必要があります。
     # `/run`はtmpfsで毎boot消えるため再生成します。
-    # 所有者はrootだけにして、
-    # コンテナ内systemdのroot権限で配下のサービスディレクトリ作成を担います。
+    # コンテナ内のgithub-runnerサービスは`User=github-runner`で起動し、
+    # `WorkingDirectory=/run/github-runner/<name>`へchdirするため、
+    # `github-runner`ユーザーが親ディレクトリをtraverseできる必要があります。
+    # `privateUsers = "identity"`によりホストとコンテナのUIDは一致するため、
+    # ホスト側のディレクトリ所有者を`github-runner`にしておけば、
+    # コンテナ内のサービスも同ユーザーとしてアクセスできます。
     tmpfiles.rules = [
-      "d /run/github-runner 0700 root root -"
+      "d /run/github-runner 0700 github-runner github-runner -"
     ];
 
     services."container@github-runner-x64" = {


### PR DESCRIPTION
`seminar`のセルフホストランナーはNixOSコンテナ内で動作しています。
コンテナの`/run`は独自tmpfsのため、
ホストのnix-daemonからは、
ランナーの`${RUNNER_TEMP}/niks3/post-build-hook`に到達できず、
`Mic92/niks3-action`のdaemonモードが`No such file or directory`で失敗していました。

`cachix-action`が`useDaemon: false`でセルフホストランナーを回避していたのと同じ問題が、
新しく導入した`Mic92/niks3-action`でも発生していました。
`Mic92/niks3-action`にはdaemonモードを無効化するinputがないため、
ホスト側で経路を通す方針で対応します。

コンテナとホストで`/run/github-runner`を同一パスのbind-mountにし、
ランナーが書いたhookスクリプトをホストのnix-daemonが、
同じ絶対パスで開けるようにします。
ホスト側パーミッションは`0700 root root`に絞り、
コンテナ内systemdの実root権限で配下のサービスディレクトリ生成を担います。

ref ncaq/dotfiles#1073