### PR TITLE
ci: ビルドが発生するジョブのタイムアウトを360分に延長

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -93,7 +93,7 @@ jobs:
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -114,7 +114,7 @@ jobs:
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -137,7 +137,7 @@ jobs:
     # セルフホステッドランナーは未認証のソースからは実行しない。
     if: needs.is-trusted.result == 'success'
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 60 # キャッシュが切れている時は時間がかかるため長めに設定。
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
       pull-requests: write # PRコメントのupsert
     runs-on: [self-hosted, Linux]
-    timeout-minutes: 60
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Emacsをカスタムビルドすることになったので、
キャッシュが切れるシチュエーションが増えました。
またマシンごとの最適化ビルドを行う予定のため、
CIランナーでビルドを行う機会が増えます。
普段はキャッシュによってチェック時間はそこまで長くならない予定ですが、
ビルドが発生した時にCI側でじっくりとビルドしてもらうように、
タイムアウトを大幅に延長します。
