### PR TITLE
feat(claude): Enterで改行にキーバインド変更

### DIFF
--- a/home/linked/.claude/keybindings.json
+++ b/home/linked/.claude/keybindings.json
@@ -9,7 +9,9 @@
         "ctrl+l": "chat:externalEditor",
         "ctrl+/": "chat:undo",
         "ctrl+t": "history:previous",
-        "ctrl+n": "history:next"
+        "ctrl+n": "history:next",
+        "enter": "chat:newline",
+        "meta+enter": "chat:submit"
       }
     },
     {


### PR DESCRIPTION
日本語入力の確定である`enter`と頻繁にぶつかる問題を解消。
`enter`に`chat:newline`を割り当てるとバグることが、
Claude Codeの`2.1.141`の修正で設定できるようになりました。

<https://www.schemastore.org/claude-code-keybindings.json>
のスキーマには`chat:newline`は載っていませんが、
実際には動作します。

本当は`chat:submit`は`ctrl+enter`や`shift+enter`の方にしたかったのですが、
tmuxの設定を変更したり色々試しても動作しなかったので、
他のキーバインドを割り当ておきました。
Androidとかからアクセスすることを考えると、
どうせこちらのキーバインドも必要かなとは思います。
