### PR TITLE
fix(firefox): Firefoxポリシー設定を調整

### DIFF
--- a/home/native-linux/firefox.nix
+++ b/home/native-linux/firefox.nix
@@ -62,25 +62,14 @@ in
     policies = {
       # [policy-templates](https://mozilla.github.io/policy-templates/)
       DisplayBookmarksToolbar = "never";
-      FirefoxHome = {
-        Search = false; # 検索ボックス非表示
-        SponsoredTopSites = false; # スポンサー付きサイト非表示
-      };
       Homepage = {
-        URL = "chrome://browser/content/blanktab.html";
-        Locked = false;
         StartPage = "previous-session";
       };
       NewTabPage = {
         Enabled = false;
         Locked = false;
       };
-      PDFjs = {
-        Enabled = true;
-        DefaultZoomValue = "page-fit";
-      };
       RequestedLocales = [ "ja" ]; # 言語設定を日本語に
-      TranslateEnabled = false; # 翻訳機能を無効化
       ExtensionSettings =
         let
           normalInstall =


### PR DESCRIPTION
- 効いていない設定を削除
- `TranslateEnabled`はなぜ無効にしたのか覚えていないので復帰
  - Claudeの翻訳機能とかの方が優秀だったから消したのかも
  - その場でさっと翻訳できるのは便利なので有効化
  - Android版でそれなりの精度があることを知っているので活用できるはず
