### PR TITLE
feat(kernel): xanmodカーネルをclient向けに有効化しCPU最適化を適用

### DIFF
--- a/lib/cpu-optimized-kernel-overlay.nix
+++ b/lib/cpu-optimized-kernel-overlay.nix
@@ -1,0 +1,61 @@
+/**
+  LinuxカーネルをCPUモデル固有の最適化Kconfigでビルドさせるoverlay。
+
+  通常のパッケージ向けの`cpu-optimized-overlay.nix`は`NIX_CFLAGS_COMPILE`を、
+  `cc-wrapper`経由でコンパイラに渡す方式で、
+  これはLinuxカーネルには効かない。
+  カーネルの`kbuild`は`KBUILD_CFLAGS`を独自に組み立てており、
+  `cc-wrapper`の環境変数を意図的に参照しないため。
+
+  代わりにXanModが取り込んでいる`graysky2/kernel_compiler_patch`相当の、
+  CPU選択用Kconfigシンボル(`MZEN4`/`MZEN5`等)を有効化する。
+  Kconfigによる選択は`-march=znver*`の付与に加えて、
+  `X86_L1_CACHE_SHIFT`等のキャッシュライン定数や、
+  Cソース内の`#ifdef CONFIG_*`分岐にも整合性を持って反映される。
+
+  実装方針として、
+  `linux_xanmod.override { structuredExtraConfig = ...; }`は使えない。
+  `xanmod-kernels.nix`内部で`structuredExtraConfig`が固定的に組み立てられた後、
+  `args.argsOverride`で`//`マージされる構造のため、
+  そこに上書きを差し込むとXanModが設定した数十項目の既定値を破壊してしまう。
+
+  そのため`kernelPatches`の各要素に含まれる`structuredExtraConfig`が、
+  `generic.nix`の`structuredConfigFromPatches`を経由して、
+  module評価でマージされるという仕組みを使う。
+  これにより既存設定を破壊せずに追加の設定だけを足せる。
+
+  カーネルの最適化設定は取り込んでいるパッチごとに異なるので、
+  使う可能性があり設定が容易な一部のカーネルだけ設定しています。
+*/
+cpuName: _final: prev:
+let
+  cpuTargets = import ./cpu-targets.nix { inherit (prev) lib; };
+  kernelOption = cpuTargets.kernelOptionFor cpuName;
+  optimizedKernel = prev.linuxKernel.kernels.linux_xanmod.override (oldArgs: {
+    kernelPatches = (oldArgs.kernelPatches or [ ]) ++ [
+      {
+        name = "cpu-optimized-${kernelOption}";
+        patch = null;
+        structuredExtraConfig = with prev.lib.kernel; {
+          # XanModのデフォルトである`GENERIC_CPU`(x86-64-v1)を外し、
+          # CPUモデル固有の最適化オプションを有効化する。
+          # `mkForce`を使うのは、
+          # XanModの`xanmod-kernels.nix`が`mkOverride 60`で多数の値を設定しており、
+          # デフォルト優先度(100)では負けるため。
+          GENERIC_CPU = prev.lib.mkForce no;
+          ${kernelOption} = prev.lib.mkForce yes;
+        };
+      }
+    ];
+  });
+in
+{
+  linuxKernel = prev.linuxKernel // {
+    kernels = prev.linuxKernel.kernels // {
+      linux_xanmod = optimizedKernel;
+    };
+    packages = prev.linuxKernel.packages // {
+      linux_xanmod = prev.linuxKernel.packagesFor optimizedKernel;
+    };
+  };
+}

--- a/lib/cpu-optimized-kernel-overlay.nix
+++ b/lib/cpu-optimized-kernel-overlay.nix
@@ -30,7 +30,7 @@
 cpuName: _final: prev:
 let
   cpuTargets =
-    assert prev.assertMsg (cpuName != null) "cpuName must be provided to cpu-optimized-kernel-overlay";
+    assert prev.lib.assertMsg (cpuName != null) "cpuName must be provided";
     import ./cpu-targets.nix { inherit (prev) lib; };
   kernelOption = cpuTargets.kernelOptionFor cpuName;
   optimizedKernel = prev.linuxKernel.kernels.linux_xanmod.override (oldArgs: {

--- a/lib/cpu-optimized-kernel-overlay.nix
+++ b/lib/cpu-optimized-kernel-overlay.nix
@@ -29,7 +29,9 @@
 */
 cpuName: _final: prev:
 let
-  cpuTargets = import ./cpu-targets.nix { inherit (prev) lib; };
+  cpuTargets =
+    assert prev.assertMsg (cpuName != null) "cpuName must be provided to cpu-optimized-kernel-overlay";
+    import ./cpu-targets.nix { inherit (prev) lib; };
   kernelOption = cpuTargets.kernelOptionFor cpuName;
   optimizedKernel = prev.linuxKernel.kernels.linux_xanmod.override (oldArgs: {
     kernelPatches = (oldArgs.kernelPatches or [ ]) ++ [

--- a/lib/cpu-optimized-overlay.nix
+++ b/lib/cpu-optimized-overlay.nix
@@ -53,7 +53,9 @@
 */
 cpuName: _final: prev:
 let
-  cpuTargets = import ../lib/cpu-targets.nix { inherit (prev) lib; };
+  cpuTargets =
+    assert prev.assertMsg (cpuName != null) "cpuName must be provided to cpu-optimized-kernel-overlay";
+    import ./cpu-targets.nix { inherit (prev) lib; };
   cflags = cpuTargets.cflagsFor cpuName;
   rustflags = cpuTargets.rustflagsFor cpuName;
 

--- a/lib/cpu-optimized-overlay.nix
+++ b/lib/cpu-optimized-overlay.nix
@@ -54,7 +54,7 @@
 cpuName: _final: prev:
 let
   cpuTargets =
-    assert prev.assertMsg (cpuName != null) "cpuName must be provided to cpu-optimized-kernel-overlay";
+    assert prev.lib.assertMsg (cpuName != null) "cpuName must be provided";
     import ./cpu-targets.nix { inherit (prev) lib; };
   cflags = cpuTargets.cflagsFor cpuName;
   rustflags = cpuTargets.rustflagsFor cpuName;

--- a/lib/cpu-targets.nix
+++ b/lib/cpu-targets.nix
@@ -105,4 +105,29 @@ rec {
       "-C"
       "target-cpu=${t.arch}"
     ];
+
+  /**
+    arch名からLinuxカーネル向けのCPUターゲットKconfigシンボル名を得る。
+    `arch/x86/Kconfig.cpu`の`MZEN`系オプションに対応する。
+    XanModカーネルは`graysky2/kernel_compiler_patch`相当のパッチを統合済みで、
+    `MZEN`〜`MZEN5`を選択可能。
+    Kconfigによる選択は`-march=znver*`の付与に加えて、
+    `X86_L1_CACHE_SHIFT`等のアーキテクチャ依存定数や、
+    Cソース内の`#ifdef CONFIG_*`分岐にも影響する。
+    `KCFLAGS`経由のフラグ注入では得られない構造的最適化が掛かるため、
+    こちらの方式を使う。
+  */
+  kernelOptionFor =
+    name:
+    let
+      t = targets.${name};
+      archToKernel = {
+        znver1 = "MZEN";
+        znver2 = "MZEN2";
+        znver3 = "MZEN3";
+        znver4 = "MZEN4";
+        znver5 = "MZEN5";
+      };
+    in
+    archToKernel.${t.arch} or (throw "cpu-targets: no kernel CPU for arch '${t.arch}'");
 }

--- a/lib/cpu-targets.nix
+++ b/lib/cpu-targets.nix
@@ -107,7 +107,7 @@ rec {
     ];
 
   /**
-    arch名からLinuxカーネル向けのCPUターゲットKconfigシンボル名を得る。
+    CPUモデル名からLinuxカーネル向けのCPUターゲットKconfigシンボル名を得る。
     `arch/x86/Kconfig.cpu`の`MZEN`系オプションに対応する。
     XanModカーネルは`graysky2/kernel_compiler_patch`相当のパッチを統合済みで、
     `MZEN`〜`MZEN5`を選択可能。

--- a/nixos/client/default.nix
+++ b/nixos/client/default.nix
@@ -1,0 +1,4 @@
+{ importDirModules, ... }:
+{
+  imports = importDirModules ./.;
+}

--- a/nixos/client/kernel.nix
+++ b/nixos/client/kernel.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  boot = {
+    kernelPackages = pkgs.linuxKernel.packages.linux_xanmod;
+  };
+}

--- a/nixos/core/cpu-target.nix
+++ b/nixos/core/cpu-target.nix
@@ -27,6 +27,7 @@ in
   config = lib.mkIf (config.local.cpuTarget != null) {
     nixpkgs.overlays = [
       (import ../../lib/cpu-optimized-overlay.nix config.local.cpuTarget)
+      (import ../../lib/cpu-optimized-kernel-overlay.nix config.local.cpuTarget)
     ];
   };
 }

--- a/nixos/host/bullet.nix
+++ b/nixos/host/bullet.nix
@@ -10,6 +10,7 @@
 
     ../native-linux
 
+    ../client
     ../desktop
 
     ./bullet

--- a/nixos/host/creep.nix
+++ b/nixos/host/creep.nix
@@ -5,6 +5,7 @@
 
     ../native-linux
 
+    ../client
     ../laptop
 
     ./creep


### PR DESCRIPTION
レイテンシ重視のxanmodカーネルをclient向けの全ホストで有効化し、
合わせてホストのCPUモデル固有のKconfig最適化を自動的に反映するoverlayを追加します。

サーバ用途には適さないため`nixos/client/`配下のモジュールとして組み込み、
`local.cpuTarget`が設定されているホスト(現状bulletとcreep)では、
CPUに応じた`-march=znver*`相当の最適化が透過的に効くようにしています。

通常パッケージ向けの`cpu-optimized-overlay.nix`は`NIX_CFLAGS_COMPILE`を`cc-wrapper`経由で渡す方式のため、
独自に`KBUILD_CFLAGS`を組み立てるLinuxカーネルには効きません。
そのためkernel側は`structuredExtraConfig`を`kernelPatches`経由でマージする別overlayを用意し、
XanModが取り込み済みの`graysky2/kernel_compiler_patch`相当のKconfigシンボル(`MZEN4`/`MZEN5`等)を有効化します。
Kconfigによる選択は`-march=znver*`の付与に加えて、
`X86_L1_CACHE_SHIFT`等のアーキテクチャ依存定数や、
Cソース内の`#ifdef CONFIG_*`分岐にも整合性を持って反映されます。

`xanmod-kernels.nix`の`structuredExtraConfig`は内部で`//`マージされる構造のため、
`override`での直接上書きはXanModが設定する数十項目の既定値を破壊してしまいます。
代わりに`generic.nix`の`structuredConfigFromPatches`が`kernelPatches`各要素の`structuredExtraConfig`をmodule評価でマージする仕組みを利用することで、
既存設定を破壊せずに追加だけ行えます。
