### PR TITLE
refactor: `.xmonad`からウィンドウマネージャ関係ないパッケージの管理を移動

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779156449,
-        "narHash": "sha256-hhvog3glt5xnXb5L18S6lpvgLfYktVt8XGd5Ml7yVXA=",
+        "lastModified": 1779261774,
+        "narHash": "sha256-Ye0ZOtwOUQyIH6csfYTS9ntEZ25s+w6ZL25GC1TdRe4=",
         "owner": "ncaq",
         "repo": ".xmonad",
-        "rev": "792fc2fb21eed9832f9e35738efa4777e69f8438",
+        "rev": "bf5db9c3db842043b58565dabd7f5d8d6a6a94d8",
         "type": "github"
       },
       "original": {

--- a/home/core/xdg.nix
+++ b/home/core/xdg.nix
@@ -8,6 +8,10 @@ in
 {
   xdg = {
     enable = true;
+    autostart = {
+      # ここでまとめてenableにします。
+      enable = true;
+    };
     userDirs = {
       # xdgディレクトリを日本語名称にせずにマジョリティな名称にするように明示的に設定。
       enable = true;

--- a/home/native-linux/copyq.nix
+++ b/home/native-linux/copyq.nix
@@ -1,0 +1,7 @@
+_: {
+  services = {
+    copyq = {
+      enable = true;
+    };
+  };
+}

--- a/home/native-linux/thunderbird.nix
+++ b/home/native-linux/thunderbird.nix
@@ -1,4 +1,5 @@
-_: {
+{ pkgs, ... }:
+{
   programs.thunderbird = {
     enable = true;
     profiles.default = {
@@ -19,4 +20,6 @@ _: {
       };
     };
   };
+  home.packages = [ pkgs.birdtray ];
+  xdg.autostart.entries = [ "${pkgs.birdtray}/share/applications/com.ulduzsoft.Birdtray.desktop" ];
 }

--- a/home/native-linux/trayscale.nix
+++ b/home/native-linux/trayscale.nix
@@ -21,9 +21,6 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = [ pkgs.trayscale ];
-    xdg.autostart = {
-      enable = true;
-      entries = [ trayscale-autostart-desktop ];
-    };
+    xdg.autostart.entries = [ trayscale-autostart-desktop ];
   };
 }

--- a/nixos/native-linux/networking.nix
+++ b/nixos/native-linux/networking.nix
@@ -28,6 +28,12 @@ in
     nameservers = encryptedDns;
   };
 
+  programs = {
+    nm-applet = {
+      enable = true;
+    };
+  };
+
   services.resolved = {
     enable = true;
     dnssec = "true";


### PR DESCRIPTION
- **refactor(xdg): xdg.autostartの有効化を共通設定に移動**
- **feat(thunderbird): Birdtrayの自動起動を追加**
- **feat(networking): nm-appletを有効化**
- **feat(native-linux): CopyQクリップボードマネージャを有効化**
- **build: `.xmonad`のリビジョンを更新**
