### PR TITLE
feat(networkmanager): WiFiプロファイルを宣言的に管理

### DIFF
--- a/nixos/native-linux/networking.nix
+++ b/nixos/native-linux/networking.nix
@@ -24,6 +24,10 @@ in
   networking = {
     networkmanager = {
       enable = true;
+      # NMが「Wired connection 1」のような一時プロファイル(nm-generated=true)を、
+      # 明示プロファイルのない管理対象NICに自動生成するのを抑止する。
+      # 宣言的に書いたプロファイル以外がランタイムに出現するのを防ぐ。
+      settings.main.no-auto-default = "*";
     };
     nameservers = encryptedDns;
   };

--- a/nixos/native-linux/wifi.nix
+++ b/nixos/native-linux/wifi.nix
@@ -1,8 +1,15 @@
-{ config, ... }:
+{ lib, config, ... }:
 let
+  # WiFiのpsk値を渡す環境変数名を生成する。
+  # systemdの`EnvironmentFile`経由で、
+  # NetworkManager-ensure-profilesに渡され、
+  # envsubstでkeyfileに展開される。
+  # 環境変数名にはハイフンを使えないためアンダースコアに変換し大文字化する。
+  pskEnvName = id: "WIFI_${lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] id)}_PSK";
+
   # 各WiFiプロファイル共通の構造を生成するヘルパー。
-  # idとssid, key-mgmt, secretのsopsキーを受け取り、
-  # ensureProfilesに渡せるattrsetを返す。
+  # `id`と`ssid`と`key-mgmt`を受け取り、
+  # `ensureProfiles`に渡せるattrsetを返す。
   # interface-nameは敢えて指定せず、
   # どのWiFiインターフェースでも使えるようにする。
   mkWifi =
@@ -23,10 +30,13 @@ let
       };
       wifi-security = {
         key-mgmt = keyMgmt;
-        # psk値はnm-file-secret-agent経由でランタイムに注入する。
-        # `psk-flags=1`はagent-ownedを意味しNMが秘密値をsecret agentに問い合わせる。
-        psk = "";
-        psk-flags = "1";
+        # psk値は`environmentFiles`経由でenvsubstがkeyfileに展開する。
+        # `psk-flags`は指定せず(=`0`, system-owned)、
+        # NetworkManager本体がkeyfileのpskを直接管理する。
+        # secret agentを介さないため手動接続でもパスワード入力を求められない。
+        # keyfileは`/run/NetworkManager/system-connections/`(tmpfs, root専用0600)に生成され、
+        # Nixストアにpsk平文が残ることはない。
+        psk = "\${${pskEnvName id}}";
       };
       ipv4 = {
         method = "auto";
@@ -36,15 +46,6 @@ let
         method = "auto";
       };
     };
-
-  # nm-file-secret-agentにpsk値を渡すエントリを生成するヘルパー。
-  mkSecretEntry = id: {
-    matchId = id;
-    matchType = "802-11-wireless"; # 短縮名(`wifi`)ではなく正式名の`802-11-wireless`である。
-    matchSetting = "802-11-wireless-security";
-    key = "psk";
-    file = config.sops.secrets."wifi/${id}".path;
-  };
 
   wifiNetworks = [
     {
@@ -81,17 +82,29 @@ in
         value = mkWifi w;
       }) wifiNetworks
     );
-
-    secrets.entries = map (w: mkSecretEntry w.id) wifiNetworks;
+    # 各WiFiのpsk値を環境変数として渡すenvファイル。
+    # `sops.templates`がplaceholderを実値に展開した上でroot専用ファイルとして配置する。
+    # NetworkManagerの通常の手動セットアップの場合、
+    # `/etc/NetworkManager/system-connections/`に、
+    # パスワードを含めた平文ファイルが生成されるので、
+    # セキュリティに大した差はない。
+    # 永続領域に置かれないだけ少しだけ安全かもしれない。
+    environmentFiles = [ config.sops.templates."wifi-env".path ];
   };
 
-  sops.secrets = builtins.listToAttrs (
-    map (w: {
-      name = "wifi/${w.id}";
-      value = {
-        sopsFile = ../../secrets/wifi.yaml;
-        key = w.id;
-      };
-    }) wifiNetworks
-  );
+  sops = {
+    # `KEY=value`形式のenvファイルを生成し`ensureProfiles.environmentFiles`に渡す。
+    templates."wifi-env".content = lib.concatMapStringsSep "\n" (
+      w: "${pskEnvName w.id}=${config.sops.placeholder."wifi/${w.id}"}"
+    ) wifiNetworks;
+    secrets = builtins.listToAttrs (
+      map (w: {
+        name = "wifi/${w.id}";
+        value = {
+          sopsFile = ../../secrets/wifi.yaml;
+          key = w.id;
+        };
+      }) wifiNetworks
+    );
+  };
 }

--- a/nixos/native-linux/wifi.nix
+++ b/nixos/native-linux/wifi.nix
@@ -1,0 +1,97 @@
+{ config, ... }:
+let
+  # 各WiFiプロファイル共通の構造を生成するヘルパー。
+  # idとssid, key-mgmt, secretのsopsキーを受け取り、
+  # ensureProfilesに渡せるattrsetを返す。
+  # interface-nameは敢えて指定せず、
+  # どのWiFiインターフェースでも使えるようにする。
+  mkWifi =
+    {
+      id,
+      uuid,
+      ssid,
+      keyMgmt,
+    }:
+    {
+      connection = {
+        inherit id uuid;
+        type = "wifi";
+      };
+      wifi = {
+        mode = "infrastructure";
+        inherit ssid;
+      };
+      wifi-security = {
+        key-mgmt = keyMgmt;
+        # psk値はnm-file-secret-agent経由でランタイムに注入する。
+        # `psk-flags=1`はagent-ownedを意味しNMが秘密値をsecret agentに問い合わせる。
+        psk = "";
+        psk-flags = "1";
+      };
+      ipv4 = {
+        method = "auto";
+      };
+      ipv6 = {
+        addr-gen-mode = "default";
+        method = "auto";
+      };
+    };
+
+  # nm-file-secret-agentにpsk値を渡すエントリを生成するヘルパー。
+  mkSecretEntry = id: {
+    matchId = id;
+    matchType = "wifi";
+    matchSetting = "802-11-wireless-security";
+    key = "psk";
+    file = config.sops.secrets."wifi/${id}".path;
+  };
+
+  wifiNetworks = [
+    {
+      id = "diana";
+      uuid = "b983e52d-f3a4-4c2d-b04e-2be1723b0d45";
+      ssid = "diana";
+      keyMgmt = "sae";
+    }
+    {
+      id = "hermes";
+      uuid = "0c58734d-a746-49d2-87c6-2693ee48df8a";
+      ssid = "hermes";
+      keyMgmt = "sae";
+    }
+    {
+      id = "lacey-wifi";
+      uuid = "8c03253a-7533-4332-9b20-c8057849c55f";
+      ssid = "Lacey WiFi";
+      keyMgmt = "wpa-psk";
+    }
+    {
+      id = "pluszero-guest";
+      uuid = "aa0eed8a-aa3f-4f28-95d4-34757e194d77";
+      ssid = "pluszero-guest";
+      keyMgmt = "wpa-psk";
+    }
+  ];
+in
+{
+  networking.networkmanager.ensureProfiles = {
+    profiles = builtins.listToAttrs (
+      map (w: {
+        name = w.id;
+        value = mkWifi w;
+      }) wifiNetworks
+    );
+
+    secrets.entries = map (w: mkSecretEntry w.id) wifiNetworks;
+  };
+
+  sops.secrets = builtins.listToAttrs (
+    map (w: {
+      name = "wifi/${w.id}";
+      value = {
+        sopsFile = ../../secrets/wifi.yaml;
+        key = w.id;
+      };
+    }) wifiNetworks
+  );
+}

--- a/nixos/native-linux/wifi.nix
+++ b/nixos/native-linux/wifi.nix
@@ -40,7 +40,7 @@ let
   # nm-file-secret-agentにpsk値を渡すエントリを生成するヘルパー。
   mkSecretEntry = id: {
     matchId = id;
-    matchType = "wifi";
+    matchType = "802-11-wireless"; # 短縮名(`wifi`)ではなく正式名の`802-11-wireless`である。
     matchSetting = "802-11-wireless-security";
     key = "psk";
     file = config.sops.secrets."wifi/${id}".path;

--- a/nixos/native-linux/wifi.nix
+++ b/nixos/native-linux/wifi.nix
@@ -8,8 +8,7 @@ let
   pskEnvName = id: "WIFI_${lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] id)}_PSK";
 
   # 各WiFiプロファイル共通の構造を生成するヘルパー。
-  # `id`と`ssid`と`key-mgmt`を受け取り、
-  # `ensureProfiles`に渡せるattrsetを返す。
+  # 各種引数から`ensureProfiles`に渡せるattrsetを返す。
   # interface-nameは敢えて指定せず、
   # どのWiFiインターフェースでも使えるようにする。
   mkWifi =

--- a/secrets/wifi.yaml
+++ b/secrets/wifi.yaml
@@ -1,0 +1,21 @@
+diana: ENC[AES256_GCM,data:fXygp44derGsQC+VgzT5rIs/bNY8BQ==,iv:1B7XBbkdIThSzUGlmt6jToREdXW+zenWyEI5MsL+V1E=,tag:4RgTFGOqQxvIorDPnClxWQ==,type:str]
+hermes: ENC[AES256_GCM,data:dd6KXAAm02FcdXdRPhrbQQ==,iv:uJbjH3mX/cyEuFCBzDFakFpappa4F+VPNLPt5UB+IAM=,tag:yUKVbuUPbxHCVH+q5zid7g==,type:str]
+lacey-wifi: ENC[AES256_GCM,data:i6worG/eoXqk,iv:6EyjvOtppy591EFJXxaoAvR8+9KlG4t+6akCK5Lzxd4=,tag:epYDXmeWjVBmndXnBv21vg==,type:str]
+pluszero-guest: ENC[AES256_GCM,data:9UZUHcWGpRRagrzD8676,iv:Z7lLdTPaWl2WcIatdLjGRti9ijNsd4Kf0CjGiYFiyCQ=,tag:OlGzkIBvaOisXVtyjwMGeQ==,type:str]
+sops:
+  lastmodified: "2026-05-18T09:13:48Z"
+  mac: ENC[AES256_GCM,data:RvN5kf+VXWo29F3nH7C2VQKiK9U6Gi1FpbUXVSbOYQR/R6J0TaG/zM0MD1dlsnTLuPSc2a0xhzyA41vGTXZ7K3ngpwnI5I8kQNKpDt2dNzzeefxLtb7FDQjFUWdePWXUNBshMqn24TiG9FzIKisIyIpgvMVfFFfd9fhLX1IHku0=,iv:f4DHcxpDjapmaqkc0mj0hjMApi2vHJKX6p87Jdz0Rtk=,tag:Z2B5+ohhZMqZiN+VFaWEiQ==,type:str]
+  pgp:
+    - created_at: "2026-05-18T09:13:48Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4Dxlt1nl1bPpUSAQdAQadB40bEPM1FFHyo1V0paPLZVOlTgVp7z/hQStTz8Hgw
+        JimoIuz02FTxOLtdgFurM3GnWI0pKAB5akJRAM6pSU3XoU6k+X9Vd1nVeIg1LAgt
+        0l4B57RNPuIt1y8s/CBUkZZcpryKqyzs/Nr9kPH1rnWd4Sk9zQsoi1tU4letPUwG
+        tvkVODf70GY3f/3ZbpwVzeqaIvUUl9ghJMcCgqHSDpP9UFnkwntH7ugFf+GrKs8N
+        =cMHT
+        -----END PGP MESSAGE-----
+      fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1


### PR DESCRIPTION
NixOSの`networking.networkmanager.ensureProfiles`でWiFiプロファイルを宣言的に管理します。

宣言化したのは、
creepで`NetworkManager-wait-online.service`が高確率で失敗する問題があり、
connection情報を完全に宣言的に把握できる状態にして、
原因究明と差分管理の両方をしやすくしたかったためです。

PSKは`secrets/wifi.yaml`にsopsで暗号化して格納し、
`sops.templates`が生成するenvファイルを、
`ensureProfiles.environmentFiles`経由でenvsubstがkeyfileに展開します。
`psk-flags`は指定せず(system-owned)NetworkManager本体がkeyfileのpskを直接管理するため、
オートコネクトでも手動接続でもパスワード入力ダイアログが出ません。
keyfileは`/run/NetworkManager/system-connections/`(tmpfsのroot専用0600)に生成されるため、
Nixストアにpsk平文が残ることはありません。

`interface-name`は敢えて指定せず、
creep以外のWiFi搭載ホストでも同じプロファイルを使い回せるようにしています。

合わせて`networking.networkmanager.settings.main.no-auto-default = "*"`を設定し、
NMが「有線接続 1」のような`nm-generated=true`な一時プロファイルを勝手に作る挙動を抑止して、
宣言したプロファイルだけが存在する状態を維持しやすくします。

bulletの手動接続で動作を確認済みです。

close #1110