### PR TITLE
build(claude): konoka依存をv8.0.0に更新しhaskell-tasukeプラグインを有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "source": {
         "source": "github",
         "repo": "ncaq/konoka",
-        "ref": "v7.1.2"
+        "ref": "v8.0.0"
       }
     }
   },

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -191,7 +191,7 @@ in
           source = {
             source = "github";
             repo = "ncaq/konoka";
-            ref = "v7.1.2";
+            ref = "v8.0.0";
           };
         };
         context7-marketplace = {
@@ -219,8 +219,8 @@ in
         "swift-lsp@claude-plugins-official" = true;
         "typescript-lsp@claude-plugins-official" = true;
         # konoka
-        "bump-cabal-index-state@konoka" = true;
         "commit@konoka" = true;
+        "haskell-tasuke@konoka" = true;
         "kyosei@konoka" = true;
         "log-analyzer@konoka" = true;
         "nix-tasuke@konoka" = true;


### PR DESCRIPTION
haskell-tasukeが作られたバージョンを有効化して、
bump-cabal-index-stateの統合にも対処。
