### PR TITLE
fix: 自動でEthernetに繋がらなくなったのを修正

### DIFF
--- a/nixos/native-linux/ethernet.nix
+++ b/nixos/native-linux/ethernet.nix
@@ -11,7 +11,7 @@ _: {
         # interface-nameは敢えて指定しません。
         # 複雑な設定を持つものだけ個別設定します。
       };
-      ivp4 = {
+      ipv4 = {
         method = "auto";
       };
       ipv6 = {

--- a/nixos/native-linux/ethernet.nix
+++ b/nixos/native-linux/ethernet.nix
@@ -1,0 +1,24 @@
+{ ... }:
+{
+  networking.networkmanager.ensureProfiles.profiles = {
+    # NetworkManagerのプロファイルの自動生成を無効化して宣言的管理に寄せているため、
+    # ベーシックなEthernetプロファイルも明示的に宣言する必要があります。
+    basic-ethernet = {
+      connection = {
+        id = "basic-ethernet";
+        uuid = "1d498986-7538-4a96-8484-5bdb1b9c6e34";
+        type = "ethernet";
+        # 大抵のethernetでは事情は概ね同じだと思うので、
+        # interface-nameは敢えて指定しません。
+        # 複雑な設定を持つものだけ個別設定します。
+      };
+      ivp4 = {
+        method = "auto";
+      };
+      ipv6 = {
+        addr-gen-mode = "default";
+        method = "auto";
+      };
+    };
+  };
+}

--- a/nixos/native-linux/ethernet.nix
+++ b/nixos/native-linux/ethernet.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+_: {
   networking.networkmanager.ensureProfiles.profiles = {
     # NetworkManagerのプロファイルの自動生成を無効化して宣言的管理に寄せているため、
     # ベーシックなEthernetプロファイルも明示的に宣言する必要があります。

--- a/nixos/native-linux/wifi.nix
+++ b/nixos/native-linux/wifi.nix
@@ -106,4 +106,17 @@ in
       }) wifiNetworks
     );
   };
+
+  # `NetworkManager-ensure-profiles.service`は、
+  # `environmentFiles`に指定したsopsテンプレート(`/run/secrets/rendered/wifi-env`)を、
+  # 必須の`EnvironmentFile`として読み込む。
+  # このファイルを展開するのは`sops-install-secrets.service`だが、
+  # nixpkgs本体の定義には両者の順序依存がなく、
+  # tmpfs上のファイルは毎ブート再生成が必要なため、
+  # 展開前に`ensure-profiles`が走ると`Failed to load environment files`で失敗することがある。
+  # 明示的に`sops-install-secrets.service`の後に走るよう順序付けする。
+  systemd.services.NetworkManager-ensure-profiles = {
+    after = [ "sops-install-secrets.service" ];
+    wants = [ "sops-install-secrets.service" ];
+  };
 }


### PR DESCRIPTION
NetworkManagerのプロファイル自動生成を無効化したため、
ベーシックなEthernetプロファイルも宣言的に明示的に設定。

wifiのプロファイル展開が失敗して、
巻き添えで全てのプロファイルが展開されない問題がありました。
依存関係を追加して失敗しないようにしました。

close #1122