### PR TITLE
fix(git): `commit.verbose`オプションを削除

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -29,7 +29,6 @@ in
           quotePath = false;
           symlinks = true;
         };
-        commit.verbose = true;
         diff.algorithm = "histogram";
         fetch.prune = true;
         init.defaultBranch = "master";


### PR DESCRIPTION
`verbose`で変更セットをバッファに入れておくことは、
GitHub Copilot Completeの精度を向上させます。

しかし現在commitlintがdiff部分に反応して行の長さをチェックしてしまうという問題と衝突します。
[{body,footer}-max-line-length may fail when git commit --verbose · Issue #437 · conventional-changelog/commitlint](https://github.com/conventional-changelog/commitlint/issues/437)

少なくとも解決策の、
[fix(read): strip verbose diff from commit message by enaktes9-hub · Pull Request #4770 · conventional-changelog/commitlint](https://github.com/conventional-changelog/commitlint/pull/4770)
がマージされるまでは、
`verbose`オプションを削除します。
