### PR TITLE
refactor(flake): `flake.nix`の肥大化したヘルパーを`lib/`に分離

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,114 +134,58 @@
       flake =
         let
           inherit (nixpkgs) lib;
-          # ディレクトリ内の全.nixファイルをimportするヘルパー関数。
+          # ディレクトリ内の全`.nix`ファイルをimportするヘルパー関数。
           importDirModules = import ./lib/import-dir-modules.nix { inherit lib; };
-          # 許可するライセンス。
-          allowlistedLicenses = with lib.licenses; [
-            nvidiaCudaRedist # 再配布可能ならまだマシ。
-            unfreeRedistributable # 再配布可能ならまだマシ。
-          ];
-          # 明示的に許可するunfreeパッケージのリスト。
-          allowedUnfreePackages = [
-            "claude-code" # 一番使いやすいLLMエージェントのため仕方がない。
-            "discord" # ネイティブ版の方が音声などが安定しているため仕方がない。
-            "slack" # ネイティブ版の方が通知などが安定しているため仕方がない。
-            "zoom" # ネイティブ版の方が動画などが安定しているため仕方がない。
-          ];
-          nixpkgsConfig = {
-            inherit allowlistedLicenses;
-            allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) allowedUnfreePackages;
-          };
+          # nixpkgsの共通設定。
+          nixpkgsConfig = import ./lib/nixpkgs-config.nix { inherit lib; };
           # 全環境で共通のoverlays。
           overlays = [
             inputs.firge-nix.overlays.default
           ];
           # system固有のpkgsを生成する関数。
-          importPkgsStable = importPkgsFor nixpkgs;
-          importPkgsUnstable = importPkgsFor nixpkgs-unstable;
           importPkgsFor =
             pkgset: system:
             import pkgset {
               inherit system overlays;
               config = nixpkgsConfig;
             };
+          # systemを受け取り安定版のpkgsを生成する。
+          importPkgsStable = importPkgsFor nixpkgs;
+          # systemを受け取り不安定版のpkgsを生成する。
+          importPkgsUnstable = importPkgsFor nixpkgs-unstable;
+          # NixOSシステムを生成する関数。
+          mkNixosSystem = import ./lib/mk-nixos-system.nix {
+            inherit
+              lib
+              importPkgsUnstable
+              importDirModules
+              inputs
+              ;
+            nixpkgs = {
+              config = nixpkgsConfig;
+              inherit overlays;
+            };
+          };
         in
         {
-          hostDefs =
-            let
-              mkNixosSystem =
-                {
-                  hostName,
-                  system,
-                }:
-                let
-                  specialArgs = {
-                    inherit
-                      importDirModules
-                      inputs
-
-                      hostName
-                      ;
-                    username = "ncaq";
-                  };
-                  modules = [
-                    (_: {
-                      nixpkgs = {
-                        config = nixpkgsConfig;
-                        inherit overlays;
-                      };
-                    })
-                    inputs.disko.nixosModules.default
-                    inputs.sops-nix.nixosModules.sops
-                    ./nixos/configuration.nix
-                    ./nixos/host/${hostName}.nix
-                    home-manager.nixosModules.home-manager
-                    (
-                      { config, ... }:
-                      {
-                        home-manager = {
-                          backupFileExtension = "hm-bak";
-                          useGlobalPkgs = true;
-                          useUserPackages = true;
-                          extraSpecialArgs = specialArgs // {
-                            pkgs-unstable = importPkgsUnstable system;
-                            isTermux = false;
-                            isWSL = config.wsl.enable or false;
-                          };
-                          sharedModules = [
-                            inputs.sops-nix.homeManagerModules.sops
-                          ];
-                          users.ncaq = import ./home;
-                        };
-                      }
-                    )
-                  ];
-                in
-                {
-                  nixosSystem = lib.nixosSystem {
-                    inherit modules specialArgs system;
-                  };
-                  inherit modules specialArgs system;
-                };
-            in
-            {
-              "SSD0086" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "SSD0086";
-              };
-              "bullet" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "bullet";
-              };
-              "creep" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "creep";
-              };
-              "seminar" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "seminar";
-              };
+          hostDefs = {
+            "SSD0086" = mkNixosSystem {
+              system = "x86_64-linux";
+              hostName = "SSD0086";
             };
+            "bullet" = mkNixosSystem {
+              system = "x86_64-linux";
+              hostName = "bullet";
+            };
+            "creep" = mkNixosSystem {
+              system = "x86_64-linux";
+              hostName = "creep";
+            };
+            "seminar" = mkNixosSystem {
+              system = "x86_64-linux";
+              hostName = "seminar";
+            };
+          };
 
           nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
 

--- a/flake.nix
+++ b/flake.nix
@@ -195,32 +195,17 @@
 
           homeConfigurations =
             let
-              mkLinuxHome =
-                {
-                  system,
-                  username,
-                }:
-                home-manager.lib.homeManagerConfiguration {
-                  pkgs = importPkgsStable system;
-                  extraSpecialArgs = {
-                    inherit
-                      importDirModules
-                      inputs
-
-                      username
-                      ;
-                    pkgs-unstable = importPkgsUnstable system;
-                    isTermux = false;
-                    isWSL = false;
-                  };
-                  modules = [
-                    inputs.sops-nix.homeManagerModules.sops
-                    ./home
-                  ];
-                };
+              mkLinuxHomeManager = import ./lib/mk-linux-home-manager.nix {
+                inherit
+                  importPkgsStable
+                  importPkgsUnstable
+                  importDirModules
+                  inputs
+                  ;
+              };
             in
             {
-              "x86_64-linux" = mkLinuxHome {
+              "x86_64-linux" = mkLinuxHomeManager {
                 system = "x86_64-linux";
                 username = "ncaq";
               };

--- a/flake.nix
+++ b/flake.nix
@@ -334,6 +334,28 @@
           ...
         }:
         {
+          treefmt.config = {
+            projectRootFile = "flake.nix";
+            programs = {
+              actionlint.enable = true;
+              deadnix.enable = true;
+              nixfmt.enable = true;
+              prettier.enable = true;
+              shellcheck.enable = true;
+              shfmt.enable = true;
+              statix.enable = true;
+              typos.enable = true;
+              zizmor.enable = true;
+            };
+            settings.formatter = {
+              editorconfig-checker = {
+                command = pkgs.editorconfig-checker;
+                includes = [ "*" ];
+              };
+              zizmor.options = [ "--pedantic" ];
+            };
+          };
+
           checks =
             let
               inherit (nixpkgs) lib;
@@ -366,27 +388,6 @@
             in
             nixosEvalChecks // hmEvalChecks;
 
-          treefmt.config = {
-            projectRootFile = "flake.nix";
-            programs = {
-              actionlint.enable = true;
-              deadnix.enable = true;
-              nixfmt.enable = true;
-              prettier.enable = true;
-              shellcheck.enable = true;
-              shfmt.enable = true;
-              statix.enable = true;
-              typos.enable = true;
-              zizmor.enable = true;
-            };
-            settings.formatter = {
-              editorconfig-checker = {
-                command = pkgs.editorconfig-checker;
-                includes = [ "*" ];
-              };
-              zizmor.options = [ "--pedantic" ];
-            };
-          };
           packages = {
             # flake.lockの管理バージョンをre-exportすることで安定した利用を促進。
             inherit (pkgs)
@@ -400,6 +401,7 @@
             # PRコメントにnvd diffを投稿するスクリプト。
             nvd-pr-diff = pkgs.callPackage ./pkgs/nvd-pr-diff { };
           };
+
           devShells.default = pkgs.mkShell {
             buildInputs = with pkgs; [
               # treefmtで指定したプログラムの単体版。

--- a/flake.nix
+++ b/flake.nix
@@ -191,7 +191,7 @@
 
           nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
 
-          testNixosBoot = import lib/test-nixos-boot.nix {
+          testNixosBoot = import ./lib/test-nixos-boot.nix {
             inherit top lib importPkgsStable;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -153,39 +153,41 @@
           importPkgsStable = importPkgsFor nixpkgs;
           # systemを受け取り不安定版のpkgsを生成する。
           importPkgsUnstable = importPkgsFor nixpkgs-unstable;
-          # NixOSシステムを生成する関数。
-          mkNixosSystem = import ./lib/mk-nixos-system.nix {
-            inherit
-              lib
-              importPkgsUnstable
-              importDirModules
-              inputs
-              ;
-            nixpkgs = {
-              config = nixpkgsConfig;
-              inherit overlays;
-            };
-          };
         in
         {
-          hostDefs = {
-            "SSD0086" = mkNixosSystem {
-              system = "x86_64-linux";
-              hostName = "SSD0086";
+          hostDefs =
+            let
+              mkNixosSystem = import ./lib/mk-nixos-system.nix {
+                inherit
+                  lib
+                  importPkgsUnstable
+                  importDirModules
+                  inputs
+                  ;
+                nixpkgs = {
+                  config = nixpkgsConfig;
+                  inherit overlays;
+                };
+              };
+            in
+            {
+              "SSD0086" = mkNixosSystem {
+                system = "x86_64-linux";
+                hostName = "SSD0086";
+              };
+              "bullet" = mkNixosSystem {
+                system = "x86_64-linux";
+                hostName = "bullet";
+              };
+              "creep" = mkNixosSystem {
+                system = "x86_64-linux";
+                hostName = "creep";
+              };
+              "seminar" = mkNixosSystem {
+                system = "x86_64-linux";
+                hostName = "seminar";
+              };
             };
-            "bullet" = mkNixosSystem {
-              system = "x86_64-linux";
-              hostName = "bullet";
-            };
-            "creep" = mkNixosSystem {
-              system = "x86_64-linux";
-              hostName = "creep";
-            };
-            "seminar" = mkNixosSystem {
-              system = "x86_64-linux";
-              hostName = "seminar";
-            };
-          };
 
           nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
 

--- a/flake.nix
+++ b/flake.nix
@@ -192,7 +192,7 @@
           nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
 
           testNixosBoot = import lib/test-nixos-boot.nix {
-            inherit lib importPkgsStable;
+            inherit top lib importPkgsStable;
           };
 
           homeConfigurations =

--- a/flake.nix
+++ b/flake.nix
@@ -189,40 +189,9 @@
 
           nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
 
-          testNixosBoot =
-            lib.mapAttrs
-              (
-                name: hostDef:
-                (importPkgsStable hostDef.system).testers.runNixOSTest {
-                  name = "test-nixos-boot-${name}";
-                  node = {
-                    # `runNixOSTest`が追加する`nixpkgs`の読み込み専用設定を無効化します。
-                    # `hardware-configuration.nix`が存在する時、
-                    # `nixpkgs.hostPlatform`を設定しているので、
-                    # 読み込み専用にされた`nixpkgs`オプションへの設定がエラーになります。
-                    # 基本的にモジュール単位のテスト機構であり、
-                    # 全体のブートを想定していないゆえの挙動でしょう。
-                    # 自動生成ファイルである`hardware-configuration.nix`を編集したくないため、
-                    # 上書きを有効にしてしまいます。
-                    # ブートのテストの場合ではあまり問題にならないはずです。
-                    pkgsReadOnly = false;
-                    inherit (hostDef) specialArgs;
-                  };
-                  nodes.machine = {
-                    imports = hostDef.modules ++ [
-                      ./nixos/test/vm-override.nix
-                    ];
-                  };
-                  # テスト環境はネットワークに繋がっていないため、
-                  # ネットワーク依存のユニットは失敗します。
-                  # よって全体成功を期待することはできません。
-                  # multi-user.targetに到達すればひとまず成功とみなしています。
-                  testScript = ''
-                    machine.wait_for_unit("multi-user.target")
-                  '';
-                }
-              )
-              (lib.filterAttrs (_: def: !(def.nixosSystem.config.wsl.enable or false)) top.config.flake.hostDefs);
+          testNixosBoot = import lib/test-nixos-boot.nix {
+            inherit lib importPkgsStable;
+          };
 
           homeConfigurations =
             let

--- a/flake.nix
+++ b/flake.nix
@@ -396,7 +396,6 @@
               git
               home-manager
               nix-fast-build
-              qemu-user
               ;
             # PRコメントにnvd diffを投稿するスクリプト。
             nvd-pr-diff = pkgs.callPackage ./pkgs/nvd-pr-diff { };

--- a/lib/mk-linux-home-manager.nix
+++ b/lib/mk-linux-home-manager.nix
@@ -23,6 +23,6 @@ inputs.home-manager.lib.homeManagerConfiguration {
   };
   modules = [
     inputs.sops-nix.homeManagerModules.sops
-    ./home
+    ../home
   ];
 }

--- a/lib/mk-linux-home-manager.nix
+++ b/lib/mk-linux-home-manager.nix
@@ -1,0 +1,28 @@
+{
+  importPkgsStable,
+  importPkgsUnstable,
+  importDirModules,
+  inputs,
+}:
+{
+  system,
+  username,
+}:
+inputs.home-manager.lib.homeManagerConfiguration {
+  pkgs = importPkgsStable system;
+  extraSpecialArgs = {
+    inherit
+      importDirModules
+      inputs
+
+      username
+      ;
+    pkgs-unstable = importPkgsUnstable system;
+    isTermux = false;
+    isWSL = false;
+  };
+  modules = [
+    inputs.sops-nix.homeManagerModules.sops
+    ./home
+  ];
+}

--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -20,9 +20,9 @@ let
     username = "ncaq";
   };
   modules = [
-    (_: {
+    {
       inherit nixpkgs;
-    })
+    }
     inputs.disko.nixosModules.default
     inputs.sops-nix.nixosModules.sops
     ../nixos/configuration.nix

--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -1,0 +1,57 @@
+{
+  nixpkgs,
+  lib,
+  importPkgsUnstable,
+  importDirModules,
+  inputs,
+}:
+{
+  system,
+  hostName,
+}:
+let
+  specialArgs = {
+    inherit
+      importDirModules
+      inputs
+
+      hostName
+      ;
+    username = "ncaq";
+  };
+  modules = [
+    (_: {
+      inherit nixpkgs;
+    })
+    inputs.disko.nixosModules.default
+    inputs.sops-nix.nixosModules.sops
+    ../nixos/configuration.nix
+    ../nixos/host/${hostName}.nix
+    inputs.home-manager.nixosModules.home-manager
+    (
+      { config, ... }:
+      {
+        home-manager = {
+          backupFileExtension = "hm-bak";
+          useGlobalPkgs = true;
+          useUserPackages = true;
+          extraSpecialArgs = specialArgs // {
+            pkgs-unstable = importPkgsUnstable system;
+            isTermux = false;
+            isWSL = config.wsl.enable or false;
+          };
+          sharedModules = [
+            inputs.sops-nix.homeManagerModules.sops
+          ];
+          users.ncaq = import ../home;
+        };
+      }
+    )
+  ];
+in
+{
+  nixosSystem = lib.nixosSystem {
+    inherit modules specialArgs system;
+  };
+  inherit modules specialArgs system;
+}

--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib }:
 let
   # 許可するライセンス。
   allowlistedLicenses = with lib.licenses; [

--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+let
+  # 許可するライセンス。
+  allowlistedLicenses = with lib.licenses; [
+    nvidiaCudaRedist # 再配布可能ならまだマシ。
+    unfreeRedistributable # 再配布可能ならまだマシ。
+  ];
+  # 明示的に許可するunfreeパッケージのリスト。
+  allowedUnfreePackages = [
+    "claude-code" # 一番使いやすいLLMエージェントのため仕方がない。
+    "discord" # ネイティブ版の方が音声などが安定しているため仕方がない。
+    "slack" # ネイティブ版の方が通知などが安定しているため仕方がない。
+    "zoom" # ネイティブ版の方が動画などが安定しているため仕方がない。
+  ];
+  nixpkgsConfig = {
+    inherit allowlistedLicenses;
+    allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) allowedUnfreePackages;
+  };
+in
+nixpkgsConfig

--- a/lib/test-nixos-boot.nix
+++ b/lib/test-nixos-boot.nix
@@ -1,4 +1,9 @@
-{ lib, importPkgsStable, ... }:
+{
+  top,
+  lib,
+  importPkgsStable,
+  ...
+}:
 lib.mapAttrs
   (
     name: hostDef:

--- a/lib/test-nixos-boot.nix
+++ b/lib/test-nixos-boot.nix
@@ -24,7 +24,7 @@ lib.mapAttrs
       };
       nodes.machine = {
         imports = hostDef.modules ++ [
-          ./nixos/test/vm-override.nix
+          ../nixos/test/vm-override.nix
         ];
       };
       # テスト環境はネットワークに繋がっていないため、

--- a/lib/test-nixos-boot.nix
+++ b/lib/test-nixos-boot.nix
@@ -1,0 +1,34 @@
+{ lib, importPkgsStable, ... }:
+lib.mapAttrs
+  (
+    name: hostDef:
+    (importPkgsStable hostDef.system).testers.runNixOSTest {
+      name = "test-nixos-boot-${name}";
+      node = {
+        # `runNixOSTest`が追加する`nixpkgs`の読み込み専用設定を無効化します。
+        # `hardware-configuration.nix`が存在する時、
+        # `nixpkgs.hostPlatform`を設定しているので、
+        # 読み込み専用にされた`nixpkgs`オプションへの設定がエラーになります。
+        # 基本的にモジュール単位のテスト機構であり、
+        # 全体のブートを想定していないゆえの挙動でしょう。
+        # 自動生成ファイルである`hardware-configuration.nix`を編集したくないため、
+        # 上書きを有効にしてしまいます。
+        # ブートのテストの場合ではあまり問題にならないはずです。
+        pkgsReadOnly = false;
+        inherit (hostDef) specialArgs;
+      };
+      nodes.machine = {
+        imports = hostDef.modules ++ [
+          ./nixos/test/vm-override.nix
+        ];
+      };
+      # テスト環境はネットワークに繋がっていないため、
+      # ネットワーク依存のユニットは失敗します。
+      # よって全体成功を期待することはできません。
+      # multi-user.targetに到達すればひとまず成功とみなしています。
+      testScript = ''
+        machine.wait_for_unit("multi-user.target")
+      '';
+    }
+  )
+  (lib.filterAttrs (_: def: !(def.nixosSystem.config.wsl.enable or false)) top.config.flake.hostDefs)


### PR DESCRIPTION
`flake.nix`が肥大化してきて見通しが悪くなっていたため、
NixOSシステム構築用の`mkNixosSystem`、
Linux向けhome-manager構築用の`mkLinuxHomeManager`、
nixpkgs共通設定の`nixpkgsConfig`、
ブートテスト用の`testNixosBoot`を、
それぞれ`lib/`配下の独立したファイルへ分離します。

これにより`flake.nix`の役割が、
各ホストの定義と各種ヘルパーの組み合わせに集中し、
個別のヘルパーの実装は対応するファイルを参照すれば把握できるようになります。

合わせて以下の細かな整理も含みます。

- `mkNixosSystem`のスコープを`hostDefs`内に限定して外部からの依存を整理。
- 管理外の場所から参照していなかった`qemu-user`をexport対象から削除。
- `treefmt.config`の記述位置を他リポジトリと揃えて統一。
