### PR TITLE
perf(flake): pkgsをsystemごとにメモ化して評価メモリを削減

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -149,10 +149,19 @@
               inherit system overlays;
               config = nixpkgsConfig;
             };
+          # systemごとにpkgsをメモ化するヘルパー。
+          # 複数ホストやcheck/test-nixos-bootから同じ`system`で繰り返し呼ばれても、
+          # 同じpkgs実体を返すようにして、評価時のメモリ消費を削減する。
+          memoizePkgsPerSystem =
+            f:
+            let
+              memo = lib.genAttrs top.config.systems f;
+            in
+            system: memo.${system};
           # systemを受け取り安定版のpkgsを生成する。
-          importPkgsStable = importPkgsFor nixpkgs;
+          importPkgsStable = memoizePkgsPerSystem (importPkgsFor nixpkgs);
           # systemを受け取り不安定版のpkgsを生成する。
-          importPkgsUnstable = importPkgsFor nixpkgs-unstable;
+          importPkgsUnstable = memoizePkgsPerSystem (importPkgsFor nixpkgs-unstable);
         in
         {
           hostDefs =


### PR DESCRIPTION
`importPkgsStable`と`importPkgsUnstable`はホスト数ぶん同じ`system`引数で呼ばれていましたが、
Nixは関数適用をキャッシュしないため、
毎回新しいpkgsインスタンスが構築されていました。
特に`pkgs-unstable`は全ホストで同じ`x86_64-linux`引数なのに4回別個に評価されており、
無駄なメモリを消費していました。

`memoizePkgsPerSystem`ヘルパーを介して、
`top.config.systems`をキーに`lib.genAttrs`でsystem別にpkgsを共有するようにしました。
これにより4ホスト一括評価時のheapピークが、
`10.42GB`から`9.93GB`へ約`490MB`減少します。
