### PR TITLE
fix(locate): direnv関連ディレクトリをupdatedbの除外リストに追加

### DIFF
--- a/nixos/core/locate.nix
+++ b/nixos/core/locate.nix
@@ -12,6 +12,7 @@
     prunePaths = lib.mkOptionDefault [
       "/home/${username}/.claude/plugins"
       "/home/${username}/.claude/projects"
+      "/home/${username}/.local/share/direnv"
       "/home/${username}/.local/state/cabal/store"
     ];
     pruneNames = lib.mkOptionDefault [
@@ -20,6 +21,7 @@
       ".Trash-1000"
       ".cabal"
       ".cargo"
+      ".direnv"
       ".dub"
       ".gem"
       ".ghcup"


### PR DESCRIPTION
- `/home/${username}/.local/share/direnv`と`.direnv`をprune対象に追加
- 不要なインデックス作成を防ぎ、検索結果のノイズを減少
