### PR TITLE
refactor: nixpkgs.pkgs共有化と未使用Haskellツールの削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,14 +169,11 @@
               mkNixosSystem = import ./lib/mk-nixos-system.nix {
                 inherit
                   lib
+                  importPkgsStable
                   importPkgsUnstable
                   importDirModules
                   inputs
                   ;
-                nixpkgs = {
-                  config = nixpkgsConfig;
-                  inherit overlays;
-                };
               };
             in
             {

--- a/home/core/haskell.nix
+++ b/home/core/haskell.nix
@@ -34,13 +34,9 @@ in
   home = {
     packages =
       (with pkgs; [
-        alex
         cabal-install
-        cabal2nix
         fourmolu
         ghc
-        happy
-        haskell-ci
         haskell-language-server
         hlint
         hpack

--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -1,6 +1,6 @@
 {
-  nixpkgs,
   lib,
+  importPkgsStable,
   importPkgsUnstable,
   importDirModules,
   inputs,
@@ -20,9 +20,11 @@ let
     username = "ncaq";
   };
   modules = [
-    {
-      inherit nixpkgs;
-    }
+    # 共有のpkgsインスタンスをNixOSに渡し、
+    # ホストごとにnixpkgs全体を再評価することによるメモリ重複を防ぐ。
+    # `nixpkgs.overlays`は`appendOverlays`で後から追加されるため、
+    # CPU最適化overlayなどホスト固有のoverlayは引き続き有効。
+    { nixpkgs.pkgs = importPkgsStable system; }
     inputs.disko.nixosModules.default
     inputs.sops-nix.nixosModules.sops
     ../nixos/configuration.nix


### PR DESCRIPTION
評価メモリ削減を狙った2件の設定整理をまとめました。
ただし計測の結果、メモリ削減効果は限定的でした。

`perf(flake)`では、
`mk-nixos-system.nix`で`nixpkgs.pkgs`が未設定だった状態を解消し、
`memoizePkgsPerSystem`済みの共有pkgsインスタンスを渡す形に変更しました。
全ホストのtoplevel drvPathが修正前後で完全に同一であることを確認しています。
副次的に現代の`nixpkgs.nix`にあるassertion違反リスクが解消されます。

`refactor(home/haskell)`では、
`alex`/`cabal2nix`/`happy`/`haskell-ci`をhome-managerから削除しました。
これらは普段直接呼び出すことがほぼなく、
必要時はdevShellや`nix shell`で個別投入で十分なためです。

計測結果として`checks.x86_64-linux`全体評価でピークRSSが約`2.4%`減少した程度で、
メモリ消費の主因にたどり着いたわけではありません。
home-managerの評価メモリの大半は、
Emacs LSP群やHaskellツールチェーンの依存ツリーで占められており、
ワークフロー上削減困難なため、本PRは設定整理として位置付けます。