### PR TITLE
build: devShellsからnix-fast-buildへの依存を削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -323,7 +323,6 @@
 
               # nixの関連ツール。
               nil
-              nix-fast-build
 
               # GitHub関連ツール。
               gh


### PR DESCRIPTION
nix-fast-buildをせっかくラッパーでカスタマイズしているのに、
devShellsから参照してしまうとカスタマイズを貫通してしまうため。
