### PR TITLE
refactor(flake): `mkFlake`のクロージャ形式を廃止して評価順を直線化

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,118 +120,123 @@
       home-manager,
       ...
     }:
-    flake-parts.lib.mkFlake { inherit inputs; } (top: {
-      imports = [
-        home-manager.flakeModules.home-manager
-        treefmt-nix.flakeModule
-      ];
+    let
+      inherit (nixpkgs) lib;
 
       systems = [
         "aarch64-linux"
         "x86_64-linux"
       ];
 
-      flake =
-        let
-          inherit (nixpkgs) lib;
-          # ディレクトリ内の全`.nix`ファイルをimportするヘルパー関数。
-          importDirModules = import ./lib/import-dir-modules.nix { inherit lib; };
-          # nixpkgsの共通設定。
-          nixpkgsConfig = import ./lib/nixpkgs-config.nix { inherit lib; };
-          # 全環境で共通のoverlays。
-          overlays = [
-            inputs.firge-nix.overlays.default
-          ];
-          # system固有のpkgsを生成する関数。
-          importPkgsFor =
-            pkgset: system:
-            import pkgset {
-              inherit system overlays;
-              config = nixpkgsConfig;
-            };
-          # systemごとにpkgsをメモ化するヘルパー。
-          # 複数ホストやcheck/test-nixos-bootから同じ`system`で繰り返し呼ばれても、
-          # 同じpkgs実体を返すようにして、評価時のメモリ消費を削減する。
-          memoizePkgsPerSystem =
-            f:
-            let
-              memo = lib.genAttrs top.config.systems f;
-            in
-            system: memo.${system};
-          # systemを受け取り安定版のpkgsを生成する。
-          importPkgsStable = memoizePkgsPerSystem (importPkgsFor nixpkgs);
-          # systemを受け取り不安定版のpkgsを生成する。
-          importPkgsUnstable = memoizePkgsPerSystem (importPkgsFor nixpkgs-unstable);
-        in
-        {
-          hostDefs =
-            let
-              mkNixosSystem = import ./lib/mk-nixos-system.nix {
-                inherit
-                  lib
-                  importPkgsStable
-                  importPkgsUnstable
-                  importDirModules
-                  inputs
-                  ;
-              };
-            in
-            {
-              "SSD0086" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "SSD0086";
-              };
-              "bullet" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "bullet";
-              };
-              "creep" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "creep";
-              };
-              "seminar" = mkNixosSystem {
-                system = "x86_64-linux";
-                hostName = "seminar";
-              };
-            };
-
-          nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) top.config.flake.hostDefs;
-
-          testNixosBoot = import ./lib/test-nixos-boot.nix {
-            inherit top lib importPkgsStable;
-          };
-
-          homeConfigurations =
-            let
-              mkLinuxHomeManager = import ./lib/mk-linux-home-manager.nix {
-                inherit
-                  importPkgsStable
-                  importPkgsUnstable
-                  importDirModules
-                  inputs
-                  ;
-              };
-            in
-            {
-              "x86_64-linux" = mkLinuxHomeManager {
-                system = "x86_64-linux";
-                username = "ncaq";
-              };
-            };
-
-          nixOnDroidConfigurations = {
-            default = import ./nix-on-droid {
-              inherit
-                importDirModules
-                inputs
-                nixpkgsConfig
-                overlays
-                ;
-              system = "aarch64-linux";
-              username = "ncaq";
-            };
-          };
+      # ディレクトリ内の全`.nix`ファイルをimportするヘルパー関数。
+      importDirModules = import ./lib/import-dir-modules.nix { inherit lib; };
+      # nixpkgsの共通設定。
+      nixpkgsConfig = import ./lib/nixpkgs-config.nix { inherit lib; };
+      # 全環境で共通のoverlays。
+      overlays = [
+        inputs.firge-nix.overlays.default
+      ];
+      # system固有のpkgsを生成する関数。
+      importPkgsFor =
+        pkgset: system:
+        import pkgset {
+          inherit system overlays;
+          config = nixpkgsConfig;
         };
+      # systemごとにpkgsをメモ化するヘルパー。
+      # 複数ホストやcheck/test-nixos-bootから同じ`system`で繰り返し呼ばれても、
+      # 同じpkgs実体を返すようにして、評価時のメモリ消費を削減する。
+      memoizePkgsPerSystem =
+        f:
+        let
+          memo = lib.genAttrs systems f;
+        in
+        system: memo.${system};
+      # systemを受け取り安定版のpkgsを生成する。
+      importPkgsStable = memoizePkgsPerSystem (importPkgsFor nixpkgs);
+      # systemを受け取り不安定版のpkgsを生成する。
+      importPkgsUnstable = memoizePkgsPerSystem (importPkgsFor nixpkgs-unstable);
+
+      mkNixosSystem = import ./lib/mk-nixos-system.nix {
+        inherit
+          lib
+          importPkgsStable
+          importPkgsUnstable
+          importDirModules
+          inputs
+          ;
+      };
+
+      hostDefs = {
+        "SSD0086" = mkNixosSystem {
+          system = "x86_64-linux";
+          hostName = "SSD0086";
+        };
+        "bullet" = mkNixosSystem {
+          system = "x86_64-linux";
+          hostName = "bullet";
+        };
+        "creep" = mkNixosSystem {
+          system = "x86_64-linux";
+          hostName = "creep";
+        };
+        "seminar" = mkNixosSystem {
+          system = "x86_64-linux";
+          hostName = "seminar";
+        };
+      };
+
+      nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) hostDefs;
+
+      testNixosBoot = import ./lib/test-nixos-boot.nix {
+        inherit lib importPkgsStable hostDefs;
+      };
+
+      mkLinuxHomeManager = import ./lib/mk-linux-home-manager.nix {
+        inherit
+          importPkgsStable
+          importPkgsUnstable
+          importDirModules
+          inputs
+          ;
+      };
+
+      homeConfigurations = {
+        "x86_64-linux" = mkLinuxHomeManager {
+          system = "x86_64-linux";
+          username = "ncaq";
+        };
+      };
+
+      nixOnDroidConfigurations = {
+        default = import ./nix-on-droid {
+          inherit
+            importDirModules
+            inputs
+            nixpkgsConfig
+            overlays
+            ;
+          system = "aarch64-linux";
+          username = "ncaq";
+        };
+      };
+    in
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        home-manager.flakeModules.home-manager
+        treefmt-nix.flakeModule
+      ];
+
+      inherit systems;
+
+      flake = {
+        inherit
+          nixosConfigurations
+          testNixosBoot
+          homeConfigurations
+          nixOnDroidConfigurations
+          ;
+      };
 
       perSystem =
         {
@@ -264,7 +269,6 @@
 
           checks =
             let
-              inherit (nixpkgs) lib;
               # NixOS構成の評価チェック(評価のみ、ビルドしない)
               nixosEvalChecks =
                 lib.mapAttrs'
@@ -279,12 +283,12 @@
                   (
                     lib.filterAttrs (
                       _: nixosConfig: nixosConfig.pkgs.stdenv.hostPlatform.system == system
-                    ) top.config.flake.nixosConfigurations
+                    ) nixosConfigurations
                   );
               # home-manager構成の評価チェック
               hmEvalChecks =
                 let
-                  hmConfig = top.config.flake.homeConfigurations.${system} or null;
+                  hmConfig = homeConfigurations.${system} or null;
                 in
                 lib.optionalAttrs (hmConfig != null) {
                   "hm-eval" = builtins.seq hmConfig.activationPackage.drvPath (
@@ -329,7 +333,7 @@
             ];
           };
         };
-    });
+    };
 
   nixConfig = {
     extra-substituters = [

--- a/lib/test-nixos-boot.nix
+++ b/lib/test-nixos-boot.nix
@@ -1,39 +1,37 @@
 {
-  top,
   lib,
   importPkgsStable,
+  hostDefs,
   ...
 }:
-lib.mapAttrs
-  (
-    name: hostDef:
-    (importPkgsStable hostDef.system).testers.runNixOSTest {
-      name = "test-nixos-boot-${name}";
-      node = {
-        # `runNixOSTest`が追加する`nixpkgs`の読み込み専用設定を無効化します。
-        # `hardware-configuration.nix`が存在する時、
-        # `nixpkgs.hostPlatform`を設定しているので、
-        # 読み込み専用にされた`nixpkgs`オプションへの設定がエラーになります。
-        # 基本的にモジュール単位のテスト機構であり、
-        # 全体のブートを想定していないゆえの挙動でしょう。
-        # 自動生成ファイルである`hardware-configuration.nix`を編集したくないため、
-        # 上書きを有効にしてしまいます。
-        # ブートのテストの場合ではあまり問題にならないはずです。
-        pkgsReadOnly = false;
-        inherit (hostDef) specialArgs;
-      };
-      nodes.machine = {
-        imports = hostDef.modules ++ [
-          ../nixos/test/vm-override.nix
-        ];
-      };
-      # テスト環境はネットワークに繋がっていないため、
-      # ネットワーク依存のユニットは失敗します。
-      # よって全体成功を期待することはできません。
-      # multi-user.targetに到達すればひとまず成功とみなしています。
-      testScript = ''
-        machine.wait_for_unit("multi-user.target")
-      '';
-    }
-  )
-  (lib.filterAttrs (_: def: !(def.nixosSystem.config.wsl.enable or false)) top.config.flake.hostDefs)
+lib.mapAttrs (
+  name: hostDef:
+  (importPkgsStable hostDef.system).testers.runNixOSTest {
+    name = "test-nixos-boot-${name}";
+    node = {
+      # `runNixOSTest`が追加する`nixpkgs`の読み込み専用設定を無効化します。
+      # `hardware-configuration.nix`が存在する時、
+      # `nixpkgs.hostPlatform`を設定しているので、
+      # 読み込み専用にされた`nixpkgs`オプションへの設定がエラーになります。
+      # 基本的にモジュール単位のテスト機構であり、
+      # 全体のブートを想定していないゆえの挙動でしょう。
+      # 自動生成ファイルである`hardware-configuration.nix`を編集したくないため、
+      # 上書きを有効にしてしまいます。
+      # ブートのテストの場合ではあまり問題にならないはずです。
+      pkgsReadOnly = false;
+      inherit (hostDef) specialArgs;
+    };
+    nodes.machine = {
+      imports = hostDef.modules ++ [
+        ../nixos/test/vm-override.nix
+      ];
+    };
+    # テスト環境はネットワークに繋がっていないため、
+    # ネットワーク依存のユニットは失敗します。
+    # よって全体成功を期待することはできません。
+    # multi-user.targetに到達すればひとまず成功とみなしています。
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+    '';
+  }
+) (lib.filterAttrs (_: def: !(def.nixosSystem.config.wsl.enable or false)) hostDefs)


### PR DESCRIPTION
`flake-parts.lib.mkFlake { inherit inputs; } (top: { ... })`形式は、
モジュール内から`top.config.systems`や`top.config.flake.hostDefs`を介して自己参照できる仕組みです。
しかし`flake`属性の中身が後続の`perSystem`から参照されるなど、
定義箇所と参照箇所が離れて評価順が追いにくくなっていました。

そこで`outputs`直下のletブロックで以下を上から順に定義し、
`flake-parts.lib.mkFlake`にはこれらを参照するだけの素のモジュール属性セットを渡す形に変更しました。

- `systems`
- `nixosConfigurations`
- `testNixosBoot`
- `homeConfigurations`
- `nixOnDroidConfigurations`

クロージャ引数の`top`は不要になるため取り除きます。

合わせて`lib/test-nixos-boot.nix`の引数も`top`から`hostDefs`を直接受け取る形に変更しました。
モジュールシステム経由の`top.config.flake.hostDefs`参照は、
letで定義済みの`hostDefs`をそのまま渡せば足りるためです。

`perSystem.checks`内で`nixosConfigurations`と`homeConfigurations`を参照していた箇所も、
`top.config.flake.*`から外側のletの値への直接参照に置き換えました。
あわせて重複していた`inherit (nixpkgs) lib;`を外側のletに集約しました。

`nix-fast-build`での評価チェックが修正前と同様に全て通ることを確認済みです。
