### PR TITLE
fix(zeroconf): systemd-resolvedのmDNSレスポンダを無効化してavahiに一本化

### DIFF
--- a/nixos/native-linux/zeroconf.nix
+++ b/nixos/native-linux/zeroconf.nix
@@ -13,20 +13,16 @@ _: {
         workstation = true;
       };
     };
+    # systemd-resolvedのmDNSレスポンダを無効化してavahiにmDNSを一本化する。
+    # 両者が同じホスト名を広告するとavahiがself-conflictを起こし、
+    # `Host name conflict, retrying with hostname-N`で名前末尾の数字が増え続ける。
+    # Debian trixieの、
+    # [TC decision on avahi vs systemd-resolved - #1091864](https://lists.debian.org/debian-ctte/2025/02/msg00019.html)や、
+    # Fedora(`-Ddefault-mdns=no`ビルド)が同等の対処をしており、
+    # avahi-daemonを主のmDNS実装とする運用が業界標準。
+    resolved.extraConfig = "MulticastDNS=no";
     gvfs.enable = true;
   };
-
-  # systemd-resolvedのmDNSレスポンダを無効化してavahiにmDNSを一本化する。
-  # 両者が同じホスト名を広告するとavahiがself-conflictを起こし、
-  # `Host name conflict, retrying with hostname-N`で名前末尾の数字が増え続ける。
-  # Debian trixieの、
-  # [TC decision on avahi vs systemd-resolved - #1091864](https://lists.debian.org/debian-ctte/2025/02/msg00019.html)や、
-  # Fedora(`-Ddefault-mdns=no`ビルド)が同等の対処をしており、
-  # avahi-daemonを主のmDNS実装とする運用が業界標準。
-  environment.etc."systemd/resolved.conf.d/disable-mdns.conf".text = ''
-    [Resolve]
-    MulticastDNS=no
-  '';
 
   # nscdのsystemd再起動制限を緩和。
   # 起動時にavahiがネットワーク変更のたびにnscdを再起動させるため。

--- a/nixos/native-linux/zeroconf.nix
+++ b/nixos/native-linux/zeroconf.nix
@@ -16,6 +16,18 @@ _: {
     gvfs.enable = true;
   };
 
+  # systemd-resolvedのmDNSレスポンダを無効化してavahiにmDNSを一本化する。
+  # 両者が同じホスト名を広告するとavahiがself-conflictを起こし、
+  # `Host name conflict, retrying with hostname-N`で名前末尾の数字が増え続ける。
+  # Debian trixieの、
+  # [TC decision on avahi vs systemd-resolved - #1091864](https://lists.debian.org/debian-ctte/2025/02/msg00019.html)や、
+  # Fedora(`-Ddefault-mdns=no`ビルド)が同等の対処をしており、
+  # avahi-daemonを主のmDNS実装とする運用が業界標準。
+  environment.etc."systemd/resolved.conf.d/disable-mdns.conf".text = ''
+    [Resolve]
+    MulticastDNS=no
+  '';
+
   # nscdのsystemd再起動制限を緩和。
   # 起動時にavahiがネットワーク変更のたびにnscdを再起動させるため。
   systemd.services.nscd = {


### PR DESCRIPTION
avahi-daemonとsystemd-resolvedの両方がmDNSレスポンダとして同じホスト名を広告すると、
avahiがself-conflictを起こしてホスト名末尾の数字を延々と増やし続けます。
起動ログには`*** WARNING: Detected another IPv4 mDNS stack running on this host. ***`の警告とともに、
`Host name conflict, retrying with bullet-2`のようなメッセージが連発します。
実機の`bullet`では稼働中に`bullet-80.local`まで到達していることを確認しました。

`/etc/systemd/resolved.conf.d/disable-mdns.conf`をdrop-inで配置して、
systemd-resolved側の`MulticastDNS`を`no`に設定し、
mDNSレスポンダ機能をavahi-daemonに集約します。
NixOSの`services.resolved`には`MulticastDNS`に対応する構造化オプションがないため、
Debianの`avahi-disable-mdns.conf`と同じ形態のdrop-inを`environment.etc`で宣言的に置きます。

この対処はDebian trixieの決定の、
[Bug#1091864: TC decision on avahi vs systemd-resolved - #1091864](https://lists.debian.org/debian-ctte/2025/02/msg00019.html)と、
Fedoraの`-Ddefault-mdns=no`ビルドフラグでの対処と、
機能的には同等の措置です。

avahi-daemonを主のmDNS実装とする運用が業界標準に沿う形になっています。

close #1158
