### PR TITLE
refactor(native-linux): gvfsの有効化を専用モジュールに分離

### DIFF
--- a/nixos/native-linux/gvfs.nix
+++ b/nixos/native-linux/gvfs.nix
@@ -1,0 +1,3 @@
+_: {
+  services.gvfs.enable = true;
+}

--- a/nixos/native-linux/zeroconf.nix
+++ b/nixos/native-linux/zeroconf.nix
@@ -21,7 +21,6 @@ _: {
     # Fedora(`-Ddefault-mdns=no`ビルド)が同等の対処をしており、
     # avahi-daemonを主のmDNS実装とする運用が業界標準。
     resolved.extraConfig = "MulticastDNS=no";
-    gvfs.enable = true;
   };
 
   # nscdのsystemd再起動制限を緩和。


### PR DESCRIPTION
zeroconfと全く関係ないというわけではないですが、
関係性が結構薄いので。
