### PR TITLE
feat(ssh): Tailnet上のNixOSホストにuser指定を拡張

### DIFF
--- a/home/core/ssh.nix
+++ b/home/core/ssh.nix
@@ -1,13 +1,21 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   programs.ssh = {
     enable = true;
     package = pkgs.openssh; # システムのがない場合に備えて一貫してインストール指定。
     enableDefaultConfig = false;
     matchBlocks = {
-      "seminar" = {
-        user = "ncaq";
-      };
+      ${
+        lib.concatStringsSep " " [
+          "bullet"
+          "creep"
+          "seminar"
+          "ssd0086-wsl"
+        ]
+      } =
+        {
+          user = "ncaq";
+        };
       "ssh.forgejo.ncaq.net" = {
         port = 2222;
         user = "forgejo";


### PR DESCRIPTION
`home/core/ssh.nix`のSSH `matchBlocks`で`user = "ncaq"`を設定する対象を、
`seminar`のみから`bullet`/`creep`/`seminar`/`ssd0086-wsl`の4ホストへ拡張しました。
Tailscale SSHを使えばTailnet内で簡単にsshサーバを起動できますが、
rootアクセスは禁じ手のため、
明示的に`ncaq`へログインする必要があります。

わざわざ書かなくても良いようにしました。

ホスト名のキーは`lib.concatStringsSep " "`で配列を結合する形にしました。
各ホスト名を縦に並べることで、
追加や削除や差分レビューを行いやすくする意図です。
