### PR TITLE
feat(ssh): 独立したSSH公開鍵を`authorizedKeys`に追加

### DIFF
--- a/nixos/server/ssh.nix
+++ b/nixos/server/ssh.nix
@@ -10,6 +10,10 @@
   programs.mosh.enable = true;
   users.users.${username}.openssh.authorizedKeys.keys = [
     # 公開鍵は全世界に公開することが前提として設計されているので、dotfilesに含めて問題ない。
+
+    # GPGエージェントから利用できるSSH鍵。
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGYLEhh/AfM0TcAn15SgUcXZGtS3DxE/7xQmuxApawWg openpgp:0x79E75544"
+    # 独立したSSH鍵。
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICl317eHn8HMJgCOVEp3O2VOuj/6rMhq5IbsL2lTTOzQ ncaq@standalone"
   ];
 }


### PR DESCRIPTION
GPGエージェントを利用できないSSHクライアントのために、
独立して作成したSSH鍵を許容するように鍵を追加。

close #1174
