### PR TITLE
feat(seminar/cloudflare): QUIC用にUDPバッファサイズを増加

### DIFF
--- a/nixos/host/seminar/cloudflare.nix
+++ b/nixos/host/seminar/cloudflare.nix
@@ -33,6 +33,14 @@ in
       };
     };
   };
+  # Cloudflare TunnelがQUICを使うときのライブラリである、
+  # quic-goの推奨ガイドラインに従って、
+  # UDPバッファサイズを増大させます。
+  # [UDP Buffer Sizes](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes)
+  boot.kernel.sysctl = {
+    "net.core.rmem_max" = 7500000;
+    "net.core.wmem_max" = 7500000;
+  };
   sops = {
     # security.acmeのDNS-01チャレンジ用環境変数ファイル。
     # lego(ACMEクライアント)がCloudflare DNS APIでTXTレコードを操作する。


### PR DESCRIPTION
Cloudflare TunnelがQUICを利用する際の推奨に従い、
quic-goのガイドラインに基づいて、
`net.core.rmem_max`と`net.core.wmem_max`を`7500000`に設定。
