### PR TITLE
fix(user): home-manager activationでgpg-agentに接続できない問題を修正

### DIFF
--- a/nixos/core/user.nix
+++ b/nixos/core/user.nix
@@ -73,6 +73,6 @@ in
   # `user@$UID.service`の起動完了を待つことで競合状態を防ぎます。
   systemd.services."home-manager-${username}" = {
     after = [ "user@${toString uid}.service" ];
-    wants = [ "user@${toString uid}.service" ]; # 失敗していてもできる限り起動をしてほしいので弱い依存。
+    wants = [ "user@${toString uid}.service" ]; # 失敗してもなるべく起動してほしいので弱い依存。
   };
 }

--- a/nixos/core/user.nix
+++ b/nixos/core/user.nix
@@ -1,4 +1,13 @@
-{ pkgs, username, ... }:
+{
+  pkgs,
+  username,
+  ...
+}:
+let
+  # 通常のユーザのUID。
+  # ほとんどのLinuxディストリビューションで、最初の通常ユーザはUID 1000から始まります。
+  uid = 1000;
+in
 {
   users = {
     # ユーザを宣言的に管理してインストールごとに情報を上書きします。
@@ -7,7 +16,7 @@
       # 通常利用するユーザです。
       ${username} = {
         isNormalUser = true;
-        uid = 1000;
+        inherit uid;
         extraGroups = [
           "input"
           "networkmanager"
@@ -18,9 +27,9 @@
         shell = pkgs.zsh;
         # `home-manager-${username}.service`はboot時に`multi-user.target`の段階で実行されます。
         # 内部で`gpg --edit-key`などgpg-agentに依存する処理を行います。
-        # gpg-agentは`/run/user/1000/`配下にソケットを作成するため、
-        # `user@1000.service`が起動していないとIPC接続に失敗します。
-        # lingerを有効にしてログインしなくてもboot時から`user@1000.service`を起動させ、
+        # gpg-agentは`/run/user/$UID/`配下にソケットを作成するため、
+        # `user@$UID.service`が起動していないとIPC接続に失敗します。
+        # lingerを有効にしてログインしなくてもboot時から`user@$UID.service`を起動させ、
         # `After=user@.service`で順序を明示することでこの問題を回避します。
         linger = true;
         # `hashedPassword`をリポジトリにコミットしている理由:
@@ -59,11 +68,11 @@
       };
     };
   };
-  # lingerだけでは`user@1000.service`と`home-manager-${username}.service`が並列起動するため、
+  # lingerだけでは`user@$UID.service`と`home-manager-${username}.service`が並列起動するため、
   # gpg-agentソケットの準備が間に合わずIPC接続に失敗することがあります。
-  # `user@1000.service`の起動完了を待つことで競合状態を防ぎます。
+  # `user@$UID.service`の起動完了を待つことで競合状態を防ぎます。
   systemd.services."home-manager-${username}" = {
-    after = [ "user@1000.service" ];
-    wants = [ "user@1000.service" ]; # 失敗していてもできる限り起動をしてほしいので弱い依存。
+    after = [ "user@${toString uid}.service" ];
+    wants = [ "user@${toString uid}.service" ]; # 失敗していてもできる限り起動をしてほしいので弱い依存。
   };
 }

--- a/nixos/core/user.nix
+++ b/nixos/core/user.nix
@@ -16,6 +16,13 @@
           "wheel"
         ];
         shell = pkgs.zsh;
+        # `home-manager-${username}.service`はboot時に`multi-user.target`の段階で実行されます。
+        # 内部で`gpg --edit-key`などgpg-agentに依存する処理を行います。
+        # gpg-agentは`/run/user/1000/`配下にソケットを作成するため、
+        # `user@1000.service`が起動していないとIPC接続に失敗します。
+        # lingerを有効にしてログインしなくてもboot時から`user@1000.service`を起動させ、
+        # `After=user@.service`で順序を明示することでこの問題を回避します。
+        linger = true;
         # `hashedPassword`をリポジトリにコミットしている理由:
         # yescrypt($y$)はメモリハード関数であり、
         # 高性能GPUでも数千hash/sec程度の速度しか出ません。
@@ -51,5 +58,12 @@
         hashedPassword = "$y$j9T$Pe0nKS1opi71jOuppQo0p/$zB9VQoagiIHgvnGNBgyxmBk7Ib6xyMDsfwW451pZoaC";
       };
     };
+  };
+  # lingerだけでは`user@1000.service`と`home-manager-${username}.service`が並列起動するため、
+  # gpg-agentソケットの準備が間に合わずIPC接続に失敗することがあります。
+  # `user@1000.service`の起動完了を待つことで競合状態を防ぎます。
+  systemd.services."home-manager-${username}" = {
+    after = [ "user@1000.service" ];
+    wants = [ "user@1000.service" ]; # 失敗していてもできる限り起動をしてほしいので弱い依存。
   };
 }


### PR DESCRIPTION
ヘッドレスサーバの`seminar`やオートログインのタイミング次第で`creep`でも、
boot時に`home-manager-ncaq.service`が以下のエラーで失敗していました。

```
hm-activate-ncaq[2509]: gpg: can't connect to the gpg-agent: IPC connect呼び出しに失敗しました
home-manager-ncaq.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```

`home-manager-${username}.service`は`multi-user.target`の段階でユーザ権限で実行されますが、
internalで`importGpgKeys`の`gpg --edit-key`がgpg-agentとのIPC接続を要求します。
gpg-agentは`/run/user/1000/gnupg/S.gpg-agent`にソケットを作るため、
`user@1000.service`が起動して`/run/user/1000/`が用意されていないとspawnに失敗します。

`bullet`では`lightdm-autologin`が早めに`user@1000.service`を起動するため失敗せず、
`creep`では同じautologinでもタイミング次第で失敗、
`seminar`は`systemd.defaultUnit`を`multi-user.target`に固定していてautologin自体が無いため、
SSHログインまで`/run/user/1000/`が存在せず必ず失敗していました。

対処として全ホスト共通の`nixos/core/user.nix`で2つの設定を加えました。

- `users.users.${username}.linger = true;`でboot時から`user@1000.service`を起動
- `systemd.services."home-manager-${username}"`に`After`/`Wants`を加えて起動順序を保証

`Requires`ではなく`Wants`を採用したのは、
`user@1000.service`が万一失敗してもhome-manager activationの試行自体は走らせたいためです。

`nix-fast-build`で全`nixosConfigurations`(`bullet`/`creep`/`seminar`/`SSD0086`)と`treefmt`が通ることを確認済みです。
