### PR TITLE
fix(github-runner): ジョブ開始フックを`.sh`ラッパー経由で実行

### DIFF
--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  lib,
   config,
   inputs,
   ...
@@ -37,6 +38,20 @@ let
       runHook postInstall
     '';
   };
+  # ジョブ開始フックを実行する`.sh`ラッパー。
+  # `ACTIONS_RUNNER_HOOK_JOB_STARTED`に`.js`を直接指定すると、
+  # github-runner 2.334.0では`.js`フックのセットアップが、
+  # .NET由来のパスエラー("Second path fragment must not be a drive or UNC name")で失敗します。
+  # GitHubが公式にサポートするフック形式は`.sh`と`.ps1`のみなので、
+  # nixpkgsのnodeでjsを実行する`.sh`ラッパー経由で呼び出します。
+  # これによりランナー内蔵nodeのパス解決にも依存しなくなります。
+  jobStartedHook = lib.getExe (
+    pkgs.writeShellApplication {
+      name = "job-started-hook.sh";
+      runtimeInputs = with pkgs; [ nodejs ];
+      text = ''exec node ${dotfiles-github-runner}/job-started-hook.js "$@"'';
+    }
+  );
   # GitHub Actionsランナーはホストのnixデーモンと通信するため、
   # 統一されたユーザ値を使います。
   user = config.serviceUser.github-runner;
@@ -75,7 +90,7 @@ in
       githubActionsRunnerPackages
       selfHostRunnerPackages
       runnerNum
-      dotfiles-github-runner
+      jobStartedHook
       users
       ciNixSettings
       ;

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -10,7 +10,7 @@ let
     githubActionsRunnerPackages
     selfHostRunnerPackages
     runnerNum
-    dotfiles-github-runner
+    jobStartedHook
     users
     ciNixSettings
     ;
@@ -62,7 +62,6 @@ in
               runnerNumbers = builtins.genList (x: x) runnerNum;
               args = { inherit pkgs; };
               extraPkgs = (githubActionsRunnerPackages args).all ++ selfHostRunnerPackages args;
-              jobStartedHook = "${dotfiles-github-runner}/job-started-hook.js";
               mkRunnerDotfilesX64 = number: {
                 name = "dotfiles-x64-${toString number}";
                 value = {


### PR DESCRIPTION
`nixpkgs 26.05`が同梱する`github-runner 2.334.0`では、
`ACTIONS_RUNNER_HOOK_JOB_STARTED`に`.js`を直接指定すると、
"Set up runner"段階でフックのセットアップが、
`.NET`由来のパスエラー(`Second path fragment must not be a drive or UNC name`)で失敗します。
全てのセルフホストジョブがこれで問答無用に落ちるようになりました。

`GetDefaultShellForScript`の`.js`分岐自体は`2.329`から`2.334`まで変わっていませんが、
`2.334.0`で式評価SDKが`GitHub.Actions.Expressions`へ大規模リファクタされ、
新たにDAPデバッガが導入されています。
エラーのパラメータ名が`expression`であることとも一致し、
これはランナー側の回帰です。

GitHubが公式にサポートするフック形式は`.sh`と`.ps1`のみなので、
nixpkgsのnodeで既存のjsを実行する`.sh`ラッパー経由に切り替えます。
これで問題の`.js`専用コードパスを避けられ、
ランナー内蔵nodeのパス解決にも依存しなくなります。
フック本体のロジックは変更していないため多層防御の意図はそのまま維持されます。
