### PR TITLE
build(deps): nixpkgsの`alacritty-theme`をそのまま使用

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "alacritty-theme": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1777677514,
-        "narHash": "sha256-F8ye16jhfldsyxcOqxVS0PNecVcQcAPnEahDKS4PGwE=",
-        "owner": "alacritty",
-        "repo": "alacritty-theme",
-        "rev": "2749b407b597790e6f08b218c2bc2acdf66210a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "alacritty",
-        "repo": "alacritty-theme",
-        "type": "github"
-      }
-    },
     "claude-desktop": {
       "inputs": {
         "flake-utils": [
@@ -546,7 +530,6 @@
     },
     "root": {
       "inputs": {
-        "alacritty-theme": "alacritty-theme",
         "claude-desktop": "claude-desktop",
         "disko": "disko",
         "dot-emacs": "dot-emacs",

--- a/flake.nix
+++ b/flake.nix
@@ -103,15 +103,6 @@
       url = "github:ncaq/firge-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-
-    # nixpkgs側にまだ求めている更新がないため、
-    # 上流から直接最新のテーマを取得します。
-    # nixpkgsのalacritty-theme derivationを`overrideAttrs`で再利用するので、
-    # `flake = false`で生のソースだけを参照します。
-    alacritty-theme = {
-      url = "github:alacritty/alacritty-theme";
-      flake = false;
-    };
   };
 
   outputs =

--- a/home/core/alacritty.nix
+++ b/home/core/alacritty.nix
@@ -51,7 +51,8 @@ in
         # ホストにおおよそ見合ったフォントサイズにします。
         # 低解像度のホストでは小さめに、
         # 高解像度のホストでは大きめにします。
-        # home-managerスタンドアロン構成ではosConfigがnullになるため`or`でデフォルト値にフォールバックします。
+        # home-managerスタンドアロン構成では`osConfig`が`null`になるため、
+        # `or`でデフォルト値にフォールバックします。
         size = if (osConfig.networking.hostName or "") == "creep" then 9 else 12;
       };
       # Windows環境で起動したときはWSLのシェルを起動するようにします。

--- a/home/core/alacritty.nix
+++ b/home/core/alacritty.nix
@@ -4,7 +4,6 @@
   config,
   isWSL,
   osConfig,
-  inputs,
   ...
 }:
 let
@@ -13,15 +12,6 @@ let
   alacrittyConfigFile = config.xdg.configFile."alacritty/alacritty.toml".source;
   # Windows環境(WSLではなく)では設定パスの場所は`%APPDATA%\alacritty\alacritty.toml`です。
   windowsAlacrittyConfigFile = "${windowsAppData}/alacritty/alacritty.toml";
-  # `modus_vivendi`はnixpkgsピン時点ではまだ含まれていないため、
-  # 上流リポジトリの最新版を直接参照したテーマパッケージを構築します。
-  # nixpkgsのderivationを`overrideAttrs`で再利用して`installPhase`等の重複を避けます。
-  # flake input側に`name`属性が無いため、`sourceRoot`も明示的に上書きします。
-  alacrittyThemeLatest = pkgs.alacritty-theme.overrideAttrs (_: {
-    version = "0-unstable-${inputs.alacritty-theme.shortRev}";
-    src = inputs.alacritty-theme;
-    sourceRoot = "source/themes";
-  });
 in
 {
   programs.alacritty = {
@@ -36,7 +26,6 @@ in
     # 画像表示対応版を選択。
     package = pkgs.alacritty-graphics;
     theme = "modus_vivendi";
-    themePackage = alacrittyThemeLatest;
 
     settings = {
       window = {


### PR DESCRIPTION
`nixpkgs 26.05`で`alacritty-theme`が更新されて、
自分が出したPRの内容を含むようになったため、
独自にinputsから入れる必要がなくなりました。
素直にnixpkgsのものを使うように変更します。
