### PR TITLE
fix(mcp-nixos): fastmcpラッパーをやめてHTTPトランスポートで直接起動

### DIFF
--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -13,13 +13,6 @@
 }:
 let
   addr = config.machineAddresses.mcp-nixos;
-  # Pythonの依存関係とパッケージ自体をまとめて環境にします。
-  # mcp-nixosコマンドを直接実行するわけではないので依存パッケージの別途指定が必要です。
-  mcp-nixos-env = pkgs.python3.withPackages (
-    _: pkgs.mcp-nixos.propagatedBuildInputs ++ [ pkgs.mcp-nixos ]
-  );
-  # HTTPで提供するためにmcp-nixosをコマンドラインで動かすのではなくPythonモジュールを呼び出します。
-  serverPy = "${pkgs.mcp-nixos}/${pkgs.python3.sitePackages}/mcp_nixos/server.py";
 in
 {
   # 仮に脆弱性があった場合の被害を最小限に抑えるため仮想マシンで動かします。
@@ -78,11 +71,15 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
-            # オリジナルのmcp-nixosはHTTPサーバでは動きませんが、
-            # オリジナルでも使っているfastmcpを使うことでHTTPサーバとして動かせるようになります。
-            ExecStart =
-              "${mcp-nixos-env}/bin/fastmcp run ${serverPy}:mcp"
-              + " --transport streamable-http --host 0.0.0.0 --port 8080";
+            # mcp-nixosはHTTPトランスポートをネイティブにサポートしているので、
+            # 環境変数で設定して直接起動します。
+            # パスは未指定だとデフォルトの`/mcp`になり、Cloudflare Tunnelの転送先と一致します。
+            Environment = [
+              "MCP_NIXOS_TRANSPORT=http"
+              "MCP_NIXOS_HOST=0.0.0.0"
+              "MCP_NIXOS_PORT=8080"
+            ];
+            ExecStart = "${pkgs.mcp-nixos}/bin/mcp-nixos";
             DynamicUser = true;
             Restart = "always";
             RestartSec = 5;


### PR DESCRIPTION
`nixpkgs 26.05`へのアップデート後、
`mcp-nixos`のmicroVMサービスが起動しなくなりました。
これまでは`mcp-nixos`本体にHTTP提供機能がなかったため、
同梱の`fastmcp`を使い`fastmcp run server.py:mcp --transport streamable-http`で、
Pythonモジュールを直接起動していました。
しかしアップデートで`fastmcp`が`3.x`系に上がりCLIの仕様が変わったため、
このラッパー経由の起動が壊れたものと見られます。

現在の`mcp-nixos 2.4.3`はHTTPトランスポートをネイティブにサポートしており、
`MCP_NIXOS_TRANSPORT=http`などの環境変数で設定できます。
パス未指定時のデフォルトが`/mcp`で、
Cloudflare Tunnelの転送先(`https://mcp-nixos.ncaq.net/mcp`)とそのまま一致します。

そこで`fastmcp`ラッパーと依存パッケージを束ねるPython環境の指定をやめて、
`mcp-nixos`コマンドを環境変数付きで直接起動するように切り替えます。
これにより`fastmcp`のCLI仕様に依存しなくなり、
今後のバージョンアップにも壊れにくくなります。

実機へのデプロイ後、
ゲストのHTTPエンドポイントへの`initialize`が、
`200`で正常応答することを確認済みです。
