### PR TITLE
build(deps): stateVersionを25.05から26.05へ移行

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -14,6 +14,7 @@ in
       enable = true;
       lfs.enable = true;
       signing = {
+        format = "openpgp";
         key = identityKey;
         signByDefault = true;
       };

--- a/home/core/pass.nix
+++ b/home/core/pass.nix
@@ -1,12 +1,7 @@
 {
   config,
-  lib,
   ...
 }:
-let
-  inherit (config.services.pass-secret-service) storePath;
-  storeRel = lib.removePrefix "${config.home.homeDirectory}/" storePath;
-in
 {
   # GPGによる暗号化を行うpassを使用します。
   # あくまでメインのパスワードマネージャはKeePassXCです。
@@ -15,9 +10,16 @@ in
   # gnome-keyringではない理由はWSLとの連携が面倒だからです。
   # KeePassXCに繋げない理由はアンロックを意図的に面倒にしているので、
   # 常にアンロックしていることが期待できないからです。
-  programs.password-store.enable = true;
+  programs.password-store = {
+    enable = true;
+    settings = {
+      # XDGデータディレクトリ以下にストアを置くため明示的に指定します。
+      PASSWORD_STORE_DIR = "${config.xdg.dataHome}/password-store";
+      # `pass init`による`.gpg-id`の生成の代わりに、
+      # 暗号化先のGPG鍵を宣言的に指定します。
+      # passは`PASSWORD_STORE_KEY`があれば`.gpg-id`より優先して使います。
+      PASSWORD_STORE_KEY = "42248C7D0FB73D57";
+    };
+  };
   services.pass-secret-service.enable = true;
-
-  # `pass init`の代わりに宣言的にパスワードストアを初期化します。
-  home.file."${storeRel}/.gpg-id".text = "42248C7D0FB73D57\n";
 }

--- a/home/core/zsh.nix
+++ b/home/core/zsh.nix
@@ -28,7 +28,7 @@ in
             echo "Warning: tmux failed to start. Falling back to normal shell." >&2
           fi
         fi
-        # tmuxセッションの中に既にいる場合はユーザの設定を読み込みます。
+        # tmuxを起動しなかった場合、もしくはtmuxから戻ってきた場合に読み込みます。
         if [ -f "${zshUserDotDir}/.zshrc" ]; then
           source "${zshUserDotDir}/.zshrc"
         fi

--- a/home/core/zsh.nix
+++ b/home/core/zsh.nix
@@ -6,6 +6,7 @@
 }:
 let
   zshDotDir = config.programs.zsh.dotDir;
+  zshUserDotDir = "${zshDotDir}/.zsh.d";
 in
 {
   programs = {
@@ -16,6 +17,9 @@ in
       initContent = ''
         if [[ -x "$(command -v ${lib.getExe pkgs.tmux})" ]] \
           && [[ -z "$TMUX" ]] && [[ $- == *i* ]]; then
+          # tmuxがインストールされていて、
+          # 現在tmuxセッション内でなく、
+          # かつ対話型シェルの場合にtmuxセッションを開始します。
           if ${lib.getExe pkgs.tmux} new -A -s master; then
             # tmuxセッションが正常終了した場合、zshシェルも終了します。
             exit
@@ -24,8 +28,9 @@ in
             echo "Warning: tmux failed to start. Falling back to normal shell." >&2
           fi
         fi
-        if [ -f "${zshDotDir}/.zshrc" ]; then
-          source "${zshDotDir}/.zshrc"
+        # tmuxセッションの中に既にいる場合はユーザの設定を読み込みます。
+        if [ -f "${zshUserDotDir}/.zshrc" ]; then
+          source "${zshUserDotDir}/.zshrc"
         fi
       '';
     };
@@ -37,8 +42,8 @@ in
     shell.enableZshIntegration = true;
 
     activation.cloneZshConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      if [ ! -d "${zshDotDir}" ]; then
-        $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.zsh.d.git "${zshDotDir}"
+      if [ ! -d "${zshUserDotDir}" ]; then
+        $DRY_RUN_CMD ${pkgs.git}/bin/git clone https://github.com/ncaq/.zsh.d.git "${zshUserDotDir}"
       fi
     '';
   };

--- a/home/core/zsh.nix
+++ b/home/core/zsh.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  zshDotDir = "${config.home.homeDirectory}/.zsh.d";
+  zshDotDir = config.programs.zsh.dotDir;
 in
 {
   programs = {

--- a/home/default.nix
+++ b/home/default.nix
@@ -11,7 +11,7 @@ let
 in
 {
   home = {
-    stateVersion = "25.05";
+    stateVersion = "26.05";
 
     # NixOSを使っていない環境向けにも日本語ロケールを指定します。
     language.base = "ja_JP.UTF-8";

--- a/home/native-linux/firefox.nix
+++ b/home/native-linux/firefox.nix
@@ -427,6 +427,6 @@ in
   # 雑に読み取り専用になっているのを解除します。
   home.activation.firefoxUserJsWritable = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD unlink \
-      ${config.home.homeDirectory}/.mozilla/firefox/google-search-title-qualified/user.js
+      ${config.programs.firefox.configPath}/google-search-title-qualified/user.js
   '';
 }

--- a/home/native-linux/thunderbird.nix
+++ b/home/native-linux/thunderbird.nix
@@ -20,6 +20,6 @@
       };
     };
   };
-  home.packages = [ pkgs.birdtray ];
   xdg.autostart.entries = [ "${pkgs.birdtray}/share/applications/com.ulduzsoft.Birdtray.desktop" ];
+  home.packages = [ pkgs.birdtray ];
 }

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -1,6 +1,6 @@
 { ... }:
 {
-  system.stateVersion = "25.05";
+  system.stateVersion = "26.05";
 
   i18n.defaultLocale = "ja_JP.UTF-8";
   time.timeZone = "Asia/Tokyo";


### PR DESCRIPTION
`nixpkgs`を`26.05`へ上げた #1192 では、
一度のdiffが大きくなるのを避けるため`stateVersion`の引き上げを見送っていました。
このPRでホスト本体の`system.stateVersion`と`home.stateVersion`を`26.05`へ移行し、
合わせて`stateVersion`依存で挙動が変わる破壊的変更に対応します。

事前に`25.11`と`26.05`の破壊的変更を調査し、
ホスト本体で実際に影響するものへ対処しました。

- `programs.firefox.configPath`がxdg準拠のパスへ切り替わるため変数を参照するようにしました。
- `programs.zsh.dotDir`がxdg準拠のディレクトリへ移るため位置をconfigから読み取り、
  さらにその直下にはnixの生成設定が置かれるのでユーザの設定とは別ディレクトリに分離しました。
- `programs.password-store`は`settings`のデフォルトから`PASSWORD_STORE_DIR`が消える影響で、
  `pass-secret-service`のストア位置が壊れていたため`PASSWORD_STORE_DIR`を明示し、
  あわせて`.gpg-id`の宣言的配置を`PASSWORD_STORE_KEY`へ置き換えて`settings`にまとめました。

その他の`stateVersion`依存サービスはホスト本体では使っていないため影響しません。
なおseminarのコンテナやmicroVMの`system.stateVersion`は、
ホストの値とある程度独立した個別管理の値なので今回は据え置いたままにします。

close #1192