### PR TITLE
build(seminar): コンテナとmicroVMの`stateVersion`も`26.05`に統一

### DIFF
--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -45,7 +45,7 @@ in
     config =
       { config, lib, ... }:
       {
-        system.stateVersion = "25.05";
+        system.stateVersion = "26.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
           firewall.allowedTCPPorts = [

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -60,7 +60,7 @@ in
     config =
       { lib, ... }:
       {
-        system.stateVersion = "25.11";
+        system.stateVersion = "26.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
           firewall.allowedTCPPorts = [

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -44,7 +44,7 @@ in
     config =
       { lib, ... }:
       {
-        system.stateVersion = "25.05";
+        system.stateVersion = "26.05";
         # NixデーモンにCI用の設定を渡します。
         # `trusted-users`などが含まれます。
         # コンテナはホストのnixデーモンソケットを共有するので、

--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -19,7 +19,7 @@ in
   microvm.vms.mcp-nixos = {
     inherit pkgs;
     config = {
-      system.stateVersion = "25.11";
+      system.stateVersion = "26.05";
       microvm = {
         hypervisor = "cloud-hypervisor";
         vsock.cid = config.microvmCid.mcp-nixos;

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -48,7 +48,7 @@ in
       { lib, ... }:
       {
         imports = [ inputs.niks3.nixosModules.niks3 ];
-        system.stateVersion = "25.11";
+        system.stateVersion = "26.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
           firewall.allowedTCPPorts = [ 5751 ];

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -48,7 +48,7 @@ in
       { lib, ... }:
       {
         imports = [ inputs.niks3.nixosModules.niks3 ];
-        system.stateVersion = "25.11";
+        system.stateVersion = "26.05";
         networking = {
           useHostResolvConf = lib.mkForce false;
           firewall.allowedTCPPorts = [ 5751 ];

--- a/nixos/host/seminar/postgresql.nix
+++ b/nixos/host/seminar/postgresql.nix
@@ -47,7 +47,7 @@ in
       config =
         { lib, ... }:
         {
-          system.stateVersion = "25.05";
+          system.stateVersion = "26.05";
           # データベースがホスト側で`ja_JP.UTF-8`で初期化されているため、
           # コンテナ内でも同じロケールが必要。
           i18n.defaultLocale = "ja_JP.UTF-8";


### PR DESCRIPTION
ふとした挙動の違いによる認知負荷を減らすため、
ホスト本体に続いてseminarのコンテナとmicroVMの`system.stateVersion`も、
`25.05`/`25.11`からチャンネルに揃えて`26.05`へ統一します。

事前に`stateVersion`依存の破壊的変更を調査し、
今回対象のコンテナには影響しないことを確認済みです。

`stateVersion`引き上げで唯一実害が出うるのはPostgreSQLですが、
`package`を`postgresql_18_jit`に明示固定しているためデフォルト選択は働きません。

`forgejo`と`garage`のモジュールはそもそも`stateVersion`非依存で、
`garage`は明示的に`package`を固定しており、
`forgejo`もデフォルト設定のまま上流を参照しているので問題ありません。

`26.05`で`stateVersion`依存となる`stalwart`や`nextcloud`などのサービスは、
これらのコンテナでは使っていないため対象外です。

なおnix-on-droidはreleaseが`24.05`のため今回の統一からは除外します。
