### PR TITLE
perf(nix): niks3-privateをpublicより高優先のsubstituterにする

### DIFF
--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -9,7 +9,11 @@
       substituters = [
         "https://cache.nixos.org/"
         "https://niks3-public.ncaq.net/"
-        "https://seminar.border-saurolophus.ts.net:8443/niks3/private/"
+        # niks3はnix-cache-infoにPriority 30をハードコードしており、
+        # niks3-publicと同値で優先順位が決まりません。
+        # tailnet経由のniks3-privateの方が高速なため、
+        # `?priority`で明示的にpublicより高優先(数値が小さいほど高優先)にします。
+        "https://seminar.border-saurolophus.ts.net:8443/niks3/private/?priority=20"
         "https://ncaq.cachix.org/"
         "https://nix-community.cachix.org/"
       ];


### PR DESCRIPTION
niks3はtailnet経由のniks3-privateの方が、
Cloudflare Tunnel経由のniks3-publicより高速だと見込まれます。
Tailscaleは可能な限り直接接続を張るのに対し、
Cloudflare Tunnelは必ずCloudflareのエッジを経由する三角経路になるためです。

しかしniks3は`nix-cache-info`に`Priority: 30`をハードコードしており、
niks3-privateとniks3-publicが同値で優先順位が定まりません。
そこでprivateのsubstituter URLに`?priority=20`を付けて、
publicより明示的に高優先(数値が小さいほど高優先)にします。

publicはデフォルトの`30`のまま据え置くので、
両方に存在するパスはprivateから取得され、
privateに無いパスはpublicへフォールバックします。
