### PR TITLE
refactor: GPG関連の値とパッケージの定義場所を整理

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -8,9 +8,6 @@
 let
   inherit (lib.hm.dag) entryBetween;
   keyConfig = import ../../key;
-  # SSH認証に使用するGPGサブキーのkeygrip。
-  # `gpg --list-keys --with-keygrip`で[A]能力を持つサブキーのkeygripを確認できます。
-  sshKeygrip = "29C212A380A9E2977752FA41C35A2F9BF6CA24E2"; # 認証サブキー 0xACA66AB679E75544
 in
 lib.mkMerge [
   {
@@ -42,7 +39,7 @@ lib.mkMerge [
           enable = true;
           enableSshSupport = true;
           pinentry.package = pkgs.pinentry-qt; # pinentry-gnome3はモーダルでパスワードマネージャが使いづらい。
-          sshKeys = [ sshKeygrip ];
+          sshKeys = [ keyConfig.sshKeygrip ];
         };
         home.packages = with pkgs; [
           pinentry-qt
@@ -65,7 +62,7 @@ lib.mkMerge [
             '';
             ".gnupg/sshcontrol".text = ''
               # SSH認証に使用するGPGサブキーのkeygrip
-              ${sshKeygrip}
+              ${keyConfig.sshKeygrip}
             '';
           };
           # Termux環境ではsystemdによるGPGデーモンのライフサイクル管理がないため、

--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -29,7 +29,15 @@ lib.mkMerge [
         "${config.programs.gpg.homedir}/gnupg_spawn_agent_sentinel.lock" \
         2>/dev/null || true
     '';
-    home.packages = with pkgs; [ paperkey ];
+    home.packages = with pkgs; [
+      # 最終復旧手段として印刷するためのパッケージ。
+      paperkey
+      # GUIがない環境でも使える幅広いpinentryです。
+      pinentry-curses
+      # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
+      # こちらを優先して使っていきます。
+      pinentry-qt
+    ];
   }
   (
     if !isTermux then
@@ -38,12 +46,9 @@ lib.mkMerge [
         services.gpg-agent = {
           enable = true;
           enableSshSupport = true;
-          pinentry.package = pkgs.pinentry-qt; # pinentry-gnome3はモーダルでパスワードマネージャが使いづらい。
+          pinentry.package = pkgs.pinentry-qt;
           sshKeys = [ keyConfig.sshKeygrip ];
         };
-        home.packages = with pkgs; [
-          pinentry-qt
-        ];
       }
     else
       {
@@ -75,9 +80,6 @@ lib.mkMerge [
               "${config.home.homeDirectory}/.gnupg/public-keys.d/" \
               2>/dev/null || true
           '';
-          packages = with pkgs; [
-            pinentry-curses
-          ];
         };
       }
   )

--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -32,10 +32,9 @@ lib.mkMerge [
     home.packages = with pkgs; [
       # 最終復旧手段として印刷するためのパッケージ。
       paperkey
-      # GUIがない環境でも使える幅広いpinentryです。
-      pinentry-curses
       # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
       # こちらを優先して使っていきます。
+      # `pinentry-curses`は`pinentry-qt`パッケージに含まれています。
       pinentry-qt
     ];
   }

--- a/key/default.nix
+++ b/key/default.nix
@@ -4,4 +4,8 @@
 
   # 公開鍵ファイルのパス。
   publicKeyFile = ./ncaq-public-key.asc;
+
+  # SSH認証に使用するGPGサブキーのkeygrip。
+  # `gpg --list-keys --with-keygrip`で[A]能力を持つサブキーのkeygripを確認できます。
+  sshKeygrip = "29C212A380A9E2977752FA41C35A2F9BF6CA24E2"; # 認証サブキー 0xACA66AB679E75544
 }


### PR DESCRIPTION
GPG周りの設定を見通し良くするための整理です。

SSH認証に使う`sshKeygrip`はもともと`home/core/gpg.nix`で定義していましたが、
鍵に関する値なので鍵情報を集約している`key/default.nix`へ移動します。
これにより鍵にまつわる値が一箇所にまとまり、
`gpg.nix`は鍵そのものの値を意識せず参照するだけで済むようになります。

あわせて`pinentry`関連パッケージのインストール場所も整理します。
これまでTermuxと非Termuxの分岐それぞれに散らばっていた`home.packages`を、
`pinentry-curses`と`pinentry-qt`を含めて環境共通の部分へまとめます。
環境ごとの差分を減らし、
どの環境でも同じpinentryが利用できる状態にします。