### PR TITLE
fix: NetworkManager dispatcherスクリプトの不具合を解消

### DIFF
--- a/nixos/laptop/tailscale-exit-node.nix
+++ b/nixos/laptop/tailscale-exit-node.nix
@@ -14,9 +14,10 @@ let
     pkgs.writeShellApplication {
       name = "tailscale-exit-node";
       runtimeInputs = with pkgs; [
+        bash
         config.services.tailscale.package
+        coreutils
         gnugrep
-        systemd
       ];
       text = ''
         # upイベント以外は無視
@@ -24,8 +25,11 @@ let
           exit 0
         fi
 
-        # tailscale-online.serviceでTailscaleの準備完了を待つ
-        systemctl start tailscale-online.service
+        # tailscaledの準備完了を最大30秒待つ。
+        # systemdのserviceを介して待つとdispatcherからの同期起動で依存が循環するため、
+        # scriptローカルで待つ。
+        timeout 30 bash -c \
+          'until tailscale status --peers=false >/dev/null 2>&1; do sleep 1; done' || true
 
         # tailscale pingでレイテンシを取得
         # 出力例: pong from seminar (100.82.4.93) via 192.168.10.88:41641 in 4ms

--- a/nixos/laptop/tailscale-exit-node.nix
+++ b/nixos/laptop/tailscale-exit-node.nix
@@ -31,7 +31,10 @@ let
         # 出力例: pong from seminar (100.82.4.93) via 192.168.10.88:41641 in 4ms
         ping_output=$(tailscale ping -c 1 seminar 2>&1) || true
         # 単位込みの値を抽出
-        latency=$(echo "$ping_output" | grep -oP 'in \K[0-9]+m?s')
+        # マッチしない場合(ping失敗など)は空文字列のままにする。
+        # `set -o pipefail`と`errexit`があるため、
+        # `grep`の非ゼロ終了でスクリプトが落ちないよう`|| true`で守る。
+        latency=$(echo "$ping_output" | grep -oP 'in \K[0-9]+m?s' || true)
         # 正規表現に当てはまらない場合は非常に大きな値を設定して外部とみなす
         latency_ms=$(echo "$latency" | grep -oP '[0-9]+(?=ms)' || echo "99999")
 

--- a/nixos/native-linux/wifi-wired-exclusive.nix
+++ b/nixos/native-linux/wifi-wired-exclusive.nix
@@ -47,7 +47,10 @@ let
         else
           # 有線が無い: disconnectで抑止された自動接続を解除し、WiFiへ繋ぎ直す。
           nmcli device set "$dev" autoconnect yes || true
-          if [ "$state" != connected ]; then
+          # `connecting`(接続処理中)に重複で`connect`を叩くと、
+          # activated待ちで90秒ブロックし、デバイスを中間状態に留めて無限ループ化する。
+          # 完全に切れている`disconnected`のときだけ繋ぎ直す。
+          if [ "$state" = disconnected ]; then
             nmcli device connect "$dev" || true
           fi
         fi


### PR DESCRIPTION
creepのNetworkManager dispatcherスクリプトに起因する、
ネットワーク起動の不安定化をまとめて解消します。

`wifi-wired-exclusive`は有線が無いときにWiFiを繋ぎ直しますが、
繋ぎ直す条件が広すぎて`connecting`(接続処理中)のデバイスにまで、
`nmcli device connect`を発行していました。
`checking IP connectivity`のような中間状態でスタックしているときに、
重複した`connect`が90秒ブロックし、
さらにデバイスを中間状態へ押し戻して`connected`への遷移を妨げます。
これがdispatcherイベントの再発火と相まって無限ループに陥っていました。
完全に切れている`disconnected`のときだけ繋ぎ直すよう条件を絞ります。

`tailscale-exit-node`はレイテンシ抽出の`grep`が、
`set -o pipefail`と`errexit`の下で非ゼロ終了するとスクリプト全体を落としていました。
seminarへpingが通らない場合に毎回ここで死に、
exit nodeの切り替えロジックに到達できていませんでした。
`grep`の失敗を吸収し、ping失敗時は外部ネットワーク扱いへフォールバックします。

あわせて`tailscale-exit-node`が`tailscaled`の準備待ちに使っていた、
`tailscale-online.service`の同期起動をやめます。
このserviceは`network-online.target`に連なるため、
`up`イベントのdispatcherから同期起動するとsystemdのジョブ依存が循環する構造でした。
systemdのserviceを介さず、
scriptローカルでタイムアウト付きに待つことで依存グラフを経由しないようにします。

これらにより、wlp2s0が`connected`まで遷移してconnectivityが回復し、
dispatcherの無限ループとexit node判定の不発、
`NetworkManager-wait-online.service`の失敗が解消します。
