### PR TITLE
fix(gpg): SSH_AUTH_SOCKをsystemdユーザーセッションに伝播

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -48,6 +48,15 @@ lib.mkMerge [
           pinentry.package = pkgs.pinentry-qt;
           sshKeys = [ keyConfig.sshKeygrip ];
         };
+        # gpg-agentのssh-agentエミュレーションソケットをsystemdユーザーセッション全体に伝える。
+        # gpg-agentのSSH_AUTH_SOCK設定はインタラクティブなシェル初期化でしか行われないため、
+        # GUIアプリやsystemdサービス(`emacs.service`など)には届かない。
+        # その結果magitのssh経由のpullなどが失敗していた。
+        # `environment.d`経由で設定すればsystemdユーザーマネージャ配下の全プロセスに伝播する。
+        # `$XDG_RUNTIME_DIR`は`environment.d`が展開するのでUIDのハードコードは不要。
+        # デフォルトのgpg homedirを使う限りソケットパスは、
+        # `$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh`で固定。
+        systemd.user.sessionVariables.SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh";
       }
     else
       {


### PR DESCRIPTION
`exec-path-from-shell`の削除以降、
`SSH_AUTH_SOCK`がシェルから同期されなくなり、
magitでssh経由のリポジトリをpullできなくなっていました。
`gpg-agent`の`SSH_AUTH_SOCK`設定はインタラクティブなシェル初期化でしか行われず、
GUIアプリや`emacs --fg-daemon`の`emacs.service`には届かないためです。
特にEmacsはデーモンプロセスの環境を引き継ぐためデーモン自体に変数が無いと、
`emacsclient`がmagitからsshを利用できません。

`systemd.user.sessionVariables`で`environment.d`経由に設定し、
systemdユーザーマネージャ配下の全プロセスに伝播させます。
`$XDG_RUNTIME_DIR`は`environment.d`が展開するためUIDのハードコードは不要で、
デフォルトのgpg homedirを使う限りソケットパスは固定です。

close ncaq/.emacs.d#343
