### PR TITLE
build(deps): `Node.js v24`への移行に合わせて依存を更新

### DIFF
--- a/nixos/host/seminar/github-runner/package-lock.json
+++ b/nixos/host/seminar/github-runner/package-lock.json
@@ -8,21 +8,21 @@
       "name": "dotfiles-github-runner",
       "version": "0.0.0",
       "devDependencies": {
-        "@types/node": "22.19.19",
+        "@types/node": "24.13.1",
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=22.22.0"
+        "node": ">=24.15.0"
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/typescript": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/nixos/host/seminar/github-runner/package.json
+++ b/nixos/host/seminar/github-runner/package.json
@@ -10,10 +10,10 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@types/node": "22.19.19",
+    "@types/node": "24.13.1",
     "typescript": "6.0.3"
   },
   "engines": {
-    "node": ">=22.22.0"
+    "node": ">=24.15.0"
   }
 }


### PR DESCRIPTION
nixpkgsのチャンネルが`nixos-26.05`に上がり、
`pkgs.nodejs`が指す標準バージョンが22系から24系(`24.15.0`)に置き換わりました。
GitHub Actionsランナー互換環境の`Node.js`も自動的に24へ追従するため、
それを前提とするように定義を合わせます。

`engines.node`の要件を`>=24.15.0`に引き上げて、
`@types/node`をランタイムのメジャーに揃えて22系から24系へ更新します。
