### PR TITLE
refactor(cpu-target): スレッド数由来の設定を`cpuTarget`から導出する

### DIFF
--- a/lib/cpu-targets.nix
+++ b/lib/cpu-targets.nix
@@ -14,6 +14,11 @@
   該当CPU上で取得した値を写経する。
   `-march=<arch>`だけではキャッシュ階層ヒントが付与されないため、
   この情報がモデル固有最適化の主要な価値になる。
+
+  `threads`はそのCPUの論理スレッド数(SMT込み、`nproc`相当)を記録する。
+  ビルド並列度やコンテナへのCPU割り当てなど、
+  評価時に固定値を要する箇所の単一の出典として使う。
+  モデル名の`6-Core`等は物理コア数でありこの値とは一致しないので注意する。
 */
 { lib }:
 let
@@ -22,6 +27,7 @@ let
   mkTarget =
     {
       arch,
+      threads,
       tune ? arch,
       cacheParams ? [ ],
       extraFlags ? [ ],
@@ -32,6 +38,7 @@ let
     {
       inherit
         arch
+        threads
         tune
         cacheParams
         extraFlags
@@ -42,6 +49,7 @@ rec {
   targets = {
     "AMD Ryzen 9 9950X3D 16-Core Processor" = mkTarget {
       arch = "znver5";
+      threads = 32;
       cacheParams = [
         "--param=l1-cache-size=48"
         "--param=l1-cache-line-size=64"
@@ -51,6 +59,7 @@ rec {
 
     "AMD Ryzen 5 PRO 7540U w/ Radeon 740M Graphics" = mkTarget {
       arch = "znver4";
+      threads = 12;
       cacheParams = [
         "--param=l1-cache-size=32"
         "--param=l1-cache-line-size=64"
@@ -60,6 +69,7 @@ rec {
 
     "AMD Ryzen 5 7600 6-Core Processor" = mkTarget {
       arch = "znver4";
+      threads = 12;
       cacheParams = [
         "--param=l1-cache-size=32"
         "--param=l1-cache-line-size=64"

--- a/nixos/core/cpu-target.nix
+++ b/nixos/core/cpu-target.nix
@@ -11,17 +11,39 @@
 { lib, config, ... }:
 let
   cpuTargets = import ../../lib/cpu-targets.nix { inherit lib; };
+  cpuTarget = config.local.cpuTarget;
+  # SMTの1物理コア分(2スレッド)はOSやその他プロセスのために空けておく。
+  reservedThreads = 2;
 in
 {
-  options.local.cpuTarget = lib.mkOption {
-    type = lib.types.nullOr (lib.types.enum (builtins.attrNames cpuTargets.targets));
-    default = null;
-    example = "AMD Ryzen 9 9950X3D 16-Core Processor";
-    description = ''
-      `/proc/cpuinfo`の`model name`文字列をそのまま指定する。
-      `lib/cpu-targets.nix`に登録されているCPUモデルのみ指定可能。
-      未登録のCPUを使うホストは`null`のままにする。
-    '';
+  options.local = {
+    cpuTarget = lib.mkOption {
+      type = lib.types.nullOr (lib.types.enum (builtins.attrNames cpuTargets.targets));
+      default = null;
+      example = "AMD Ryzen 9 9950X3D 16-Core Processor";
+      description = ''
+        `/proc/cpuinfo`の`model name`文字列をそのまま指定する。
+        `lib/cpu-targets.nix`に登録されているCPUモデルのみ指定可能。
+        未登録のCPUを使うホストは`null`のままにする。
+      '';
+    };
+
+    cpuBudgetThreads = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default =
+        if cpuTarget == null then null else cpuTargets.targets.${cpuTarget}.threads - reservedThreads;
+      defaultText = lib.literalMD ''
+        `cpuTarget`の論理スレッド数から予約分(${toString reservedThreads}スレッド)を引いた値。
+        `cpuTarget`が`null`なら`null`。
+      '';
+      description = ''
+        CIジョブやテストVMなどに割り当ててよいスレッド数。
+        全論理スレッドからOSや他プロセス用の予約分を引いた値で、
+        ビルド並列度やコンテナのCPU割り当て量の単一の出典として使う。
+        `cpuTarget`未登録のホストでは`null`になるため、
+        この値を使う側は`cpuTarget`が設定済みであることを前提にする。
+      '';
+    };
   };
 
   config = lib.mkIf (config.local.cpuTarget != null) {

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -130,7 +130,8 @@ in
       serviceConfig = {
         # CIジョブがホストのリソースを過剰に消費しないよう制限します。
         # CPUQuotaはコア数×100%で指定する必要があります。
-        CPUQuota = "1000%"; # サーバが12スレッドなので、2スレッド引いた分を割り当てます。
+        # 割り当て可能スレッド数分を割り当てます。
+        CPUQuota = "${toString (config.local.cpuBudgetThreads * 100)}%";
         MemoryHigh = "16G"; # ソフトリミット。これを超えるとメモリを積極的に解放します。
         MemoryMax = "32G"; # ハードリミット。これぐらいで十分だろうという推定値。
       };

--- a/nixos/test/vm-override.nix
+++ b/nixos/test/vm-override.nix
@@ -5,6 +5,7 @@
 {
   pkgs,
   lib,
+  config,
   options,
   username,
   ...
@@ -16,7 +17,8 @@ lib.mkMerge [
     # 多めに設定していても破綻はしませんが、
     # リソース制限をわかりやすくするためにこちらでも記述しておきます。
     virtualisation = {
-      cores = 10; # CPUは奪い合っても良いので12スレッドから2スレッド引いた分を割り当てます。
+      # CPUは奪い合っても良いので割り当て可能スレッド数を割り当てます。
+      cores = config.local.cpuBudgetThreads;
       memorySize = 4 * 1024; # 4GB。並列に動かすことを考えて控えめにします。
     };
 


### PR DESCRIPTION
CPUのスレッド数に基づくリソース割り当てを`CPUQuota = "1000%"`や`cores = 10`のように、
各所でベタ書きしていました。
いずれも「全スレッド数から2スレッド引いた分」という同じ意図の計算結果でしたが、
数値が散在しているため対象CPUが変わったときに追従が漏れやすい状態でした。

ホストごとに既に宣言している`local.cpuTarget`を単一の出典として活用します。
`lib/cpu-targets.nix`の各CPUに論理スレッド数`threads`を持たせ、
`local.cpuBudgetThreads`オプションで割り当ててよいスレッド数を導出します。
これは全スレッドから予約分を引いた値で、
予約分の2スレッド(SMTの1物理コア)も一箇所に集約しました。

各ベタ書き箇所を`local.cpuBudgetThreads`からの計算に置き換えます。
これにより数値も「2を引く」という方針も起点が`cpuTarget`一つに収束します。
副次的にテストVMの`cores`もホストごとのCPUに最適化され、
従来の固定値10からbulletなら30のように各ホストに追従するようになります。