### PR TITLE
fix(claude): デフォルトモデルを`opus[1m]`に変更し`fallbackModel`を拡充

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -137,7 +137,9 @@ in
       # 頻繁に最適な値が変わるので設定するその時に最適なものを選びます。
       model = "opus[1m]";
       fallbackModel = [
+        "opus"
         "sonnet[1m]"
+        "sonnet"
       ];
       # メッセージにCo-Authored-Byフッターを付与しません。
       # 私はAIエージェントはテキストエディタの延長線上だと考えているため、

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -135,9 +135,8 @@ in
       # 応答に使う自然言語です。
       language = "japanese";
       # 頻繁に最適な値が変わるので設定するその時に最適なものを選びます。
-      model = "fable";
+      model = "opus[1m]";
       fallbackModel = [
-        "opus[1m]"
         "sonnet[1m]"
       ];
       # メッセージにCo-Authored-Byフッターを付与しません。


### PR DESCRIPTION
規制によりfableが利用できなくなったため、
デフォルトモデルを`opus[1m]`に変更します。

あわせて障害発生時の`fallbackModel`を見直し、
退避先として`opus`と`sonnet`を加えます。
特定のモデルに問題が起きても利用可能なモデルへ順に切り替えられるようにして、
作業が止まらないようにします。
