### PR TITLE
feat(forgejo): LFSオブジェクトのストレージにgarageを使用

### DIFF
--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -42,8 +42,12 @@ in
     bindMounts = {
       # garage-setupが出力したS3キーをマウントします。
       # Forgejo自身がRuntimeDirectoryに使う/run/forgejo配下はセットアップと衝突するため避けます。
-      "/run/forgejo-secrets" = {
-        hostPath = "/run/forgejo";
+      "/run/forgejo-secrets/s3-access-key" = {
+        hostPath = "/run/forgejo/s3-access-key";
+        isReadOnly = true;
+      };
+      "/run/forgejo-secrets/s3-secret-key" = {
+        hostPath = "/run/forgejo/s3-secret-key";
         isReadOnly = true;
       };
       "/run/postgresql" = {

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -149,15 +149,15 @@ in
     services = {
       "container@forgejo" = {
         requires = [
-          "forgejo-garage-setup.service"
+          "garage-setup-forgejo.service"
           "postgresql-ready.service"
         ];
         after = [
-          "forgejo-garage-setup.service"
+          "garage-setup-forgejo.service"
           "postgresql-ready.service"
         ];
       };
-      "forgejo-garage-setup" = garageSetup;
+      "garage-setup-forgejo" = garageSetup;
     };
     tmpfiles.rules = [
       "d /var/lib/forgejo 0750 forgejo forgejo -"

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -16,6 +16,13 @@ let
       exec nixos-container run forgejo -- forgejo "$@"
     '';
   };
+  garageAddr = config.machineAddresses.garage.guest;
+  # LFSオブジェクトをgarage(S3互換)に保存するためのバケットとキーをidempotentに作成します。
+  # name = "forgejo" なので/run/forgejoにキーが書き出され、forgejoユーザーが所有します。
+  garageSetup = import ../../../lib/garage-setup.nix {
+    inherit pkgs config;
+    name = "forgejo";
+  };
 in
 {
   containers.forgejo = {
@@ -33,6 +40,12 @@ in
       }
     ];
     bindMounts = {
+      # garage-setupが出力したS3キーをマウントします。
+      # Forgejo自身がRuntimeDirectoryに使う/run/forgejo配下はセットアップと衝突するため避けます。
+      "/run/forgejo-secrets" = {
+        hostPath = "/run/forgejo";
+        isReadOnly = true;
+      };
       "/run/postgresql" = {
         hostPath = "/run/postgresql";
         isReadOnly = true;
@@ -66,9 +79,14 @@ in
           resolved.enable = true;
           forgejo = {
             enable = true;
+            # LFSサーバ機能(`LFS_START_SERVER`)を有効化し、
+            # `LFS_JWT_SECRET`も自動生成します。
+            # 保存先は下の`settings.lfs`でminio(garage)に切り替えます。
+            lfs.enable = true;
             database = {
               type = "postgres";
-              # PostgreSQLは直接接続されないため、NixOSによるデータベース自動生成機能は無効にします。
+              # PostgreSQLは直接接続されないため、
+              # NixOSによるデータベース自動生成機能は無効にします。
               createDatabase = false;
               socket = "/run/postgresql";
             };
@@ -91,6 +109,23 @@ in
               repository = {
                 DEFAULT_BRANCH = "master";
               };
+              lfs = {
+                # LFSオブジェクトのストレージにgarage(S3互換)を使用。
+                STORAGE_TYPE = "minio";
+                MINIO_ENDPOINT = "${garageAddr}:3900";
+                MINIO_BUCKET = "forgejo";
+                MINIO_LOCATION = "garage";
+                # 内部のIP直アクセスのためSSLは不要。
+                MINIO_USE_SSL = false;
+                # コンテナ間はIP直アクセスのためpath style。
+                MINIO_BUCKET_LOOKUP = "path";
+              };
+            };
+            # S3キーはgarage-setupが起動ごとに生成するため、
+            # LoadCredential経由でファイルから読み込みます。
+            secrets.lfs = {
+              MINIO_ACCESS_KEY_ID = "/run/forgejo-secrets/s3-access-key";
+              MINIO_SECRET_ACCESS_KEY = "/run/forgejo-secrets/s3-secret-key";
             };
           };
         };
@@ -107,9 +142,18 @@ in
   postgresClient = [ "forgejo" ];
 
   systemd = {
-    services."container@forgejo" = {
-      requires = [ "postgresql-ready.service" ];
-      after = [ "postgresql-ready.service" ];
+    services = {
+      "container@forgejo" = {
+        requires = [
+          "forgejo-garage-setup.service"
+          "postgresql-ready.service"
+        ];
+        after = [
+          "forgejo-garage-setup.service"
+          "postgresql-ready.service"
+        ];
+      };
+      "forgejo-garage-setup" = garageSetup;
     };
     tmpfiles.rules = [
       "d /var/lib/forgejo 0750 forgejo forgejo -"


### PR DESCRIPTION
ForgejoのGit LFSオブジェクトを、
同じseminar上で稼働するgarage(S3互換)をバックエンドとして保存するようにします。
既にgarageが`/mnt/noa`のbtrfs RAID1上に大容量領域を持っているので、
LFSオブジェクトをそちらに逃がすほうが容量管理の面で適切です。

`services.forgejo.lfs.enable`でLFSサーバ機能(`LFS_START_SERVER`)を有効化し、
`LFS_JWT_SECRET`も自動生成させます。
これがないと管理画面でLFSが無効のままなので有効化は必須です。

`settings.lfs`で`STORAGE_TYPE = "minio"`を指定し、
エンドポイントをgarageコンテナのS3 API(`3900`番ポート)に向けます。
コンテナ間はIP直アクセスのためpath styleルックアップが必須で、
内部通信なのでSSLは使いません。

S3キーは`lib/garage-setup.nix`の共通関数を`name = "forgejo"`で呼び出し、
garage Admin API経由でバケットとキーをidempotentに生成します。
生成されたキーはホストの`/run/forgejo`に書き出されforgejoユーザーが所有します。
`/run/forgejo`本体はForgejo自身がRuntimeDirectoryに使い、
配下へのマウントはそのセットアップと衝突して起動できません。
そのためコンテナへは`/run/forgejo-secrets`にread-onlyでbindMountして、
`services.forgejo.secrets`のLoadCredential経由で読み込みます。
キーは起動ごとに使い捨てで生成されるため、
平文をnixストアやsopsに置く必要がありません。

`container@forgejo`が`forgejo-garage-setup.service`をrequires/afterして、
コンテナ起動前にキー生成とバケット作成を保証します。
garage-setup自体が`container@garage`に依存するため、
連鎖でgarageの起動も待ちます。
