### PR TITLE
refactor: garage-setupのキーを`/run/garage-setup`配下に置きマウントパスを統一

### DIFF
--- a/lib/garage-setup.nix
+++ b/lib/garage-setup.nix
@@ -19,7 +19,7 @@
   serviceConfig = {
     Type = "oneshot";
     RemainAfterExit = true;
-    RuntimeDirectory = name;
+    RuntimeDirectory = "garage-setup/${name}";
     RuntimeDirectoryMode = "0700";
     # Hardening
     CapabilityBoundingSet = [
@@ -109,10 +109,12 @@
           # Write keys to runtime directory for ${name} container.
           (
             umask 0377
-            echo -n "$ACCESS_KEY" > /run/${name}/s3-access-key
-            echo -n "$SECRET_KEY" > /run/${name}/s3-secret-key
+            echo -n "$ACCESS_KEY" > /run/garage-setup/${name}/s3-access-key
+            echo -n "$SECRET_KEY" > /run/garage-setup/${name}/s3-secret-key
           )
-          chown ${name}:${name} /run/${name}/s3-access-key /run/${name}/s3-secret-key
+          chown ${name}:${name} \
+            /run/garage-setup/${name}/s3-access-key \
+            /run/garage-setup/${name}/s3-secret-key
 
           # Get existing bucket or create a new one.
           if BUCKET_JSON=$(garage_api GET "/v2/GetBucketInfo?globalAlias=${name}" 2>/dev/null); then

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -18,7 +18,7 @@ let
   };
   garageAddr = config.machineAddresses.garage.guest;
   # LFSオブジェクトをgarage(S3互換)に保存するためのバケットとキーをidempotentに作成します。
-  # name = "forgejo" なので/run/forgejoにキーが書き出され、forgejoユーザーが所有します。
+  # name = "forgejo" なので/run/garage-setup/forgejoにキーが書き出され、forgejoユーザーが所有します。
   garageSetup = import ../../../lib/garage-setup.nix {
     inherit pkgs config;
     name = "forgejo";
@@ -41,13 +41,12 @@ in
     ];
     bindMounts = {
       # garage-setupが出力したS3キーをマウントします。
-      # Forgejo自身がRuntimeDirectoryに使う/run/forgejo配下はセットアップと衝突するため避けます。
-      "/run/forgejo-secrets/s3-access-key" = {
-        hostPath = "/run/forgejo/s3-access-key";
+      "/run/garage-setup/forgejo/s3-access-key" = {
+        hostPath = "/run/garage-setup/forgejo/s3-access-key";
         isReadOnly = true;
       };
-      "/run/forgejo-secrets/s3-secret-key" = {
-        hostPath = "/run/forgejo/s3-secret-key";
+      "/run/garage-setup/forgejo/s3-secret-key" = {
+        hostPath = "/run/garage-setup/forgejo/s3-secret-key";
         isReadOnly = true;
       };
       "/run/postgresql" = {
@@ -128,8 +127,8 @@ in
             # S3キーはgarage-setupが起動ごとに生成するため、
             # LoadCredential経由でファイルから読み込みます。
             secrets.lfs = {
-              MINIO_ACCESS_KEY_ID = "/run/forgejo-secrets/s3-access-key";
-              MINIO_SECRET_ACCESS_KEY = "/run/forgejo-secrets/s3-secret-key";
+              MINIO_ACCESS_KEY_ID = "/run/garage-setup/forgejo/s3-access-key";
+              MINIO_SECRET_ACCESS_KEY = "/run/garage-setup/forgejo/s3-secret-key";
             };
           };
         };

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -27,19 +27,19 @@ in
         hostPath = "/run/postgresql";
         isReadOnly = true;
       };
-      "/etc/niks3-private/s3-access-key" = {
-        hostPath = "/run/niks3-private/s3-access-key";
+      "/run/garage-setup/niks3-private/s3-access-key" = {
+        hostPath = "/run/garage-setup/niks3-private/s3-access-key";
         isReadOnly = true;
       };
-      "/etc/niks3-private/s3-secret-key" = {
-        hostPath = "/run/niks3-private/s3-secret-key";
+      "/run/garage-setup/niks3-private/s3-secret-key" = {
+        hostPath = "/run/garage-setup/niks3-private/s3-secret-key";
         isReadOnly = true;
       };
-      "/etc/niks3-private/api-token" = {
+      "/run/niks3-private/api-token" = {
         hostPath = config.sops.secrets."niks3-private-api-token".path;
         isReadOnly = true;
       };
-      "/etc/niks3-private/sign-key" = {
+      "/run/niks3-private/sign-key" = {
         hostPath = config.sops.secrets."niks3-private-sign-key".path;
         isReadOnly = true;
       };
@@ -85,11 +85,11 @@ in
               bucket = "niks3-private";
               region = "garage";
               useSSL = true;
-              accessKeyFile = "/etc/niks3-private/s3-access-key";
-              secretKeyFile = "/etc/niks3-private/s3-secret-key";
+              accessKeyFile = "/run/garage-setup/niks3-private/s3-access-key";
+              secretKeyFile = "/run/garage-setup/niks3-private/s3-secret-key";
             };
-            apiTokenFile = "/etc/niks3-private/api-token";
-            signKeyFiles = [ "/etc/niks3-private/sign-key" ];
+            apiTokenFile = "/run/niks3-private/api-token";
+            signKeyFiles = [ "/run/niks3-private/sign-key" ];
             # Tailscale Serve経由でHTTPSアクセスされるURL。
             cacheUrl = "https://seminar.border-saurolophus.ts.net:8443/niks3/private/";
             # readはTailscaleネットワーク認証、writeはAPIトークン認証。

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -27,19 +27,19 @@ in
         hostPath = "/run/postgresql";
         isReadOnly = true;
       };
-      "/etc/niks3-public/s3-access-key" = {
-        hostPath = "/run/niks3-public/s3-access-key";
+      "/run/garage-setup/niks3-public/s3-access-key" = {
+        hostPath = "/run/garage-setup/niks3-public/s3-access-key";
         isReadOnly = true;
       };
-      "/etc/niks3-public/s3-secret-key" = {
-        hostPath = "/run/niks3-public/s3-secret-key";
+      "/run/garage-setup/niks3-public/s3-secret-key" = {
+        hostPath = "/run/garage-setup/niks3-public/s3-secret-key";
         isReadOnly = true;
       };
-      "/etc/niks3-public/api-token" = {
+      "/run/niks3-public/api-token" = {
         hostPath = config.sops.secrets."niks3-public-api-token".path;
         isReadOnly = true;
       };
-      "/etc/niks3-public/sign-key" = {
+      "/run/niks3-public/sign-key" = {
         hostPath = config.sops.secrets."niks3-public-sign-key".path;
         isReadOnly = true;
       };
@@ -85,11 +85,11 @@ in
               bucket = "niks3-public";
               region = "garage";
               useSSL = true;
-              accessKeyFile = "/etc/niks3-public/s3-access-key";
-              secretKeyFile = "/etc/niks3-public/s3-secret-key";
+              accessKeyFile = "/run/garage-setup/niks3-public/s3-access-key";
+              secretKeyFile = "/run/garage-setup/niks3-public/s3-secret-key";
             };
-            apiTokenFile = "/etc/niks3-public/api-token";
-            signKeyFiles = [ "/etc/niks3-public/sign-key" ];
+            apiTokenFile = "/run/niks3-public/api-token";
+            signKeyFiles = [ "/run/niks3-public/sign-key" ];
             cacheUrl = "https://niks3-public.ncaq.net";
             # publicバケットですがGarage S3 APIが匿名読み取りを未サポートのため、
             # niks3のread proxy経由で配信しています。


### PR DESCRIPTION
garage-setupはS3キーをホストの`/run/${name}`に書き出していました。
しかしForgejoのようにサービス自身が`/run/forgejo`をRuntimeDirectoryとして使う場合、
配下へのbindMountがそのセットアップと衝突して起動できず、
`/run/forgejo-secrets`へ逃がすという回避策が必要でした。

書き出し先を`/run/garage-setup/${name}`に分離して、
サービス自身のRuntimeDirectoryと名前空間が重ならないようにします。
これにより回避マウントが不要になり、
コンテナ側もホストと同じ`/run/garage-setup/${name}`のパスをそのままマウントできます。
niks3も`/etc/niks3-*/`という人工的なマウント先をやめて同じパスに揃えます。

ついでにgarageとは無関係なsops管理のapi-tokenとsign-keyは、
`/etc/niks3-*/`ではなく`/run/${name}/`配下にマウントするよう整理します。
garage由来のキーとそれ以外で`/run/garage-setup/`と`/run/${name}/`に置き場所が分かれて、
出所が分かりやすくなります。
