### PR TITLE
refactor: home-managerのmcpモジュールを使用

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -203,7 +203,7 @@ Claude Codeの設定は2箇所で管理されています。
 ## `home/core/claude-code.nix`
 
 home-managerの`programs.claude-code`モジュールで全ホスト共通の設定を宣言的に管理します。
-MCPサーバ、プラグイン、権限、フックなどの主要な設定はここで管理します。
+プラグイン、権限、フックなどの主要な設定はここで管理します。
 
 ビルド時にユーザの`~/.claude/settings.json`として展開されます。
 

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -7,45 +7,7 @@
   ...
 }:
 let
-  # Claude Codeのパッケージをsopsシークレットから環境変数を注入するラッパーで包む。
-  # `api.githubcopilot.com`がOAuth Dynamic Client Registrationをサポートしないのと、
-  # それを正しくClaude Codeが処理しないため、
-  # PATをBearer tokenとしてHTTPヘッダーで渡す必要があります。
-  # 全シェルにトークンを展開するのはあまりやりたくないため、
-  # コマンドだけに注入する方法を取ります。
-  # `symlinkJoin`+`wrapProgram`ではなく`writeShellApplication`を使うことで、
-  # home-managerの`--mcp-config`ラッピングと合わせた二重wrappingを避けて、
-  # プロセスの名前を`claude`に保ちます。
-  claude-code-wrapped = pkgs.writeShellApplication {
-    name = "claude";
-    text = ''
-      if [[ -r ${config.sops.secrets."github-mcp-server/pat".path} ]]; then
-        GITHUB_PERSONAL_ACCESS_TOKEN="$(< ${config.sops.secrets."github-mcp-server/pat".path})"
-        export GITHUB_PERSONAL_ACCESS_TOKEN
-      fi
-      exec ${lib.getExe pkgs-unstable.claude-code} "$@"
-    '';
-  };
-
   ccstatusline = pkgs.callPackage ../../pkgs/ccstatusline.nix { };
-
-  backlog-mcp-server = pkgs.callPackage ../../pkgs/backlog-mcp-server.nix { };
-  # Backlog MCP Serverの認証情報をsops-nixで管理されたシークレットから読み込むラッパー
-  backlog-mcp-server-wrapper = pkgs.writeShellApplication {
-    name = "backlog-mcp-server-wrapper";
-    runtimeInputs = [ backlog-mcp-server ];
-    text = ''
-      if [[ -r ${config.sops.secrets."backlog-mcp-server/domain".path} ]]; then
-        BACKLOG_DOMAIN="$(< ${config.sops.secrets."backlog-mcp-server/domain".path})"
-        export BACKLOG_DOMAIN
-      fi
-      if [[ -r ${config.sops.secrets."backlog-mcp-server/api-key".path} ]]; then
-        BACKLOG_API_KEY="$(< ${config.sops.secrets."backlog-mcp-server/api-key".path})"
-        export BACKLOG_API_KEY
-      fi
-      exec backlog-mcp-server "$@"
-    '';
-  };
 
   # npm, yarn, pnpm, bunで共通のサブコマンドを許可するためのヘルパー
   jsPackageManagers = [
@@ -108,28 +70,13 @@ in
 {
   programs.claude-code = {
     enable = true;
-    package = claude-code-wrapped;
+    package = pkgs-unstable.claude-code;
 
     # `CLAUDE.md`と同等です。
     context = config.prompt.codingAgent;
 
-    mcpServers = {
-      github = {
-        type = "http";
-        url = "https://api.githubcopilot.com/mcp/";
-        headers = {
-          Authorization = "Bearer \${GITHUB_PERSONAL_ACCESS_TOKEN}";
-        };
-      };
-      deepwiki = {
-        type = "http";
-        url = "https://mcp.deepwiki.com/mcp";
-      };
-      backlog = {
-        type = "stdio";
-        command = lib.getExe backlog-mcp-server-wrapper;
-      };
-    };
+    # `mcp.nix`と連携します。
+    enableMcpIntegration = true;
 
     settings = {
       # 応答に使う自然言語です。
@@ -577,32 +524,5 @@ in
           })
         ]
       );
-  };
-
-  sops.secrets = {
-    # GitHub MCP Server用のPersonal Access Tokenをsops-nixで管理します。
-    # シークレットファイルは `sops secrets/github-mcp-server.yaml` で編集してください。
-    # 形式:
-    # pat: ghp_xxxxxxxxxxxxxxxxxxxxx
-    "github-mcp-server/pat" = {
-      sopsFile = ../../secrets/github-mcp-server.yaml;
-      key = "pat";
-      mode = "0400";
-    };
-    # Backlog MCP Server用の認証情報をsops-nixで管理します。
-    # シークレットファイルは `sops secrets/backlog-mcp-server.yaml` で編集してください。
-    # 形式:
-    # domain: your-space.backlog.com
-    # api-key: your-api-key
-    "backlog-mcp-server/domain" = {
-      sopsFile = ../../secrets/backlog-mcp-server.yaml;
-      key = "domain";
-      mode = "0400";
-    };
-    "backlog-mcp-server/api-key" = {
-      sopsFile = ../../secrets/backlog-mcp-server.yaml;
-      key = "api-key";
-      mode = "0400";
-    };
   };
 }

--- a/home/core/codex.nix
+++ b/home/core/codex.nix
@@ -5,6 +5,7 @@
       enable = true;
       package = pkgs-unstable.codex;
       context = config.prompt.codingAgent;
+      enableMcpIntegration = true;
     };
   };
 }

--- a/home/core/mcp.nix
+++ b/home/core/mcp.nix
@@ -1,0 +1,66 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  backlog-mcp-server = pkgs.callPackage ../../pkgs/backlog-mcp-server.nix { };
+in
+{
+  programs.mcp = {
+    enable = true;
+    servers = {
+      backlog = {
+        command = lib.getExe backlog-mcp-server;
+        env = {
+          BACKLOG_API_KEY.file = config.sops.secrets."backlog-mcp-server/api-key".path;
+          BACKLOG_DOMAIN.file = config.sops.secrets."backlog-mcp-server/domain".path;
+        };
+      };
+      deepwiki = {
+        url = "https://mcp.deepwiki.com/mcp";
+      };
+      github = {
+        # GitHub公式のローカル(stdio)MCPサーバを使用します。
+        # リモートHTTPサーバ(url)ではenvが使えずファイルベースのシークレットを渡せないためです。
+        command = lib.getExe pkgs.github-mcp-server;
+        args = [ "stdio" ];
+        env = {
+          GITHUB_PERSONAL_ACCESS_TOKEN.file = config.sops.secrets."github-mcp-server/pat".path;
+        };
+      };
+    };
+  };
+
+  sops.secrets = {
+    # Backlog MCP Server用の認証情報をsops-nixで管理します。
+    # シークレットファイルは
+    # `sops secrets/backlog-mcp-server.yaml`
+    # で編集してください。
+    # 形式:
+    # api-key: your-api-key
+    # domain: your-space.backlog.com
+    "backlog-mcp-server/api-key" = {
+      sopsFile = ../../secrets/backlog-mcp-server.yaml;
+      key = "api-key";
+      mode = "0400";
+    };
+    "backlog-mcp-server/domain" = {
+      sopsFile = ../../secrets/backlog-mcp-server.yaml;
+      key = "domain";
+      mode = "0400";
+    };
+    # GitHub MCP Server用のPersonal Access Tokenをsops-nixで管理します。
+    # シークレットファイルは
+    # `sops secrets/github-mcp-server.yaml`
+    # で編集してください。
+    # 形式:
+    # pat: ghp_xxxxxxxxxxxxxxxxxxxxx
+    "github-mcp-server/pat" = {
+      sopsFile = ../../secrets/github-mcp-server.yaml;
+      key = "pat";
+      mode = "0400";
+    };
+  };
+}

--- a/secrets/backlog-mcp-server.yaml
+++ b/secrets/backlog-mcp-server.yaml
@@ -1,19 +1,19 @@
-domain: ENC[AES256_GCM,data:4DZyDI9xy2brWMDgxBZzByc=,iv:LucQPtjA7el3OSdhMcxQGziZ61axGyqEr/NljKjUItg=,tag:rWFkOW3UCRzq17D573vkpQ==,type:str]
-api-key: ENC[AES256_GCM,data:tmspghOKNfuih2KY4VPtjk/UU818WtxnOk/ZmMbD7LNVJXWMO35fVmd7WNtEOR7+WYt5R9xz0zpH9eovwUkssg==,iv:TBW63Fjr0bZmlleOPaj+/AfAzCEXIbL+JQVsMVS9nGc=,tag:DdPn0S4hZaJZnzREYY3gnA==,type:str]
+api-key: ENC[AES256_GCM,data:M/la7L+Hd2ashILQ6BTaNPq0bfrRfBiIE4kAUTI+m3MjMkahUJPBnLZrzlpH11LPCOueG55g1iJF8CfOc/YqAQ==,iv:2kRVD1ryO6IVzYMaf3qcm2SW9YYn0AJmRtXOalr6ciY=,tag:eqmvQpMcagtOqk4U4clbug==,type:str]
+domain: ENC[AES256_GCM,data:31IeXUostSLKr7H3+gRHvX4=,iv:f0HkJEgqmEliPMjGELoHVxhgdSFQE316nluTa8vaeDE=,tag:HI1xtWfek7aFp3Ro/zyFQg==,type:str]
 sops:
-  lastmodified: "2026-01-09T08:52:46Z"
-  mac: ENC[AES256_GCM,data:mR/LyBD7TlTpD/HTiP9w1AW56iaifxXGctf60PW672rJRR1Frljg8olUmi2aLIZQi/z2hOE3JzsnBzjDusDVNbKPXdEnKbcLwQbZkN1n0OXAww5zaalY+lTvHQLmibaQSSTGVJ5j+HePE92V5j/Nmrc6IlKnGX4nufbhop0jvXI=,iv:3arrGNTAC7BTAcWLKvhA9DWM0XhBpUU1QU1esPI4wjc=,tag:W+6Fes7JqiU5IfT+1TGTgA==,type:str]
+  lastmodified: "2026-06-15T03:51:50Z"
+  mac: ENC[AES256_GCM,data:aO6OuH9HLxCN5/TVl8T3mgzyQIzJtirg+rmovxkXhrymCry/0qpIJra17BLOKdlKlBtSgFtLo1wmH3Nw+4VWOdsPbTkj1lwkFUlXShh6PWpKSWzelwjaZ1hNqoleJCDBReT378at4UEdfOTQHlIFvkIPlLyv5z17wygsU7F+cR4=,iv:JlQ2iVcciCMk08NpW02Emg3ePv3uyGuX/eR7rEe09UQ=,tag:yS/0+sbv9zgMDeRjNwxMOg==,type:str]
   pgp:
-    - created_at: "2026-01-09T08:47:04Z"
+    - created_at: "2026-06-15T03:51:50Z"
       enc: |-
         -----BEGIN PGP MESSAGE-----
 
-        hF4Dxlt1nl1bPpUSAQdAKeOHJaZBsWVbCdgFnTTHlyKAT9kwaJyIfdiWda8ABUEw
-        i18/DSSOWhw1BxMbt516PFLlZTVvMMq6+S+Eo0MWED3i7J2dCj2ZS4pmpCXcWJJ+
-        0l4Bs7thopzIqwyYOQSeQLNsZsdN66EWgTsxHHicmcExvx2SQzQTywLtIhnuAdD9
-        ZLAbDHrLXta6fGdM1dmrtLEbZ4Cg/z/B5lmtiNMHz5zH7rIFsoFppgeDHKtFX3fV
-        =EREc
+        hF4Dxlt1nl1bPpUSAQdAhM3KChAVqd/tK8H00x68O7pNye2w0HEdy5I2qD9TODcw
+        ZDcvHUg1tJsAu0rF/pqOdrcg/uhlq4TmtD7YIcmDYWD5SP6gdHp/86ipyD0k+Jw3
+        0l4Bwzi+OeUykx1w3ENjioeMtuA5oM26FLxn7J9nBTKyp7mUn9sU3B0ViDQZGvWr
+        ufx8womgj3zJYIQUIt5F/e09zPCyzK34oHtGzbj/2Wq5dhf37cu4JmANQkthZW61
+        =2Y7L
         -----END PGP MESSAGE-----
       fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.13.1


### PR DESCRIPTION
Claude Codeのmcp設定はそちら側で行って連携することで整理。
