### PR TITLE
fix(claude): Claude Code設定を整理して攻撃面を減らす

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -9,51 +9,6 @@
 let
   ccstatusline = pkgs.callPackage ../../pkgs/ccstatusline.nix { };
 
-  # npm, yarn, pnpm, bunで共通のサブコマンドを許可するためのヘルパー
-  jsPackageManagers = [
-    "npm"
-    "yarn"
-    "pnpm"
-    "bun"
-  ];
-
-  # 直接実行するサブコマンド (install等)
-  jsDirectSubcommands = [
-    "ci:*"
-    "info:*"
-    "install:*"
-    "ls:*"
-    "view:*"
-  ];
-
-  # npm run経由で実行するサブコマンド (npmは `npm run <cmd>` 形式、他は `<pkg> <cmd>` 形式)
-  jsRunSubcommands = [
-    "build:*"
-    "dev:*"
-    "fix:*"
-    "lint:*"
-    "lint:eslint"
-    "lint:prettier"
-    "lint:tsc"
-    "npm:*"
-    "prettier:*"
-    "preview:*"
-    "test:*"
-  ];
-
-  mkJsDirectPermissions = pkg: map (sub: "Bash(${pkg} ${sub})") jsDirectSubcommands;
-
-  mkJsRunPermissions =
-    pkg:
-    let
-      prefix = if pkg == "npm" then "${pkg} run" else pkg;
-    in
-    map (sub: "Bash(${prefix} ${sub})") jsRunSubcommands;
-
-  jsRunnerPermissions = lib.concatMap (
-    pkg: mkJsDirectPermissions pkg ++ mkJsRunPermissions pkg
-  ) jsPackageManagers;
-
   # コーディングエージェントの作業ディレクトリ。
   # konokaプラグインは`${XDG_RUNTIME_DIR:-/tmp}/coding-agent-work/`を使用します。
   # NixOS環境では`osConfig`からUIDを取得して、
@@ -209,7 +164,7 @@ in
           # 適切に拒否するのが面倒なのでそのままにしています。
           "~/dotfiles/"
         ];
-        allow = jsRunnerPermissions ++ [
+        allow = [
           "Bash($EDITOR:*)"
           "Bash(* --help *)"
           "Bash(* --version)"

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -109,13 +109,6 @@ in
             ref = "v8.5.0";
           };
         };
-        context7-marketplace = {
-          source = {
-            source = "github";
-            repo = "upstash/context7";
-            ref = "@upstash/context7-mcp@3.2.1";
-          };
-        };
       };
       # pluginを記述しておくことで起動時にインストールされていない場合自動でインストールされます。
       enabledPlugins = {
@@ -137,8 +130,6 @@ in
         "research@konoka" = true;
         "rm-to-trash@konoka" = true;
         "web-tasuke@konoka" = true;
-        # Context7
-        "context7@context7-marketplace" = true; # ライブラリドキュメント検索
       };
       skipAutoPermissionPrompt = true; # auto modeをdefaultModeにしているので許可を求めない。
       permissions = {
@@ -327,6 +318,7 @@ in
           "mcp__plugin_claude-code-home-manager_backlog__get_wiki"
           "mcp__plugin_claude-code-home-manager_backlog__get_wiki_pages"
           "mcp__plugin_claude-code-home-manager_backlog__get_wikis_count"
+          "mcp__plugin_claude-code-home-manager_context7"
           "mcp__plugin_claude-code-home-manager_deepwiki"
           "mcp__plugin_claude-code-home-manager_github__get_commit"
           "mcp__plugin_claude-code-home-manager_github__get_file_contents"
@@ -351,7 +343,6 @@ in
           "mcp__plugin_claude-code-home-manager_github__search_pull_requests"
           "mcp__plugin_claude-code-home-manager_github__search_repositories"
           "mcp__plugin_claude-code-home-manager_github__search_users"
-          "mcp__plugin_context7_context7"
           "mcp__plugin_nix-tasuke_nixos"
         ];
         ask = [

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -113,7 +113,7 @@ in
           source = {
             source = "github";
             repo = "upstash/context7";
-            ref = "@upstash/context7-mcp@2.2.5";
+            ref = "@upstash/context7-mcp@3.2.1";
           };
         };
       };

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -164,8 +164,6 @@ in
       };
       # pluginを記述しておくことで起動時にインストールされていない場合自動でインストールされます。
       enabledPlugins = {
-        # claude-plugins-official
-        "plugin-dev@claude-plugins-official" = true;
         ## lsp plugin
         "clangd-lsp@claude-plugins-official" = true;
         "csharp-lsp@claude-plugins-official" = true;

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -138,7 +138,7 @@ in
         "rm-to-trash@konoka" = true;
         "web-tasuke@konoka" = true;
         # Context7
-        "context7-plugin@context7-marketplace" = true; # ライブラリドキュメント検索
+        "context7@context7-marketplace" = true; # ライブラリドキュメント検索
       };
       skipAutoPermissionPrompt = true; # auto modeをdefaultModeにしているので許可を求めない。
       permissions = {
@@ -351,7 +351,7 @@ in
           "mcp__plugin_claude-code-home-manager_github__search_pull_requests"
           "mcp__plugin_claude-code-home-manager_github__search_repositories"
           "mcp__plugin_claude-code-home-manager_github__search_users"
-          "mcp__plugin_context7-plugin_context7"
+          "mcp__plugin_context7_context7"
           "mcp__plugin_nix-tasuke_nixos"
         ];
         ask = [

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -121,15 +121,9 @@ in
       enabledPlugins = {
         ## lsp plugin
         "clangd-lsp@claude-plugins-official" = true;
-        "csharp-lsp@claude-plugins-official" = true;
         "gopls-lsp@claude-plugins-official" = true;
-        "jdtls-lsp@claude-plugins-official" = true;
-        "kotlin-lsp@claude-plugins-official" = true;
-        "lua-lsp@claude-plugins-official" = true;
         "pyright-lsp@claude-plugins-official" = true;
-        "ruby-lsp@claude-plugins-official" = true;
         "rust-analyzer-lsp@claude-plugins-official" = true;
-        "swift-lsp@claude-plugins-official" = true;
         "typescript-lsp@claude-plugins-official" = true;
         # konoka
         "commit@konoka" = true;

--- a/home/core/mcp.nix
+++ b/home/core/mcp.nix
@@ -18,6 +18,9 @@ in
           BACKLOG_DOMAIN.file = config.sops.secrets."backlog-mcp-server/domain".path;
         };
       };
+      context7 = {
+        command = lib.getExe pkgs.context7-mcp;
+      };
       deepwiki = {
         url = "https://mcp.deepwiki.com/mcp";
       };


### PR DESCRIPTION
Claude Codeの設定をいくつかまとめて見直します。

めったに編集しない言語のLSPプラグインを無効化して、
有効なプラグインを実際に使う言語だけに絞ります。
使っていないプラグインを常駐させずに済ませることで攻撃面を減らせます。
同様の理由で結局使う機会のなかった`plugin-dev`プラグインも削除します。

`npm`や`yarn`などのパッケージマネージャのサブコマンドの自動実行許可は、
全プロジェクト共通のグローバル設定から外します。
任意のプロジェクトで無条件に実行を許すのはリスクがあるため、
必要なプロジェクトごとに個別に許可する方針に変えます。

あわせて`context7-mcp`を最新バージョンに更新します。
