### PR TITLE
feat(seminar): garageのメトリクスをOTel Collector経由でMackerelに送る

### DIFF
--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -32,6 +32,14 @@ in
         }
       ];
       processors = {
+        # 公式ベストプラクティスに従いmemory_limiterをパイプライン先頭に置き、
+        # collectorのメモリ上限を確定させてホスト全体のOOMを防ぎます。
+        # 通常時のメモリは小さいので、転送失敗時の上限を抑えるのが主目的です。
+        memory_limiter = {
+          check_interval = "1s";
+          limit_mib = 256;
+          spike_limit_mib = 64;
+        };
         # Mackerelのラベル付きメトリクスは課金対象なので、
         # ボトルネック調査に有用なメトリクスファミリーのみ残します。
         # filterのconditionはtrueになったメトリクスを破棄するので、
@@ -56,6 +64,7 @@ in
       service.pipelines.metrics = {
         receivers = [ "prometheus" ];
         processors = [
+          "memory_limiter"
           "filter/garage"
           "batch"
         ];
@@ -64,11 +73,17 @@ in
     };
   };
 
-  # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
-  # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
-  systemd.services.opentelemetry-collector.serviceConfig.EnvironmentFile = [
-    config.sops.templates."otelcol-env".path
-  ];
+  systemd.services.opentelemetry-collector.serviceConfig = {
+    # collector内部のmemory_limiterに加えて、
+    # cgroupレベルでもメモリ上限を設けて二重に保護します。
+    # memory_limiterのlimit_mib(256MiB)より上に設定して、
+    # 通常はcollector側で先に制御が効くようにします。
+    MemoryHigh = "384M";
+    MemoryMax = "512M";
+    # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
+    # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
+    EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
+  };
 
   # `GARAGE_METRICS_TOKEN`: Garageの`/metrics`アクセス用Bearerトークン(garage.nixで定義)。
   # `MACKEREL_APIKEY`: MackerelのAPIキー(mackerel.nixで定義)。

--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -1,0 +1,79 @@
+{ config, ... }:
+let
+  garageAddr = config.machineAddresses.garage.guest;
+in
+{
+  # PrometheusメトリクスをOpenTelemetry Collectorでスクレイプし、
+  # OTLPでMackerelに転送します。
+  #
+  # 専用のPrometheus + Grafanaスタックは立てず、
+  # 既にホストで動いているMackerelに一本化します。
+  # `mackerel-plugin-prometheus-exporter`ではなくOTel Collectorを使うのは、
+  # プラグイン方式だとヒストグラムのバケットが平坦化されてレイテンシの
+  # パーセンタイルが失われるためです。
+  services.opentelemetry-collector = {
+    enable = true;
+    settings = {
+      receivers.prometheus.config.scrape_configs = [
+        {
+          job_name = "garage";
+          # Mackerelのメトリクス粒度は1分なので、それに合わせて1分間隔にします。
+          scrape_interval = "60s";
+          scheme = "http";
+          metrics_path = "/metrics";
+          # `GARAGE_METRICS_TOKEN`はGarageコンテナと同じsopsシークレットを、
+          # `EnvironmentFile`経由で渡し、
+          # collectorの環境変数展開で参照します。
+          authorization = {
+            type = "Bearer";
+            credentials = "\${env:GARAGE_METRICS_TOKEN}";
+          };
+          static_configs = [ { targets = [ "${garageAddr}:3903" ]; } ];
+        }
+      ];
+      processors = {
+        # Mackerelのラベル付きメトリクスは課金対象なので、
+        # ボトルネック調査に有用なメトリクスファミリーのみ残します。
+        # filterのconditionはtrueになったメトリクスを破棄するので、
+        # 対象プレフィックスにマッチしないものを破棄します。
+        # プレフィックス一致なので、
+        # prometheus receiverによる名前正規化(_total付与等)が起きても取りこぼしません。
+        "filter/garage" = {
+          error_mode = "ignore";
+          metrics.metric = [
+            ''not IsMatch(name, "^(api_s3_|block_|rpc_|table_|cluster_)")''
+          ];
+        };
+        batch = { };
+      };
+      exporters."otlp/mackerel" = {
+        # TLSはデフォルトで有効(Mackerelが要求)なので明示設定は不要です。
+        endpoint = "otlp.mackerelio.com:4317";
+        headers."Mackerel-Api-Key" = "\${env:MACKEREL_APIKEY}";
+      };
+      service.pipelines.metrics = {
+        receivers = [ "prometheus" ];
+        processors = [
+          "filter/garage"
+          "batch"
+        ];
+        exporters = [ "otlp/mackerel" ];
+      };
+    };
+  };
+
+  # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
+  # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
+  systemd.services.opentelemetry-collector.serviceConfig.EnvironmentFile = [
+    config.sops.templates."otelcol-env".path
+  ];
+
+  # `GARAGE_METRICS_TOKEN`: Garageの`/metrics`アクセス用Bearerトークン(garage.nixで定義)。
+  # `MACKEREL_APIKEY`: MackerelのAPIキー(mackerel.nixで定義)。
+  # どちらも既存のsopsシークレットのプレースホルダを参照するだけで、
+  # 新規シークレットの作成は不要です。
+  sops.templates."otelcol-env".content = ''
+    GARAGE_METRICS_TOKEN=${config.sops.placeholder."garage-metrics-token"}
+    MACKEREL_APIKEY=${config.sops.placeholder."mackerel-api-key"}
+  '';
+}

--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -46,7 +46,9 @@ in
         };
         batch = { };
       };
-      exporters."otlp/mackerel" = {
+      # `otlp` exporterはv0.144.0で`otlp_grpc`にリネームされ、
+      # `otlp`はdeprecatedエイリアスになったため`otlp_grpc`を使います。
+      exporters."otlp_grpc/mackerel" = {
         # TLSはデフォルトで有効(Mackerelが要求)なので明示設定は不要です。
         endpoint = "otlp.mackerelio.com:4317";
         headers."Mackerel-Api-Key" = "\${env:MACKEREL_APIKEY}";
@@ -57,7 +59,7 @@ in
           "filter/garage"
           "batch"
         ];
-        exporters = [ "otlp/mackerel" ];
+        exporters = [ "otlp_grpc/mackerel" ];
       };
     };
   };


### PR DESCRIPTION
niks3経由でgarageにアクセスが集中すると応答が遅くなることがあり、
どこがボトルネックなのかを計測したいです。

garageはadmin APIの`/metrics`でPrometheus形式のメトリクスを公開していて、
レイテンシのヒストグラムやHDD I/Oの逼迫を示す指標が取れます。
これをホスト上のOpenTelemetry Collectorでスクレイプして、
OTLPで既にホストで動いているMackerelに転送します。

専用のPrometheus + Grafanaスタックは立てず、
まずは既存のMackerelに一本化して様子を見ます。
プラグイン方式だとヒストグラムのバケットが平坦化されて、
p95やp99のようなレイテンシのパーセンタイルが失われます。
そのため`mackerel-plugin-prometheus-exporter`ではなくOTel Collectorを使い、
Mackerelのラベル付きメトリクスとして取り込んでp90やp95やp99を得ます。

Mackerelのラベル付きメトリクスは課金対象なので、
filterで主要なメトリクスファミリーに絞ります。
スクレイプ間隔はMackerelの粒度に合わせて1分にします。

認証情報はgarageとmackerelの既存のsopsシークレットを参照していて、
EnvironmentFile経由で渡すので新規シークレットの作成は不要です。

niks3自体はメトリクスを持たないため、
niks3経由の負荷はgarageのエンドポイント別やバケット別のメトリクスと、
mackerel-agentが取得するホストのディスクI/Oに現れる形で間接的に観測します。
