### PR TITLE
fix(seminar): mackerelのファイルシステム容量がbtrfsサブボリュームで重複するのを解消

### DIFF
--- a/nixos/host/seminar/mackerel.nix
+++ b/nixos/host/seminar/mackerel.nix
@@ -23,8 +23,6 @@ in
     settings = {
       # エージェント自身のメモリ使用量も収集
       diagnostic = true;
-      # ファイルシステムをデバイス名(dm-1等)ではなくマウントポイント名で表示
-      filesystems.use_mountpoint = true;
       # disk I/Oメトリクスを物理ディスク単位だけに絞ってノイズを削減する。
       # この正規表現はデバイス名に部分一致したものを収集対象から除外する。
       # 残したいのは物理ディスク全体(nvme0n1, nvme1n1, sda, sdb, sdc)のI/Oだけ。
@@ -36,8 +34,6 @@ in
       #   1本のHDDへのI/Oが sd[a-z] -> bcacheN -> bcacheNp1 -> dm-N と多重計上されて増幅する。
       #   物理実体である sd[a-z] だけ残せば各HDDの真のI/Oが分かる。
       # - nvme[0-9]+n[0-9]+p[0-9]+: nvmeのパーティション。親デバイス全体だけ見れば足りる。
-      #   use_mountpoint=trueだと、
-      #   パーティションがマウントポイント名(/var/tmp等)で表示され紛らわしいので除外する。
       # - sd[a-z][0-9]+: SCSI/SATAディスクのパーティション(現状は無いが将来用)。
       # なおdm-*はmackerel-agentが標準で除外するため明示不要。
       disks.ignore = "loop|zram|bcache|nvme[0-9]+n[0-9]+p[0-9]+|sd[a-z][0-9]+";


### PR DESCRIPTION
seminarのMackerelのファイルシステムメトリクスが、
btrfsのサブボリュームごとに分裂して同じ容量が何度も重複表示され、
実際のディスク使用量が読み取りにくい状態でした。

ルートの`/dev/nvme0n1p3`は`/`や`/nix/store`や`/var/log`などのサブボリュームを、
同一デバイスの別マウントポイントとしてマウントしています。
`use_mountpoint = true`だとmackerel-agentがマウントポイントごとに別メトリクスを作るため、
btrfsの全サブボリュームが共有する同じ容量が、
サブボリュームの数だけ重複報告されていました。

mackerel-agentの`[filesystems] ignore`はデバイス名にしかマッチせず、
同一デバイスの特定サブボリュームだけを除外する手段はありません。
そこで`use_mountpoint`をデフォルトの`false`に戻して、
メトリクスをデバイス名単位(`nvme0n1p3`や`dm-0`)に集約します。
btrfsのサブボリュームは容量を共有していて値はどれも同じなので、
1エントリにまとめても情報は失われません。
