### PR TITLE
fix(seminar): garageに未完了マルチパートを自動abortするlifecycleを設定

### DIFF
--- a/lib/garage-setup.nix
+++ b/lib/garage-setup.nix
@@ -131,6 +131,21 @@
             --arg accessKeyId "$ACCESS_KEY" \
             '{$bucketId, $accessKeyId, permissions: {read: true, write: true}}')
           garage_api POST /v2/AllowBucketKey "$ALLOW_PAYLOAD" > /dev/null
+
+          # 未完了マルチパートアップロードを1日後に自動abortするlifecycleルールを設定する。
+          # 未完了マルチパートが溜まり続けるとメタデータDB(LMDB)が肥大化する。
+          # Garage組み込みのlifecycle worker(既定でUTC 0時に100件ずつバッチ実行)に日々掃除させ、
+          # 負荷を平準化する。
+          LIFECYCLE_PAYLOAD=$(jq -nc \
+            '{lifecycleRules: [
+               {
+                 ID: "abort-incomplete-multipart-upload",
+                 Status: "Enabled",
+                 Filter: { Prefix: "" },
+                 AbortIncompleteMultipartUpload: { DaysAfterInitiation: 1 }
+               }
+             ]}')
+          garage_api POST "/v2/UpdateBucket?id=$BUCKET_ID" "$LIFECYCLE_PAYLOAD" > /dev/null
         '';
       }
     );


### PR DESCRIPTION
毎晩深夜にgarageが重くなる原因は、
niks3-gcが溜まった未完了マルチパートアップロードを一括abortしていたことでした。
未完了マルチパートが放置されるとメタデータDB(LMDB)が肥大化し、
それをまとめて処理するときに負荷が集中していました。

niks3-gcに頼って一括で掃除するのではなく、
バケットにlifecycleルールを設定して、
未完了マルチパートを開始から1日後に自動abortするようにします。
Garage組み込みのlifecycle workerは既定でUTC 0時に100件ずつバッチ実行するので、
日々少しずつ掃除させることで負荷を平準化できます。

`UpdateBucket` APIに`AbortIncompleteMultipartUpload`を含むlifecycleルールを渡して、
bucket作成時のセットアップで宣言的に設定します。
