### PR TITLE
feat(seminar): rootのsnapperスナップショットをnoaへbtrfs send/receiveでバックアップ

### DIFF
--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -125,6 +125,16 @@ _: {
                     "noatime"
                     "compress=zstd"
                   ];
+                  subvolumes = {
+                    # snapperスナップショットの転送先。
+                    # 独立したサブボリュームにすることで、
+                    # noa config(SUBVOLUME = /mnt/noa)のタイムラインスナップショットに含まれず、
+                    # バックアップの二重保存を避けられる。
+                    # `mountpoint`は指定しない。
+                    # トップレベルがマウントされている`/mnt/noa/snapshot-backup`として参照でき、
+                    # 別途マウントユニットを生成するとブート時のマウント失敗でemergencyに落ちるため。
+                    "snapshot-backup" = { };
+                  };
                   extraArgs = [
                     "-d raid1"
                     "/dev/mapper/noa0"

--- a/nixos/host/seminar/noa-snapper-backup.nix
+++ b/nixos/host/seminar/noa-snapper-backup.nix
@@ -1,0 +1,35 @@
+{ pkgs, ... }:
+{
+  # snapperが取得済みのrootスナップショットを、
+  # snbk(snapper-backup)でnoa(HDD RAID1)へbtrfs send/receive増分転送する。
+  # システムドライブ故障時の復旧と、
+  # 容量逼迫時の退避先を兼ねる。
+
+  # 転送先は /mnt/noa/snapshot-backup/<hostname>/<config> で名前空間を切る。
+  environment.etc."snapper/backup-configs/seminar-root.json".text = builtins.toJSON {
+    config = "root";
+    target-mode = "local";
+    automatic = true;
+    source-path = "/";
+    target-path = "/mnt/noa/snapshot-backup/seminar/root";
+  };
+
+  # snapper同梱のbackup unitをそのまま流用する。
+  # serviceは`snbk --verbose --automatic transfer-and-delete`を実行し、
+  # `automatic: true`のbackup-configを転送しつつリテンションに基づく削除も行う。
+  systemd.units = {
+    "snapper-backup.service".text =
+      builtins.readFile "${pkgs.snapper}/lib/systemd/system/snapper-backup.service";
+    "snapper-backup.timer" = {
+      text = builtins.readFile "${pkgs.snapper}/lib/systemd/system/snapper-backup.timer";
+      wantedBy = [ "timers.target" ];
+    };
+  };
+
+  # target-path配下のディレクトリを用意する。
+  # サブボリューム自体はdiskoで管理している。
+  systemd.tmpfiles.rules = [
+    "d /mnt/noa/snapshot-backup/seminar 0700 root root -"
+    "d /mnt/noa/snapshot-backup/seminar/root 0700 root root -"
+  ];
+}


### PR DESCRIPTION
システムドライブが故障するとsnapperのスナップショットも道連れになるため、
別ディスクへの退避先がありませんでした。
また容量逼迫時にスナップショットを逃がす先も用意したいです。

snapper同梱のsnbk(snapper-backup)を使って、
取得済みのrootスナップショットをnoa(HDD RAID1)へbtrfs send/receiveで増分転送します。
serviceとtimerはsnapperがlibに同梱しているunitファイルをそのまま流用し、
`automatic: true`のbackup-configを転送しつつリテンションに基づく削除も行わせます。

転送先は`/mnt/noa/snapshot-backup/<hostname>/<config>`で名前空間を切り、
将来他ホストやconfigを追加しても衝突しないようにします。

転送先はnoa配下に独立したサブボリューム`snapshot-backup`として切り出します。
これによりnoa config(`SUBVOLUME = /mnt/noa`)のタイムラインスナップショットに含まれず、
バックアップが二重に保存されるのを避けられます。
このサブボリュームには`mountpoint`を指定せず、
トップレベルがマウントされている`/mnt/noa/snapshot-backup`として参照します。
別途マウントユニットを生成すると、
ブート時のマウント失敗でemergencyモードに落ちる恐れがあるためです。