### PR TITLE
perf(snapper): snapperの操作とバックアップの優先度を下げて他の作業を妨げないようにする

### DIFF
--- a/nixos/host/seminar/noa-snapper-backup.nix
+++ b/nixos/host/seminar/noa-snapper-backup.nix
@@ -1,4 +1,19 @@
 { pkgs, ... }:
+let
+  # snapper.nixの`lowPriority`と同じ意図で、btrfs send/receiveの転送を低優先度にする。
+  # snapper-backup.serviceは`systemd.units`の生テキストで定義しているため、
+  # `serviceConfig`では上書きできない。
+  # 代わりに`[Service]`セクションを追記する。
+  # 同一ファイル内の重複セクションはsystemdがマージする。
+  lowPriority = ''
+
+    [Service]
+    Nice=19
+    CPUSchedulingPolicy=idle
+    IOSchedulingClass=idle
+    IOWeight=10
+  '';
+in
 {
   # snapperが取得済みのrootスナップショットを、
   # snbk(snapper-backup)でnoa(HDD RAID1)へbtrfs send/receive増分転送する。
@@ -19,7 +34,7 @@
   # `automatic: true`のbackup-configを転送しつつリテンションに基づく削除も行う。
   systemd.units = {
     "snapper-backup.service".text =
-      builtins.readFile "${pkgs.snapper}/lib/systemd/system/snapper-backup.service";
+      builtins.readFile "${pkgs.snapper}/lib/systemd/system/snapper-backup.service" + lowPriority;
     "snapper-backup.timer" = {
       text = builtins.readFile "${pkgs.snapper}/lib/systemd/system/snapper-backup.timer";
       wantedBy = [ "timers.target" ];

--- a/nixos/native-linux/snapper.nix
+++ b/nixos/native-linux/snapper.nix
@@ -1,4 +1,23 @@
-_: {
+_:
+let
+  # snapperのスナップショット作成・クリーンアップは緊急性がないので、
+  # 他のプロセスを妨害しないようにCPUとI/Oの優先度を下げる。
+  lowPriority = {
+    # CPUはniceとidleクラスで確実に後回しにできる。スケジューラに依存しない。
+    Nice = 19;
+    CPUSchedulingPolicy = "idle";
+    # `IOSchedulingClass = idle`はmq-deadlineやBFQで有効。
+    # カーネル5.18以降のmq-deadlineはI/O優先度対応なので効くが、
+    # idleリクエストの餓死防止で緩く割り込む。
+    # NVMeのnoneスケジューラでは効かない。
+    IOSchedulingClass = "idle";
+    # IOWeight(cgroupのio.weight)による比例配分はBFQでのみ効く。
+    # mq-deadlineやnoneでは効かないが無害なので、
+    # 将来BFQに切り替えた場合に備えて指定しておく。
+    IOWeight = 10;
+  };
+in
+{
   services.snapper = {
     configs = {
       root = {
@@ -8,5 +27,13 @@ _: {
         TIMELINE_CLEANUP = true;
       };
     };
+  };
+
+  # 実際の重いbtrfs操作(subvolume削除など)はD-Bus越しにsnapperdが行うため、
+  # トリガとなるtimeline/cleanupだけでなくsnapperd本体にも適用する。
+  systemd.services = {
+    snapper-cleanup.serviceConfig = lowPriority;
+    snapper-timeline.serviceConfig = lowPriority;
+    snapperd.serviceConfig = lowPriority;
   };
 }


### PR DESCRIPTION
サーバでsnapperのスナップショットのクリーンアップが走るときにHDDへのアクセスが遅延したり、
デスクトップで頻繁に取るスナップショットが他の作業を妨げるのが気になっていました。
snapperは基本的にゆっくり進んでも問題のないサービスなので、
透過的にCPUとI/Oの優先度を下げます。

実際の重いbtrfs操作(subvolume削除など)はD-Bus越しに`snapperd`が実行するため、
トリガとなる`snapper-timeline`や`snapper-cleanup`だけに設定しても効きません。
`snapperd`本体を含む3つのユニットに同じ低優先度設定を適用します。
seminarのバックアップ(`snapper-backup.service`)がnoa(HDD RAID1)へ流す、
btrfs send/receiveの転送も同様に後回しにします。

CPU側は`Nice`と`CPUSchedulingPolicy=idle`でスケジューラに依存せず確実に後回しにできます。
I/O側は`IOSchedulingClass=idle`がmq-deadlineやBFQで効きます。
NVMeのnoneスケジューラでは効きませんが、
NVMeはそもそもI/O競合しにくいのでCPU優先度の低下で十分です。
`IOWeight`はBFQでしか効かず現状のmq-deadlineやnoneでは無害な空振りですが、
将来BFQに切り替えた場合に備えて指定しておきます。