### PR TITLE
fix(snapper): rootスナップショットに`FREE_LIMIT`を明示してシステムディスクの空きを確保する

### DIFF
--- a/nixos/native-linux/snapper.nix
+++ b/nixos/native-linux/snapper.nix
@@ -25,6 +25,13 @@ in
 
         TIMELINE_CREATE = true;
         TIMELINE_CLEANUP = true;
+
+        # 空き容量がこの割合を下回ると、timeline cleanupが世代数の制限とは別に、
+        # 古いスナップショットから追加で削除して空き容量を確保する。
+        # 過去にスナップショットがシステムディスクを圧迫したので明示的に引き上げる。
+        # FREE_LIMITはstatvfsベースで動作しquota(qgroup)を必要としない。
+        # 世代数自体は絞らない。容量に余裕がある限り履歴は多く残して構わない方針。
+        FREE_LIMIT = "0.4";
       };
     };
   };


### PR DESCRIPTION
過去にsnapperのスナップショットがシステムディスクの容量を圧迫したため、
空き容量を一定割合保つようにします。

NixOSの`services.snapper`はテンプレートをコピーせず指定したキーだけを書き出すので、
これまで`/etc/snapper/configs/root`には`FREE_LIMIT`が含まれていませんでした。
snapper本体のC++既定値`0.2`は効いていたものの、
それでは肥大化を防げなかったため明示的に`0.4`へ引き上げます。
空きが40%を下回ると、
timeline cleanupが世代数の制限とは別に古いスナップショットから追加削除して空きを確保します。

`FREE_LIMIT`は`statvfs`ベースで動作しquota(qgroup)を必要としないので、
`snapper setup-quota`などの追加設定は不要です。
世代数(`TIMELINE_LIMIT_*`)は絞らず既定のままにします。
容量に余裕がある限り履歴は多く残して構わない方針です。

seminarもクライアントPCも共通の`native-linux`設定なので、
全ホストの`/`に同じ空き容量確保が適用されます。
