### PR TITLE
bcacheストレージシステムに使っていたキャッシュSSDデバイスをアップグレード

### DIFF
--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -84,10 +84,10 @@ _: {
       # # diskoはbcacheを直接サポートしていないため、
       # # 一部は以下のように手動で設定する必要があります。
       # # bcacheデバイスの作成
-      # # キャッシュデバイス（SSD）
+      # # キャッシュデバイス(SSD)
       # CACHE_DEVICE=/dev/disk/by-id/nvme-WD_BLACK_SN770_1TB_242810800421
       # sudo make-bcache --cache --writeback --discard $CACHE_DEVICE
-      # # バッキングデバイス（HDD）
+      # # バッキングデバイス(HDD)
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD121PURZ-85GUCY0_2AGN938Y
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAAZ-00BXBB0_WD-RD2PKLEH
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAZZ-00BKLB0_WD-CA2HPAUK

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -85,13 +85,14 @@ _: {
       # # 一部は以下のように手動で設定する必要があります。
       # # bcacheデバイスの作成
       # # キャッシュデバイス（SSD）
-      # sudo make-bcache --cache --writeback --discard /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935
+      # CACHE_DEVICE=/dev/disk/by-id/nvme-WD_BLACK_SN770_1TB_242810800421
+      # sudo make-bcache --cache --writeback --discard $CACHE_DEVICE
       # # バッキングデバイス（HDD）
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD121PURZ-85GUCY0_2AGN938Y
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAAZ-00BXBB0_WD-RD2PKLEH
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAZZ-00BKLB0_WD-CA2HPAUK
       # # キャッシュセットに接続
-      # CACHE_SET_UUID=$(sudo bcache-super-show /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935|grep 'cset.uuid'|awk '{print $2}')
+      # CACHE_SET_UUID=$(sudo bcache-super-show $CACHE_DEVICE|grep 'cset.uuid'|awk '{print $2}')
       # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache0/bcache/attach"
       # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache1/bcache/attach"
       # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache2/bcache/attach"

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -93,9 +93,7 @@ _: {
       # sudo make-bcache --bdev --writeback --discard /dev/disk/by-id/ata-WDC_WD80EAZZ-00BKLB0_WD-CA2HPAUK
       # # キャッシュセットに接続
       # CACHE_SET_UUID=$(sudo bcache-super-show $CACHE_DEVICE|grep 'cset.uuid'|awk '{print $2}')
-      # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache0/bcache/attach"
-      # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache1/bcache/attach"
-      # sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache2/bcache/attach"
+      # for i in 0 1 2; do sudo zsh -c "echo $CACHE_SET_UUID > /sys/block/bcache$i/bcache/attach"; done
       # # パスワードファイル作成
       # sudo nano /tmp/secret.password
       # # 初期インストール時以外はフォーマットを手動で済ませる。


### PR DESCRIPTION
以下の手順を実行してからシャットダウンして、
後はコメントを書き換えてからセットアップの一部を実行して換装しました。

```
sudo bcache-super-show /dev/disk/by-id/nvme-WD_PC_SN740_SDDQNQD-256G-1201_23252F808935
```

```
sb.magic		ok
sb.first_sector		8 [match]
sb.csum			682AE8D536A20E6D [match]
sb.version		3 [cache device]

dev.label		(empty)
dev.uuid		350ae30d-0b01-4f0d-8528-546832eaf076
dev.sectors_per_block	1
dev.sectors_per_bucket	1024
dev.cache.first_sector	1024
dev.cache.cache_sectors	500116480
dev.cache.total_sectors	500117504
dev.cache.ordered	yes
dev.cache.discard	yes
dev.cache.pos		0
dev.cache.replacement	0 [lru]

cset.uuid		16f38cd3-b763-4db6-aa21-2df5b1dfae77
```

```
2026-06-19T17:13:45 on  master via ❄️  impure (nix-shell-env)
ncaq@🌐 seminar:~/dotfiles ❯ for n in 0 1 2; do echo writethrough | sudo tee /sys/block/bcache$n/bcache/cache_mode; done
writethrough
writethrough
writethrough

2026-06-19T17:15:04 on  master via ❄️  impure (nix-shell-env) took 29s
ncaq@🌐 seminar:~/dotfiles ❯ cat /sys/block/bcache{0,1,2}/bcache/dirty_data /sys/block/bcache{0,1,2}/bcache/state
0.0k
0.0k
0.0k
clean
clean
clean
```

```
CSET=16f38cd3-b763-4db6-aa21-2df5b1dfae77
```

```
2026-06-19T17:15:53 on  master via ❄️  impure (nix-shell-env)
ncaq@🌐 seminar:~/dotfiles ❯ for n in 0 1 2; do echo "$CSET" | sudo tee /sys/block/bcache$n/bcache/detach; done
16f38cd3-b763-4db6-aa21-2df5b1dfae77
16f38cd3-b763-4db6-aa21-2df5b1dfae77
16f38cd3-b763-4db6-aa21-2df5b1dfae77
```

```
2026-06-19T17:16:11 on  master via ❄️  impure (nix-shell-env)
ncaq@🌐 seminar:~/dotfiles ❯ echo 1 | sudo tee /sys/fs/bcache/$CSET/unregister

1
```
