### PR TITLE
build(deps): niks3の参照先を自分のforkに変更

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,15 +289,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781722189,
-        "narHash": "sha256-hwHukB+GctoQLC1DFdDN4Do3O2OpFvbDD47I3tunjHk=",
-        "owner": "Mic92",
+        "lastModified": 1781868640,
+        "narHash": "sha256-JRZA5vadKkne7xuNYBkEybOkA3kEUG/CbFj78o+sSkQ=",
+        "owner": "ncaq",
         "repo": "niks3",
-        "rev": "39146705df96b81763b19862ea0b72bce3608222",
+        "rev": "96b5bb7238d4b7db716c25c20ade073390b176ba",
         "type": "github"
       },
       "original": {
-        "owner": "Mic92",
+        "owner": "ncaq",
+        "ref": "dup-multipart",
         "repo": "niks3",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
     };
 
     niks3 = {
-      url = "github:Mic92/niks3";
+      url = "github:ncaq/niks3/dup-multipart";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         treefmt-nix.follows = "treefmt-nix";


### PR DESCRIPTION
[fix(pending_closures): reuse in-flight multipart upload across closures by ncaq · Pull Request #412 · Mic92/niks3](https://github.com/Mic92/niks3/pull/412)
がマージされる前に、
自分のサーバで挙動を確認するために自分自身で作ったforkを参照します。
マージされるか他の方法で修正されたら本家を参照するように戻します。
