### PR TITLE
fix(audio): Razer Seiren Miniをデフォルトソースとして確実に選ばれるようにする

### DIFF
--- a/nixos/native-linux/audio.nix
+++ b/nixos/native-linux/audio.nix
@@ -22,8 +22,8 @@
                 ]
                 actions = {
                   update-props = {
-                    "priority.session" = 2100
-                    "priority.driver" = 2100
+                    "priority.session" = 3000
+                    "priority.driver" = 3000
                   }
                 }
               }


### PR DESCRIPTION
`priority.session = 2100`ではHD Pro Webcam C920の内蔵マイクの`priority.session = 2109`に負けて、
WirePlumberのデフォルトソースとして選ばれませんでした。
WirePlumberはUSBオーディオデバイスに対して内部ルールで2000台の値を自動付与するため、
2100では他のUSBオーディオと衝突した際に逆転される余地があります。

Webcamだけでなく他のUSBオーディオ機器との将来的な衝突も避けるため、
余裕を持って3000まで引き上げます。
`priority.driver`も同じ値で揃えます。
