### PR TITLE
feat: yarn-berryをグローバル追加

### DIFF
--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -52,5 +52,6 @@ in
     typescript
     typescript-language-server
     vscode-langservers-extracted
+    yarn-berry
   ];
 }


### PR DESCRIPTION
まだグローバル依存しているところがあったので。
そのうち内部解決するようにはしますが、
とりあえずはまだグローバル解決します。
home-managerのprogramのyarnはyarnバイナリ自体はインストールしませんでしあ。
