### PR TITLE
feat: seminarのSSD換装とそれに必要な変更

### DIFF
--- a/docs/install/nixos-disko.md
+++ b/docs/install/nixos-disko.md
@@ -16,7 +16,24 @@ export NIX_CONFIG="experimental-features = flakes nix-command"
 nix run 'nixpkgs#git' -- clone https://github.com/ncaq/dotfiles.git
 cd dotfiles
 sudo -E nix run '.#disko' -- --mode format,mount --flake ".#${NEW_HOST}"
-sudo nixos-install --flake ".#${NEW_HOST}" --root /mnt
+
+# workaround nixos-install
+
+sudo mkdir -p /mnt/build
+
+df -h /
+mount | grep -iE 'rw-store|overlay|/nix'
+sudo mount -o remount,size=48G /nix/.rw-store
+
+nix build "path:$PWD#nixosConfigurations.${NEW_HOST}.config.system.build.toplevel" \
+  --out-link /mnt/build/toplevel \
+  --extra-experimental-features "nix-command flakes"
+
+TOPLEVEL=$(readlink -f /mnt/build/toplevel)
+sudo nix copy --to /mnt "$TOPLEVEL" --no-check-sigs \
+  --extra-experimental-features "nix-command flakes"
+
+sudo nixos-install --system "$TOPLEVEL" --root /mnt --no-channel-copy
 ```
 
 Please reboot after installation.

--- a/nixos/core/label.nix
+++ b/nixos/core/label.nix
@@ -16,7 +16,9 @@ let
   # コミットリビジョン。
   # `install.sh`が最後のコミット情報ファイルをstagingするため必ずdirtyになります。
   # "-dirty"サフィックスは自前の注入によるものなので除去します。
-  shortRev = lib.strings.removeSuffix "-dirty" inputs.self.dirtyShortRev or inputs.self.shortRev;
+  shortRev =
+    lib.strings.removeSuffix "-dirty"
+      inputs.self.dirtyShortRev or inputs.self.shortRev or "nothing-rev";
   # `install.sh`が最新コミットの情報を`last-commit.json`に保存してstagingします。
   lastCommitFile = "${inputs.self}/last-commit.json";
   lastCommit =

--- a/nixos/core/tailscale.nix
+++ b/nixos/core/tailscale.nix
@@ -33,7 +33,6 @@
           '';
         }
       );
-      TimeoutStartSec = "10min";
     };
   };
 }

--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -17,6 +17,15 @@
       systemd = {
         enable = true;
       };
+      luks.devices = {
+        "nixos-root" = {
+          device = "/dev/disk/by-partlabel/disk-main-luks";
+          allowDiscards = true;
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+          ];
+        };
+      };
     };
   };
 }

--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -18,8 +18,8 @@
         enable = true;
       };
       luks.devices = {
-        "nixos-root" = {
-          device = "/dev/disk/by-partlabel/disk-main-luks";
+        nixos-root = {
+          device = "/dev/disk/by-partlabel/disk-main-nixos-root";
           allowDiscards = true;
           crypttabExtraOpts = [
             "tpm2-device=auto"

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -3,8 +3,7 @@ _: {
     disk = {
       main = {
         type = "disk";
-        # 最終的にM.2スロットに挿した状態のIDを記載する。
-        device = "/dev/disk/by-id/nvme-WD_BLACK_SN850X_HS_2000GB_xxxxx";
+        device = "/dev/disk/by-id/nvme-WD_BLACK_SN850X_HS_2000GB_25393V801805";
         content = {
           type = "gpt";
           partitions = {

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -40,41 +40,48 @@ _: {
               size = "100%";
               type = "8300";
               content = {
-                type = "btrfs";
-                subvolumes = {
-                  "@" = {
-                    mountpoint = "/";
-                    mountOptions = [
-                      "noatime"
-                      "compress=zstd"
-                    ];
-                  };
-                  "@nix-store" = {
-                    mountpoint = "/nix/store";
-                    mountOptions = [
-                      "noatime"
-                      "compress=zstd"
-                    ];
-                  };
-                  "@swap" = {
-                    mountpoint = "/swap";
-                    mountOptions = [
-                      "noatime"
-                    ];
-                  };
-                  "@var-log" = {
-                    mountpoint = "/var/log";
-                    mountOptions = [
-                      "noatime"
-                      "compress=zstd"
-                    ];
-                  };
-                  "@snapshots" = {
-                    mountpoint = "/.snapshots";
-                    mountOptions = [
-                      "noatime"
-                      "compress=zstd"
-                    ];
+                type = "luks";
+                name = "nixos-root";
+                settings.allowDiscards = true;
+                # フォーマット時のみ使う一時パスワードファイル。
+                passwordFile = "/tmp/secret.password";
+                content = {
+                  type = "btrfs";
+                  subvolumes = {
+                    "@" = {
+                      mountpoint = "/";
+                      mountOptions = [
+                        "noatime"
+                        "compress=zstd"
+                      ];
+                    };
+                    "@nix-store" = {
+                      mountpoint = "/nix/store";
+                      mountOptions = [
+                        "noatime"
+                        "compress=zstd"
+                      ];
+                    };
+                    "@swap" = {
+                      mountpoint = "/swap";
+                      mountOptions = [
+                        "noatime"
+                      ];
+                    };
+                    "@var-log" = {
+                      mountpoint = "/var/log";
+                      mountOptions = [
+                        "noatime"
+                        "compress=zstd"
+                      ];
+                    };
+                    "@snapshots" = {
+                      mountpoint = "/.snapshots";
+                      mountOptions = [
+                        "noatime"
+                        "compress=zstd"
+                      ];
+                    };
                   };
                 };
               };

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -3,7 +3,8 @@ _: {
     disk = {
       main = {
         type = "disk";
-        device = "/dev/disk/by-id/nvme-Samsung_SSD_970_EVO_Plus_1TB_S4EWNF0M300603J";
+        # 最終的にM.2スロットに挿した状態のIDを記載する。
+        device = "/dev/disk/by-id/nvme-WD_BLACK_SN850X_HS_2000GB_xxxxx";
         content = {
           type = "gpt";
           partitions = {

--- a/secrets/cachix.yaml
+++ b/secrets/cachix.yaml
@@ -1,0 +1,18 @@
+CACHIX_AUTH_TOKEN: ENC[AES256_GCM,data:tDeXRAJ0wY5grDLSxVKhnd8v9FtUW3H3He7odtKeB0PNN3WRpOi0K0CNAnpB+SKgNjpGOdrWgcolcR8ihmOzrFEhGgRpo6boEyvb0vfKBSlZme5zcDbtDY0wnBd9JGza7O/NoGw9lHoFL2K4KZss9hcPLd/8MH1D4qvvnL9YYapjC5QffwxI+pEID0X7d4+j3m2Cruc=,iv:Opp1RM0yU1Lwd5X9WU2itleKs2Sv1Br9ZAX2l3gHVJs=,tag:X9Q+In8rh6fR5kxrNOElkw==,type:str]
+sops:
+  lastmodified: "2026-06-22T08:46:27Z"
+  mac: ENC[AES256_GCM,data:/EqW/oxKxByxofkRTAR+I6YMocfzRtiwmVXFlREqFJdHi0trNG5su7tqPx7EUvREtFst3WcNF1HzHBfi3e2yZjDvAChz7JKLhWqZ/206XT3ZETKA7qysfsS/X3kCwzm4wdSEg01KfBjc9aH7kWe1PhuvAQJ+6zN6nOxYkw0/OZE=,iv:Qstwbi59mmhsyQxHsFJsmwD8h25rTS0nYgAbu/ILxuY=,tag:cSa50P5dr8mxF50v8CneZw==,type:str]
+  pgp:
+    - created_at: "2026-06-22T08:46:05Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4Dxlt1nl1bPpUSAQdAiv4/gDF2Nymz6rJHut3Rw3rNjl+AQi0VGnEY2EwPNlAw
+        DPxnduz6O2KOfyZKCU6lGyCV65IM7o3+0vdv9O5wpQiDNEqYJnC8aHTM+e6Zi2Fh
+        0lwBNiDRGb7f1RFQ67n7IIZd7YJ33oGGsGH2NvRsGWWrh++8hYB0w3s4P53suSx5
+        rGTnRwHSTbD5wg6ZyCD9mCoX/xsjdqrHVruTJkdwJdFVJ1dVs06JUtfWcCA0KA==
+        =Uwgn
+        -----END PGP MESSAGE-----
+      fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
+  unencrypted_suffix: _unencrypted
+  version: 3.13.1


### PR DESCRIPTION
- **feat: デバイス名を仮のものに変更**
- **feat: メインディスクを暗号化**
- **feat: ブートディスクを暗号化されたもの前提に変更**
- **fix: 実際のディスクのシリアルナンバーを記載**
- **fix: bootのluksのデバイスパスを修正**
- **fix: `shortRev`にfallback追加**
- **docs: nixos-installがうまく動かないのでとりあえずワークアラウンドを書いておきます**
- **feat: seminarのキャッシュサーバが落ちていても使えるcachixのサーバのトークンを保存しておく**
- **fix: `tailscale-online`の`TimeoutStartSec`をデフォルトに戻す**
