### PR TITLE
fix: GPGの`use-keyboxd`を宣言的に無効化する

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -21,22 +21,31 @@ lib.mkMerge [
         }
       ];
     };
-    # 非gracefulなシャットダウン(WSL終了など)でgpg-agentのsentinel lockが残留し、
-    # importGpgKeysでgpg-agentに接続できなくなることがあります。
-    # importGpgKeysの前にstaleなロックファイルを削除して回避します。
-    home.activation.cleanGpgStaleLocks = entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
-      $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash \
-        "${config.programs.gpg.homedir}/gnupg_spawn_agent_sentinel.lock" \
-        2>/dev/null || true
-    '';
-    home.packages = with pkgs; [
-      # 最終復旧手段として印刷するためのパッケージ。
-      paperkey
-      # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
-      # こちらを優先して使っていきます。
-      # `pinentry-curses`は`pinentry-qt`パッケージに含まれています。
-      pinentry-qt
-    ];
+    home = {
+      # `use-keyboxd`を有効化しないために空の`common.conf`を配置します。
+      # 有効化するとkeyboxdデーモンが`pubring.db`のロックを抱え続けるため、
+      # root権限で動く`sops-install-secrets`がユーザのGPG keyringを参照する際に、
+      # ロック競合で復号化に失敗します。
+      # `gpg.conf`を弄っても効かない(keyboxd設定は`common.conf`を見る)ため、
+      # `programs.gpg.settings`ではなく直接ファイルを配置しています。
+      file.".gnupg/common.conf".text = "";
+      # 非gracefulなシャットダウン(WSL終了など)でgpg-agentのsentinel lockが残留し、
+      # importGpgKeysでgpg-agentに接続できなくなることがあります。
+      # importGpgKeysの前にstaleなロックファイルを削除して回避します。
+      activation.cleanGpgStaleLocks = entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
+        $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash \
+          "${config.programs.gpg.homedir}/gnupg_spawn_agent_sentinel.lock" \
+          2>/dev/null || true
+      '';
+      packages = with pkgs; [
+        # 最終復旧手段として印刷するためのパッケージ。
+        paperkey
+        # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
+        # こちらを優先して使っていきます。
+        # `pinentry-curses`は`pinentry-qt`パッケージに含まれています。
+        pinentry-qt
+      ];
+    };
   }
   (
     if !isTermux then


### PR DESCRIPTION
新規にGPG homedirを初期化したサーバで`common.conf`に`use-keyboxd`が入ると、
常駐するkeyboxdが`pubring.db`のロックを抱え続け、
root権限で動く`sops-install-secrets`がユーザのGPG keyringを参照する際に、
ロック競合で復号化に失敗していました。
空の`common.conf`を`home.file`で配置することでkeyboxdの有効化を防止し、
従来通り`pubring.kbx`バックエンドで運用されるようにします。

合わせて`home.file`/`home.activation`/`home.packages`を`home`ブロックにまとめて、
属性パスの繰り返しを減らしました。
