### PR TITLE
fix: `opentelemetry-collector`を`sops-install-secrets`の後に起動する

### DIFF
--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -73,16 +73,20 @@ in
     };
   };
 
-  systemd.services.opentelemetry-collector.serviceConfig = {
-    # collector内部のmemory_limiterに加えて、
-    # cgroupレベルでもメモリ上限を設けて二重に保護します。
-    # memory_limiterのlimit_mib(256MiB)より上に設定して、
-    # 通常はcollector側で先に制御が効くようにします。
-    MemoryHigh = "384M";
-    MemoryMax = "512M";
-    # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
-    # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
-    EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
+  systemd.services.opentelemetry-collector = {
+    serviceConfig = {
+      # collector内部のmemory_limiterに加えて、
+      # cgroupレベルでもメモリ上限を設けて二重に保護します。
+      # memory_limiterのlimit_mib(256MiB)より上に設定して、
+      # 通常はcollector側で先に制御が効くようにします。
+      MemoryHigh = "384M";
+      MemoryMax = "512M";
+      # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
+      # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
+      EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
+    };
+    after = [ "sops-install-secrets.service" ];
+    requires = [ "sops-install-secrets.service" ];
   };
 
   # `GARAGE_METRICS_TOKEN`: Garageの`/metrics`アクセス用Bearerトークン(garage.nixで定義)。


### PR DESCRIPTION
`EnvironmentFile`に指定したsopsテンプレート(`/run/secrets/rendered/otelcol-env`)を、
展開するのは`sops-install-secrets.service`ですが、
nixpkgs本体の`opentelemetry-collector`モジュールには両者の順序依存がなく、
tmpfs上のファイルは毎ブート再生成が必要なため、
展開前にcollectorが起動すると`Failed to load environment files`で失敗していました。
`Restart=always`によるリトライで最終的には成功していたものの、
起動直後に複数回失敗するのは望ましくないので、
`after`と`requires`で明示的に`sops-install-secrets.service`の後に走るよう順序付けします。

既存の`nixos/native-linux/wifi.nix`の`NetworkManager-ensure-profiles`に対する修正と、
同じパターンです。
