### PR TITLE
build(deps): update ncaq/nix-composite-action to v3

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,18 +1,11 @@
 name: Setup Nix
 description: Reusable action for nix config
 
-inputs:
-  cachix-auth-token:
-    description: Cachix authentication token
-    required: false
-    default: ""
-
 runs:
   using: composite
   steps:
-    - uses: ncaq/nix-composite-action@76930b11f37310bc68c66492a09045c4f0432226 # v1.3.1
+    - uses: ncaq/nix-composite-action@9b26867355388b589de67c08de87e8786e2e8094 # v3.0.0
       with:
-        cachix-auth-token: "${{ inputs.cachix-auth-token }}"
         # セルフホストランナーのためflake.nixの内容を転写します。
         # flake.nixの内容と乖離しないように注意してください。
         extra-nix-config: >

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,8 +69,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: >-
           nix run '.#nix-fast-build' --
           --option eval-cache false
@@ -99,8 +97,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build -L .#homeConfigurations.x86_64-linux.activationPackage
       # Nix-on-Droidのビルドはimpureモードで行う必要があります
       - run: nix build -L .#nixOnDroidConfigurations.default.activationPackage --impure
@@ -120,8 +116,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: nix build
         run: >-
           nix eval --json .#nixosConfigurations --apply builtins.attrNames |
@@ -143,8 +137,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: nix build
         run: >-
           nix eval --json .#testNixosBoot --apply builtins.attrNames |

--- a/.github/workflows/nvd-diff.yml
+++ b/.github/workflows/nvd-diff.yml
@@ -29,8 +29,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Run nvd-pr-diff
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
ncaq/nix-composite-actionのv3で`cachix-auth-token`入力が削除され、
Cachixはread-only substituterとしてのみ追加されるようになりました。
書き込みはniks3に一本化されています。

これに伴い、以下の対応を行います。

- 各ワークフローと`setup-nix`アクションで`cachix-auth-token`の受け渡しを削除する
- `setup-nix`アクションの`cachix-auth-token`入力定義を削除する
- バージョン参照をv3へ更新する

ref https://github.com/ncaq/nix-composite-action/pull/67
