### PR TITLE
feat: `cachix-push-ncaq`コマンドを追加

### DIFF
--- a/home/core/nix.nix
+++ b/home/core/nix.nix
@@ -46,10 +46,13 @@ let
         "$@"
     '';
   };
+  # `secrets/cachix.yaml`から認証トークンを復号して`cachix push ncaq`するラッパー。
+  cachix-push-ncaq = pkgs.callPackage ../../pkgs/cachix-push-ncaq { };
 in
 {
   home.packages = with pkgs; [
     cachix
+    cachix-push-ncaq
     nil
     nix-diff
     nix-fast-build-wrapper

--- a/pkgs/cachix-push-ncaq/cachix-push-ncaq.bash
+++ b/pkgs/cachix-push-ncaq/cachix-push-ncaq.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `secrets/cachix.yaml`からCachix認証トークンを復号して、
+# `cachix push ncaq`を実行するラッパー。
+#
+# 自宅サーバのniks3キャッシュが落ちた時のフォールバックとして、
+# 別マシンやCIに手軽にキャッシュを転送するために使います。
+#
+# 引数があればそのまま`cachix push <cache>`に渡します。
+# 引数がなければ標準入力からstoreパス一覧を読みます。
+#
+# 環境変数で挙動を変更できます:
+#   CACHIX_PUSH_NCAQ_SECRETS_FILE  sopsで暗号化されたシークレットファイル。
+#                                  デフォルトは`$HOME/dotfiles/secrets/cachix.yaml`。
+#   CACHIX_PUSH_NCAQ_CACHE         Cachixのキャッシュ名。デフォルトは`ncaq`。
+
+secrets_file=${CACHIX_PUSH_NCAQ_SECRETS_FILE:-$HOME/dotfiles/secrets/cachix.yaml}
+cache_name=${CACHIX_PUSH_NCAQ_CACHE:-ncaq}
+
+if [ ! -f "$secrets_file" ]; then
+  echo "Error: secrets file not found: $secrets_file" >&2
+  echo "Set CACHIX_PUSH_NCAQ_SECRETS_FILE to override." >&2
+  exit 1
+fi
+
+# トークン取得時のみ環境に露出させ、cachixのサブプロセスに継承させます。
+CACHIX_AUTH_TOKEN=$(sops decrypt --extract '["CACHIX_AUTH_TOKEN"]' "$secrets_file")
+export CACHIX_AUTH_TOKEN
+
+if [ "$#" -gt 0 ]; then
+  exec cachix push "$cache_name" "$@"
+else
+  exec cachix push "$cache_name"
+fi

--- a/pkgs/cachix-push-ncaq/cachix-push-ncaq.bash
+++ b/pkgs/cachix-push-ncaq/cachix-push-ncaq.bash
@@ -28,8 +28,4 @@ fi
 CACHIX_AUTH_TOKEN=$(sops decrypt --extract '["CACHIX_AUTH_TOKEN"]' "$secrets_file")
 export CACHIX_AUTH_TOKEN
 
-if [ "$#" -gt 0 ]; then
-  exec cachix push "$cache_name" "$@"
-else
-  exec cachix push "$cache_name"
-fi
+exec cachix push "$cache_name" "$@"

--- a/pkgs/cachix-push-ncaq/default.nix
+++ b/pkgs/cachix-push-ncaq/default.nix
@@ -1,0 +1,31 @@
+# `secrets/cachix.yaml`から認証トークンを復号して、
+# `cachix push ncaq`を実行するラッパー。
+{
+  lib,
+  runCommand,
+  makeWrapper,
+  shellcheck,
+  cachix,
+  coreutils,
+  sops,
+}:
+runCommand "cachix-push-ncaq"
+  {
+    nativeBuildInputs = [
+      makeWrapper
+      shellcheck
+    ];
+    meta.mainProgram = "cachix-push-ncaq";
+  }
+  ''
+    shellcheck ${./cachix-push-ncaq.bash}
+    install -Dm755 ${./cachix-push-ncaq.bash} $out/libexec/cachix-push-ncaq/cachix-push-ncaq.bash
+    makeWrapper $out/libexec/cachix-push-ncaq/cachix-push-ncaq.bash $out/bin/cachix-push-ncaq \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          cachix
+          coreutils
+          sops
+        ]
+      }
+  ''

--- a/pkgs/cachix-push-ncaq/default.nix
+++ b/pkgs/cachix-push-ncaq/default.nix
@@ -6,7 +6,6 @@
   makeWrapper,
   shellcheck,
   cachix,
-  coreutils,
   sops,
 }:
 runCommand "cachix-push-ncaq"
@@ -24,7 +23,6 @@ runCommand "cachix-push-ncaq"
       --prefix PATH : ${
         lib.makeBinPath [
           cachix
-          coreutils
           sops
         ]
       }


### PR DESCRIPTION
自宅サーバのniks3キャッシュが落ちている時のフォールバックとして、
`secrets/cachix.yaml`の`CACHIX_AUTH_TOKEN`をsopsで復号して、
`cachix push ncaq`に委譲するシェルラッパーを追加します。
別マシンやCIへ手軽にキャッシュを転送する用途を想定しています。

引数を渡せばそのまま`cachix push`に透過するため、
`-j`や`-l`などのオプションも追加で指定可能です。
引数がなければ標準入力からstoreパス一覧を受け取ります。

`home/core/nix.nix`経由でhome-managerが管理するパッケージとして導入し、
全環境でログイン直後から利用可能にしています。
