### PR TITLE
fix: garageの使い捨てキーの有効期限を1年から3ヶ月に短縮

### DIFF
--- a/lib/garage-setup.nix
+++ b/lib/garage-setup.nix
@@ -90,8 +90,8 @@
             exit 1
           fi
 
-          # Calculate expiration date (1 year from now) in RFC 3339 format.
-          EXPIRATION=$(date -u -d '+365 days' '+%Y-%m-%dT%H:%M:%SZ')
+          # Calculate expiration date (3 months from now) in RFC 3339 format.
+          EXPIRATION=$(date -u -d '+90 days' '+%Y-%m-%dT%H:%M:%SZ')
 
           # Create a new ephemeral key via admin API.
           KEY_JSON=$(garage_api POST /v2/CreateKey \


### PR DESCRIPTION
`lib/garage-setup.nix`はサービス起動時に毎回新しいS3キーを作成し、
古いキーは期限切れを待って自然消滅させる運用です。
有効期限が1年だと再起動の度にキーが積み重なり、
admin UIや`ListKeys`の結果が並び過ぎて見通しが悪くなるため、
3ヶ月(90日)に短縮して滞留する期間を縮めます。
