### PR TITLE
feat: forgejoのパブリックリポジトリを使えるようにする

### DIFF
--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -107,7 +107,6 @@ in
               };
               service = {
                 DISABLE_REGISTRATION = true;
-                REQUIRE_SIGNIN_VIEW = true;
               };
               repository = {
                 DEFAULT_BRANCH = "master";


### PR DESCRIPTION
Git LFSを使う上でサインインしないと全く使えない場合、
GitHubなどのパブリックリポジトリでGit LFSが当然使えなくなるため、
サインインしなくても見ることはできるようにします。
プライベートリポジトリはそれぞれの権限で守られますし、
アカウント作成も許可していないので、
権限なしでプライベートな空間にアクセスされることはありません。
