### PR TITLE
feat: forgejoの認証情報をpass-git-helper経由で記憶する

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -46,6 +46,10 @@ in
         push.default = "current";
         rerere.enabled = true;
         github.user = "ncaq";
+        credential."https://forgejo.ncaq.net" = {
+          helper = "!${pkgs.pass-git-helper}/bin/pass-git-helper $@";
+          useHttpPath = false;
+        };
       };
       ignores = [
         "**/.claude/scheduled_tasks.lock"
@@ -59,5 +63,13 @@ in
 
     gh.enable = true;
   };
-  home.packages = with pkgs; [ zizmor ];
+  xdg.configFile."pass-git-helper/git-pass-mapping.ini".text = ''
+    [forgejo.ncaq.net*]
+    target=forgejo.ncaq.net/ncaq
+    username=ncaq
+  '';
+  home.packages = with pkgs; [
+    pass-git-helper
+    zizmor
+  ];
 }

--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -63,13 +63,5 @@ in
 
     gh.enable = true;
   };
-  xdg.configFile."pass-git-helper/git-pass-mapping.ini".text = ''
-    [forgejo.ncaq.net*]
-    target=forgejo.ncaq.net/ncaq
-    username=ncaq
-  '';
-  home.packages = with pkgs; [
-    pass-git-helper
-    zizmor
-  ];
+  home.packages = with pkgs; [ zizmor ];
 }

--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -49,6 +49,7 @@ in
         credential."https://forgejo.ncaq.net" = {
           helper = "!${pkgs.pass-git-helper}/bin/pass-git-helper $@";
           useHttpPath = false;
+          username = "ncaq";
         };
       };
       ignores = [

--- a/home/core/pass.nix
+++ b/home/core/pass.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   lib,
   config,
   ...
@@ -6,6 +7,7 @@
 let
   inherit (config.services.pass-secret-service) storePath;
   storeRel = lib.removePrefix "${config.home.homeDirectory}/" storePath;
+  inherit (config.programs.password-store.settings) PASSWORD_STORE_KEY;
 in
 {
   # GPGによる暗号化を行うpassを使用します。
@@ -26,9 +28,45 @@ in
   };
   services.pass-secret-service.enable = true;
 
-  # `pass init`の代わりに宣言的に`.gpg-id`を配置してストアを初期化します。
-  # `pass-secret-service`が内部で使うプログラムは`PASSWORD_STORE_KEY`を読まず、
-  # 起動時に`.gpg-id`の存在を必須とするため実ファイルの配置が避けられません。
-  home.file."${storeRel}/.gpg-id".text =
-    "${config.programs.password-store.settings.PASSWORD_STORE_KEY}\n";
+  # gitのcredential helperとしてpass-git-helperを使用します。
+  # Forgejoの`https`エンドポイントへのアクセス時に、
+  # passに格納されたトークンを返します。
+  # 実際のhelperの紐付けは`programs.git.settings.credential`で行います。
+  xdg.configFile."pass-git-helper/git-pass-mapping.ini".text = ''
+    [forgejo.ncaq.net*]
+    target=forgejo.ncaq.net/ncaq
+    username=ncaq
+  '';
+
+  # sopsで管理されているForgejoのトークンを長期管理します。
+  sops.secrets."forgejo/token/normal" = {
+    sopsFile = ../../secrets/forgejo.yaml;
+    key = "token/normal";
+    mode = "0400";
+  };
+
+  home = {
+    # `pass init`の代わりに宣言的に`.gpg-id`を配置してストアを初期化します。
+    # `pass-secret-service`が内部で使うプログラムは`PASSWORD_STORE_KEY`を読まず、
+    # 起動時に`.gpg-id`の存在を必須とするため実ファイルの配置が避けられません。
+    file."${storeRel}/.gpg-id".text = "${PASSWORD_STORE_KEY}\n";
+
+    # sopsで復号化したトークンをpassのエントリとして再暗号化して配置します。
+    # 内容が変化した時のみ書き換えて`home-manager switch`の度に差分が出るのを避けます。
+    activation.forgejoTokenToPass = lib.hm.dag.entryAfter [ "sops-nix" ] ''
+      src="${config.sops.secrets."forgejo/token/normal".path}"
+      dst="${storePath}/forgejo.ncaq.net/ncaq.gpg"
+      $DRY_RUN_CMD mkdir -p "$(dirname "$dst")"
+      if [ ! -e "$dst" ] \
+         || ! ${pkgs.gnupg}/bin/gpg --batch --quiet --decrypt "$dst" 2>/dev/null \
+              | ${pkgs.diffutils}/bin/cmp -s - "$src"; then
+        $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpg \
+          --batch --yes --trust-model always \
+          --encrypt --recipient ${PASSWORD_STORE_KEY} \
+          --output "$dst" "$src"
+      fi
+    '';
+
+    packages = [ pkgs.pass-git-helper ];
+  };
 }

--- a/secrets/forgejo.yaml
+++ b/secrets/forgejo.yaml
@@ -1,8 +1,8 @@
 token:
-  - normal: ENC[AES256_GCM,data:itdIIbD1JfJIjnfl8UFkaWNJXNaoDEGP6eAGtz/v/uihBBWV3Ky0Pw==,iv:U7JDfz+HdrPyrrqGfnGIT3o+vvyxX259eLHnBCDSzCY=,tag:7zq7rXnRL1DrKZOlyWobxg==,type:str]
+  normal: ENC[AES256_GCM,data:itdIIbD1JfJIjnfl8UFkaWNJXNaoDEGP6eAGtz/v/uihBBWV3Ky0Pw==,iv:U7JDfz+HdrPyrrqGfnGIT3o+vvyxX259eLHnBCDSzCY=,tag:7zq7rXnRL1DrKZOlyWobxg==,type:str]
 sops:
-  lastmodified: "2026-06-27T09:10:01Z"
-  mac: ENC[AES256_GCM,data:Hcx3rFUDCNDu3fgwRNUyhlF2hoYU+Hq/WiztXu6NwYqVXBfm+Jm0WJLfO8VIo8Oxr5BmT0rfyiTo2XL1GFiEQG3fi5O6+LwiDubUEk5AdwxblKFuEVvs+WKIhVeZjzlsXGULmrJ0ffOrgX2pBVyGoYTZTX899FQ4KyUe7X8Sqg0=,iv:WDxBlc44Q6IZe6yEYihEojFZWLFAylG+VWtm1sXVBAY=,tag:NXzSju7TvaSBTqvZkU6htA==,type:str]
+  lastmodified: "2026-06-27T09:28:43Z"
+  mac: ENC[AES256_GCM,data:JwwiPnslhp2BbIL3CVR+eMY2W+6pVpx1MZqD3+ujLgE5taAzVV78RYxi+B2ZKUHhwME9incK6gfL9fN+IpoKc4mb4h+j9rvehWbMdecC+QQ1Y5ZTCQ+VmFl1OUfQ5EaJlQtMaM/amC3OgJLxr5a4Tr8UMhbmUEL1XzycOXJX8io=,iv:zyNJebch/dnAQAQ+dZrFw0bFTKASVrJBm7fmewNNIhM=,tag:PNgOkRyxB+MaDPuhUKdF+Q==,type:str]
   pgp:
     - created_at: "2026-06-27T09:09:22Z"
       enc: |-

--- a/secrets/forgejo.yaml
+++ b/secrets/forgejo.yaml
@@ -1,0 +1,19 @@
+token:
+  - normal: ENC[AES256_GCM,data:itdIIbD1JfJIjnfl8UFkaWNJXNaoDEGP6eAGtz/v/uihBBWV3Ky0Pw==,iv:U7JDfz+HdrPyrrqGfnGIT3o+vvyxX259eLHnBCDSzCY=,tag:7zq7rXnRL1DrKZOlyWobxg==,type:str]
+sops:
+  lastmodified: "2026-06-27T09:10:01Z"
+  mac: ENC[AES256_GCM,data:Hcx3rFUDCNDu3fgwRNUyhlF2hoYU+Hq/WiztXu6NwYqVXBfm+Jm0WJLfO8VIo8Oxr5BmT0rfyiTo2XL1GFiEQG3fi5O6+LwiDubUEk5AdwxblKFuEVvs+WKIhVeZjzlsXGULmrJ0ffOrgX2pBVyGoYTZTX899FQ4KyUe7X8Sqg0=,iv:WDxBlc44Q6IZe6yEYihEojFZWLFAylG+VWtm1sXVBAY=,tag:NXzSju7TvaSBTqvZkU6htA==,type:str]
+  pgp:
+    - created_at: "2026-06-27T09:09:22Z"
+      enc: |-
+        -----BEGIN PGP MESSAGE-----
+
+        hF4Dxlt1nl1bPpUSAQdAaAAOMdqH5EP8yLBSIujsB1h88uq/T6uaTN4mMxQ7dXww
+        v1essRwlkmCViXYzGH3C1RLbWMEnLCWPLR+v2c6lGoQcdcX3jMQ4uue17TJceFns
+        0l4BN5zFWbnsPAo6Hf3RZOmVA/AOlI8v5WTKRO2LnlOpX3mjyTjm02pPQUPig9GW
+        WknsoSrhu9Kmh+Fy3qkwI6j4QQsj25s2flpg+IK30hzesQg474R6iadxDRpvigIy
+        =745l
+        -----END PGP MESSAGE-----
+      fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
+  unencrypted_suffix: _unencrypted
+  version: 3.13.1

--- a/secrets/forgejo.yaml
+++ b/secrets/forgejo.yaml
@@ -1,18 +1,18 @@
 token:
-  normal: ENC[AES256_GCM,data:itdIIbD1JfJIjnfl8UFkaWNJXNaoDEGP6eAGtz/v/uihBBWV3Ky0Pw==,iv:U7JDfz+HdrPyrrqGfnGIT3o+vvyxX259eLHnBCDSzCY=,tag:7zq7rXnRL1DrKZOlyWobxg==,type:str]
+  normal: ENC[AES256_GCM,data:fEeLXCPCyHw8PjaBT9SSeHc7mjk0YPHiiqOZHv51qcaStlwy2naGMw==,iv:3SmZ3dy+Ts1l/DBHS5WNVRlHoKwFLVptZnlqM43QfGY=,tag:smixRYYhgl5jTcCIPW1GxQ==,type:str]
 sops:
-  lastmodified: "2026-06-27T09:28:43Z"
-  mac: ENC[AES256_GCM,data:JwwiPnslhp2BbIL3CVR+eMY2W+6pVpx1MZqD3+ujLgE5taAzVV78RYxi+B2ZKUHhwME9incK6gfL9fN+IpoKc4mb4h+j9rvehWbMdecC+QQ1Y5ZTCQ+VmFl1OUfQ5EaJlQtMaM/amC3OgJLxr5a4Tr8UMhbmUEL1XzycOXJX8io=,iv:zyNJebch/dnAQAQ+dZrFw0bFTKASVrJBm7fmewNNIhM=,tag:PNgOkRyxB+MaDPuhUKdF+Q==,type:str]
+  lastmodified: "2026-06-27T09:36:39Z"
+  mac: ENC[AES256_GCM,data:U2yL4rz2R8x1zGxin9HcRmpTPml9/6mYgku/eM7WN8yHb+sPmJoV5kZyfgBqXLN/Xm+lZvGCKr3rWKcu1TwJeiyWFL6ZZ+apTVQAfpxfIfhvW3Kempnv3+RY9ZeKfO0bOFl14digH0Dy7mpXWgBIJ8oai6sSLJcls22nbV/IkXM=,iv:qEojYfsjBBIbel6tZNfZbGSoXtHhggORgi4eVrlq5cw=,tag:k0hUeZc9QpL4M0C8704fvw==,type:str]
   pgp:
-    - created_at: "2026-06-27T09:09:22Z"
+    - created_at: "2026-06-27T09:36:39Z"
       enc: |-
         -----BEGIN PGP MESSAGE-----
 
-        hF4Dxlt1nl1bPpUSAQdAaAAOMdqH5EP8yLBSIujsB1h88uq/T6uaTN4mMxQ7dXww
-        v1essRwlkmCViXYzGH3C1RLbWMEnLCWPLR+v2c6lGoQcdcX3jMQ4uue17TJceFns
-        0l4BN5zFWbnsPAo6Hf3RZOmVA/AOlI8v5WTKRO2LnlOpX3mjyTjm02pPQUPig9GW
-        WknsoSrhu9Kmh+Fy3qkwI6j4QQsj25s2flpg+IK30hzesQg474R6iadxDRpvigIy
-        =745l
+        hF4Dxlt1nl1bPpUSAQdAIqJ57h/GeJy+H2efDxNPZ4b/XOfTuLWkPgmJlismGXAw
+        LbptdFOqiB3XwVkQk6/HCQ8v8qlUOe2v5GAqeq0g05pnQVEmyywPoyfGPjcagEdf
+        0lwBwwzvA4oFRIrmwUSt0c9pp/usISVEkC0YjS9U4PHe6D2y+M8+4xXpBNyhaN21
+        eX8Wn5LWdoPICZ5vDbz0UiATcygS6b0D5rlUcfmqnL6dtxyVOvPoDllEE/972Q==
+        =Czd6
         -----END PGP MESSAGE-----
       fp: 7DDE3BC405DC58D94BF661D342248C7D0FB73D57
   unencrypted_suffix: _unencrypted


### PR DESCRIPTION
Forgejoに対する`git push`などのHTTPS操作でユーザ名とトークンを毎回聞かれずに済むよう、
`pass-git-helper`をcredential helperとして組み込みます。

トークン自体はsopsで暗号化したものを正本として`secrets/forgejo.yaml`に長期保存し、
home-managerのactivationで内容に変化があった時だけpassのエントリへ再暗号化して配置します。
これによりトークンの管理はsopsとgitで完結しつつ、
日常の認証はGUIや`libsecret`連携の豊富なpassエコシステムに乗せられます。

`git`側ではForgejoのエンドポイントに対して`useHttpPath = false`と`username = ncaq`を指定し、
ホスト単位でhelperを引かせます。
helperの問い合わせマッピングは`pass-git-helper`の設定ファイルで定義します。
