### PR TITLE
feat: native-linux向けにrootless Docker環境を構築する

### DIFF
--- a/home/core/docker.nix
+++ b/home/core/docker.nix
@@ -1,8 +1,15 @@
 { pkgs, ... }:
 {
+  # Dockerクライアント設定(~/.docker/config.jsonとDOCKER_CONFIG)を
+  # home-managerで宣言的に管理する。
+  # このモジュールはパッケージを入れないのでdocker-clientは別途入れる。
+  # config.jsonがNixストアへの読み取り専用リンクになるため、
+  # docker loginが必要になったらsettings.credsStoreでcredential helperを宣言する。
+  programs.docker-cli.enable = true;
+
   home.packages = with pkgs; [
     act
-    docker-client
+    docker-client # clientOnlyなdockerパッケージ。buildx(BuildKit)とcomposeプラグイン同梱。
     docker-compose-language-service
     dockerfile-language-server
     hadolint

--- a/nixos/native-linux/docker.nix
+++ b/nixos/native-linux/docker.nix
@@ -1,0 +1,15 @@
+{ username, ... }:
+{
+  # rootless Dockerを使う。
+  # 常時rootで動くデーモンを避けるため。
+  # podmanではなくDockerなのはBuildKitがそのまま動いてほしいから。
+  # nixpkgsのdockerパッケージはbuildx(BuildKit)とcomposeプラグインを同梱している。
+  virtualisation.docker.rootless = {
+    enable = true;
+    # DOCKER_HOSTをrootlessソケット(unix://$XDG_RUNTIME_DIR/docker.sock)に向ける。
+    setSocketVariable = true;
+  };
+
+  # rootlessコンテナ内のuid/gidマッピングに必要なsubuid/subgidを自動割り当てする。
+  users.users.${username}.autoSubUidGidRange = true;
+}


### PR DESCRIPTION
`nixos/native-linux/docker.nix`を追加してrootless Dockerを有効にします。
常時rootで動くデーモンを避けたいのでrootlessにします。
podmanではなくDockerを選ぶのはBuildKitがそのまま動いてほしいためで、
nixpkgsのdockerパッケージはbuildx(BuildKit)とcomposeプラグインを同梱しています。
rootlessに必須のsubuid/subgidは`autoSubUidGidRange`で自動割り当てします。
恒久的にコンテナを動かす予定はまだありませんが、
`linger`が既に有効なので将来の常駐化にも対応できます。

home-manager側は`programs.docker-cli`モジュールを有効にして、
クライアント設定(`config.json`と`DOCKER_CONFIG`)を宣言的に管理するようにします。
`config.json`がNixストアへの読み取り専用リンクになるため、
`docker login`が必要になったら`settings.credsStore`でcredential helperを宣言する方針です。