### PR TITLE
refactor: xserverとディスプレイマネージャとIceWMの設定を分離

### DIFF
--- a/nixos/native-linux/display-manager.nix
+++ b/nixos/native-linux/display-manager.nix
@@ -1,0 +1,34 @@
+{ username, ... }:
+let
+  home-manager-session-name = "hm-xsession";
+in
+{
+  services = {
+    xserver = {
+      displayManager = {
+        lightdm.enable = true;
+        session = [
+          {
+            manage = "desktop";
+            name = home-manager-session-name;
+            description = ''
+              home-manager側で設定した`.xsession`を起動する。
+              デフォルトで起動するセッション。
+            '';
+            start = ''
+              exec $HOME/.xsession
+            '';
+          }
+        ];
+      };
+    };
+    displayManager = {
+      enable = true;
+      defaultSession = home-manager-session-name;
+      autoLogin = {
+        enable = true;
+        user = username;
+      };
+    };
+  };
+}

--- a/nixos/native-linux/xserver-recovery.nix
+++ b/nixos/native-linux/xserver-recovery.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  services = {
+    xserver = {
+      # 何かあったときの復旧用のミニマルなウィンドウマネージャを有効にしておきます。
+      windowManager.icewm.enable = true;
+    };
+  };
+  # 復旧に必要な最低限のパッケージをインストールしておきます。
+  environment.systemPackages = with pkgs; [
+    rxvt-unicode
+    xterm
+  ];
+}

--- a/nixos/native-linux/xserver.nix
+++ b/nixos/native-linux/xserver.nix
@@ -1,41 +1,13 @@
-# 基本的にビルドした自分のxmonad-launchを使うが、トラブル時の復旧セッションも用意する。
-{ pkgs, username, ... }:
-{
+_: {
   services = {
     xserver = {
       enable = true;
-      displayManager = {
-        lightdm.enable = true;
-        session = [
-          {
-            manage = "desktop";
-            name = "hm-xsession";
-            description = "home-manager側で設定した `.xsession` を起動する。";
-            start = ''
-              exec $HOME/.xsession
-            '';
-          }
-        ];
-      };
-      windowManager.icewm.enable = true;
       xkb = {
         layout = "us";
         model = "pc104";
         variant = "dvorak";
       };
     };
-    displayManager = {
-      enable = true;
-      defaultSession = "hm-xsession";
-      autoLogin = {
-        enable = true;
-        user = username;
-      };
-    };
     libinput.enable = true;
   };
-  environment.systemPackages = with pkgs; [
-    rxvt-unicode
-    xterm
-  ];
 }


### PR DESCRIPTION
新しいウィンドウマネージャを追加したくなったときなどにスッキリとさせたいため。
