### PR TITLE
fix: boot時のForgejoトークン同期をsystemdユーザサービスに移行

### DIFF
--- a/home/core/pass.nix
+++ b/home/core/pass.nix
@@ -8,6 +8,29 @@ let
   inherit (config.services.pass-secret-service) storePath;
   storeRel = lib.removePrefix "${config.home.homeDirectory}/" storePath;
   inherit (config.programs.password-store.settings) PASSWORD_STORE_KEY;
+
+  # sopsで復号化したトークンをpassのエントリとして再暗号化して配置します。
+  # 内容が変化した時のみ書き換えて実行の度に差分が出るのを避けます。
+  syncForgejoTokenToPass = pkgs.writeShellApplication {
+    name = "sync-forgejo-token-to-pass";
+    runtimeInputs = with pkgs; [
+      coreutils
+      diffutils
+      gnupg
+    ];
+    text = ''
+      src="${config.sops.secrets."forgejo/token/normal".path}"
+      dst="${storePath}/forgejo.ncaq.net/ncaq.gpg"
+      mkdir -p "$(dirname "$dst")"
+      if [ ! -e "$dst" ] || ! gpg --batch --quiet --decrypt "$dst" \
+         | cmp -s - "$src"; then
+        gpg \
+          --batch --yes --trust-model always \
+          --encrypt --recipient ${PASSWORD_STORE_KEY} \
+          --output "$dst" "$src"
+      fi
+    '';
+  };
 in
 {
   # GPGによる暗号化を行うpassを使用します。
@@ -45,27 +68,30 @@ in
     mode = "0400";
   };
 
+  # boot時にsops-nixのシークレット展開が完了してからトークンを同期します。
+  # boot時のactivationはシステムサービス経由で実行されるため、
+  # ユーザのsystemdデーモンと同期できず、
+  # activationスクリプトではシークレットの存在を保証できません。
+  systemd.user.services.forgejo-token-to-pass = {
+    Unit = {
+      Description = "Sync Forgejo token from sops-nix secrets into pass";
+      After = [ "sops-nix.service" ];
+      Wants = [ "sops-nix.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = lib.getExe syncForgejoTokenToPass;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   home = {
     # `pass init`の代わりに宣言的に`.gpg-id`を配置してストアを初期化します。
     # `pass-secret-service`が内部で使うプログラムは`PASSWORD_STORE_KEY`を読まず、
     # 起動時に`.gpg-id`の存在を必須とするため実ファイルの配置が避けられません。
     file."${storeRel}/.gpg-id".text = "${PASSWORD_STORE_KEY}\n";
-
-    # sopsで復号化したトークンをpassのエントリとして再暗号化して配置します。
-    # 内容が変化した時のみ書き換えて`home-manager switch`の度に差分が出るのを避けます。
-    activation.forgejoTokenToPass = lib.hm.dag.entryAfter [ "sops-nix" ] ''
-      src="${config.sops.secrets."forgejo/token/normal".path}"
-      dst="${storePath}/forgejo.ncaq.net/ncaq.gpg"
-      $DRY_RUN_CMD mkdir -p "$(dirname "$dst")"
-      if [ ! -e "$dst" ] \
-         || ! ${pkgs.gnupg}/bin/gpg --batch --quiet --decrypt "$dst" 2>/dev/null \
-              | ${pkgs.diffutils}/bin/cmp -s - "$src"; then
-        $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpg \
-          --batch --yes --trust-model always \
-          --encrypt --recipient ${PASSWORD_STORE_KEY} \
-          --output "$dst" "$src"
-      fi
-    '';
 
     packages = [ pkgs.pass-git-helper ];
   };


### PR DESCRIPTION
boot時に以下のエラーが発生していました。

```
gpg: '/home/ncaq/.config/sops-nix/secrets/forgejo/token/normal'が開けません:
そのようなファイルやディレクトリはありません
```

boot時のhome-manager activationは`home-manager-<username>.service`という、
システムサービス経由で実行されるため、
ユーザのsystemdデーモンと通信できません。
そのためsops-nixのactivationは`sops-nix.service`の再起動をスキップしますが、
直後の`forgejoTokenToPass`は無条件にシークレットを読んでいたため、
ユーザセッション側でシークレットが展開される前にgpgが失敗する競合状態がありました。

sops-nix自身と同じ構造に合わせて、
同期処理をactivationスクリプトからsystemdユーザサービスに移行します。
`forgejo-token-to-pass.service`は`After=sops-nix.service`により、
シークレットの展開完了後に実行されることが保証されます。

同期スクリプトは`writeShellApplication`に切り出して、
`runtimeInputs`で依存コマンドを解決するようにします。
