### PR TITLE
feat: bulletのブートローダーをGRUBからLimineに切り替える

### DIFF
--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -18,6 +18,7 @@ let
       hostName
       ;
     username = "ncaq";
+    pkgs-unstable = importPkgsUnstable system;
   };
   modules = [
     # 共有のpkgsインスタンスをNixOSに渡し、
@@ -38,7 +39,6 @@ let
           useGlobalPkgs = true;
           useUserPackages = true;
           extraSpecialArgs = specialArgs // {
-            pkgs-unstable = importPkgsUnstable system;
             isTermux = false;
             isWSL = config.wsl.enable or false;
           };

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -6,31 +6,34 @@
         efiSysMountPoint = "/efi";
       };
       timeout = 1;
-      grub = {
+      limine = {
         enable = true;
-        device = "nodev";
-        efiSupport = true;
-        gfxmodeEfi = "1024x768";
-        default = "saved";
+        # ディスク容量を埋め尽くさないように上限を定めます。
+        maxGenerations = 50;
+        style = {
+          interface = {
+            # ブート時はGPUを効率的に使えないことが多いため解像度を下げて負荷を減らします。
+            resolution = "1920x1080";
+          };
+        };
+        # Nixが直接対応していない設定を直接書き込みます。
+        extraConfig = ''
+          # 最後に起動したエントリを記憶して次回起動時に自動選択します。
+          remember_last_entry: yes
+          # ブートローダーでも慣れたdvorak入力を使ってトラブルシューティングを楽にします。
+          keyboard_layout: dvorak
+        '';
+        # 他のSSDに入っているWindowsのブートマネージャにチェインロードします。
+        # vfatのボリュームシリアルはGUID形式ではないため、
+        # GPTパーティションGUID(PARTUUID)で指定します。
         extraEntries = ''
-          menuentry "Windows Game" {
-            savedefault
-            insmod part_gpt
-            insmod fat
-            insmod search_fs_uuid
-            insmod chain
-            search --fs-uuid --set=root 8E7A-6494
-            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
-          }
-          menuentry "Windows Work" {
-            savedefault
-            insmod part_gpt
-            insmod fat
-            insmod search_fs_uuid
-            insmod chain
-            search --fs-uuid --set=root CE5B-C127
-            chainloader /EFI/Microsoft/Boot/bootmgfw.efi
-          }
+          /Windows Game
+              protocol: efi_chainload
+              path: guid(4df43761-322e-44ef-9219-3b923e95d5b6):/EFI/Microsoft/Boot/bootmgfw.efi
+
+          /Windows Work
+              protocol: efi_chainload
+              path: guid(386d2f0a-f36e-4678-93d1-84c7df8665a0):/EFI/Microsoft/Boot/bootmgfw.efi
         '';
       };
     };

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -1,3 +1,4 @@
+{ lib, pkgs, ... }:
 {
   boot = {
     loader = {
@@ -43,4 +44,43 @@
       };
     };
   };
+
+  # Limineの`remember_last_entry`はエントリのパス名をEFI変数`LimineLastBootedEntry`に保存します。
+  # 例: `NixOS default profile/Generation 769`
+  # NixOSの世代エントリは名前に世代番号を含むため、
+  # 記憶されたままだとrebuild後も古い世代が延々と選択され続けてしまいます。
+  # そこでNixOS起動時に記憶を消して、
+  # 次回起動は`default_entry`(常に最新世代)に戻します。
+  # Windowsのエントリ名は不変なので、
+  # Windows起動時の記憶はそのまま機能します。
+  # Windows Updateの複数回再起動でもWindowsが選択され続けます。
+  systemd.services.limine-forget-last-entry =
+    let
+      bulletLimineLastBootedEntryPath = "/sys/firmware/efi/efivars/LimineLastBootedEntry-513ee0d0-6e43-cb05-b272-f146a2fcb88a";
+    in
+    {
+      description = "Forget Limine last booted entry so the newest NixOS generation boots next";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        ConditionPathExists = bulletLimineLastBootedEntryPath;
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe (
+          pkgs.writeShellApplication {
+            name = "limine-forget-last-entry";
+            runtimeInputs = with pkgs; [
+              coreutils
+              e2fsprogs
+            ];
+            text = ''
+              var=${bulletLimineLastBootedEntryPath}
+              # efivarfsは変数をimmutable属性付きで公開するため、削除前に解除します。
+              chattr -i "$var"
+              rm "$var"
+            '';
+          }
+        );
+      };
+    };
 }

--- a/nixos/host/bullet/disk.nix
+++ b/nixos/host/bullet/disk.nix
@@ -8,26 +8,12 @@
           type = "gpt";
           partitions = {
             ESP = {
-              size = "1G";
+              size = "2G";
               type = "EF00";
               content = {
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/efi";
-                mountOptions = [
-                  "noatime"
-                  "fmask=0077"
-                  "dmask=0077"
-                ];
-              };
-            };
-            nixos-boot = {
-              size = "1G";
-              type = "EA00";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot";
                 mountOptions = [
                   "noatime"
                   "fmask=0077"


### PR DESCRIPTION
bulletのブートローダーをGRUBからLimineに移行します。
NixOSモジュールのサポートが充実しており、
デュアルブート周りの構成をシンプルにできるためです。
セキュアブート対応は今回は扱わず、後回しにします。

移行にあたって以下を行います。

- GRUBの`savedefault`に相当する最終起動エントリの記憶は、
  Limineの`remember_last_entry`を`extraConfig`で有効にして実現します。
- Windowsブートマネージャへのチェインロードは、
  `efi_chainload`プロトコルの`extraEntries`として移植します。
  ESPの指定はvfatのボリュームシリアルからGPTパーティションGUID(PARTUUID)に変更します。
- LimineはEFIブートではカーネルとinitrdも含めて全てESP以下に設置するため、
  GRUB時代のXBOOTLDRパーティション(1GiB)が遊休になります。
  これを削除して隣接するESPに統合し、2GiBのESP一本の構成にします。
  実機ではパーティションを切り直して再設置済みです。
- Limineの`remember_last_entry`は世代番号を含むエントリ名をEFI変数に保存するため、
  一度記憶された古い世代がrebuild後も延々とデフォルト選択され続ける問題があります。
  NixOS起動時にこのEFI変数を削除するoneshotサービスを追加して回避します。
  Windows側のエントリ名は不変なので、
  Windows Updateの複数回再起動でもWindowsが選択され続ける挙動は維持されます。

close #1214