### PR TITLE
feat: bulletのLimineでセキュアブートを有効にする

### DIFF
--- a/home/core/misc.nix
+++ b/home/core/misc.nix
@@ -3,6 +3,7 @@
   home.packages = with pkgs; [
     openssl
     renovate
+    sbctl
     sqlite
     strace
     trash-cli

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -17,6 +17,15 @@
             resolution = "1920x1080";
           };
         };
+        # セキュアブート設定。
+        secureBoot = {
+          # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
+          enable = true;
+        };
+        # チェックサム不一致を起動時の致命的エラーにします。
+        # enrollConfigのデフォルトはこの値に追従するため、
+        # limine.conf自体のハッシュ検証も同時に有効になります。
+        panicOnChecksumMismatch = true;
         # Nixが直接対応していない設定を直接書き込みます。
         extraConfig = ''
           # 最後に起動したエントリを記憶して次回起動時に自動選択します。


### PR DESCRIPTION
Limine移行(#1319)で後回しにしていたbulletのセキュアブート対応を行います。

NixOSのLimineモジュールの`secureBoot.enable`を有効にして、
`/var/lib/sbctl`の鍵でLimineバイナリをsbctl署名するようにします。
鍵の作成やUEFIへのenrollを手元で操作できるように、
sbctlパッケージもインストールします。

あわせて`panicOnChecksumMismatch`を有効にして、
チェックサム不一致を起動時の致命的エラーとして扱います。
`enrollConfig`のデフォルトはこの値に追従するため、
`limine.conf`自体のハッシュ検証も同時に有効になります。

close #1320