### PR TITLE
fix: NixOSのブート世代数を40に変更

### DIFF
--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -10,7 +10,7 @@
       limine = {
         enable = true;
         # ディスク容量を埋め尽くさないように上限を定めます。
-        maxGenerations = 50;
+        maxGenerations = 40;
         style = {
           interface = {
             # ブート時はGPUを効率的に使えないことが多いため解像度を下げて負荷を減らします。

--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -10,7 +10,7 @@
         enable = true;
         consoleMode = "auto";
         xbootldrMountPoint = "/boot";
-        configurationLimit = 50;
+        configurationLimit = 40;
       };
     };
     initrd = {

--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -10,7 +10,7 @@
         enable = true;
         consoleMode = "auto";
         xbootldrMountPoint = "/boot";
-        configurationLimit = 50;
+        configurationLimit = 40;
       };
     };
     initrd = {


### PR DESCRIPTION
50は多すぎて、
容量を埋め尽くさなくても画面を圧迫しすぎるので、
40に変更しました。
40でも基本的にそこまで要らないので問題ないと思います。
