### PR TITLE
feat: bulletのLimineセキュアブート設定を自動化と整理

### DIFF
--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -24,9 +24,10 @@
           # 自動での鍵作成と署名を有効化して、
           # 確認は手動で`sudo bootctl`や`sudo sbctl status`で行います。
           autoGenerateKeys = true;
-          # デフォルトでMicrosoftやファームウェアの鍵は含まれるため設定は基本的に不要です。
           autoEnrollKeys = {
             enable = true;
+            # デフォルトでMicrosoftやファームウェアの鍵が含まれるため、
+            # `extraArgs`の設定は基本的に不要です。
           };
         };
         # Nixが直接対応していない設定を直接書き込みます。

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -68,13 +68,13 @@
   # Windows Updateの複数回再起動でもWindowsが選択され続けます。
   systemd.services.limine-forget-last-entry =
     let
-      bulletLimineLastBootedEntryPath = "/sys/firmware/efi/efivars/LimineLastBootedEntry-513ee0d0-6e43-cb05-b272-f146a2fcb88a";
+      limineLastBootedEntryPath = "/sys/firmware/efi/efivars/LimineLastBootedEntry-513ee0d0-6e43-cb05-b272-f146a2fcb88a";
     in
     {
       description = "Forget Limine last booted entry so the newest NixOS generation boots next";
       wantedBy = [ "multi-user.target" ];
       unitConfig = {
-        ConditionPathExists = bulletLimineLastBootedEntryPath;
+        ConditionPathExists = limineLastBootedEntryPath;
       };
       serviceConfig = {
         Type = "oneshot";
@@ -86,7 +86,7 @@
               e2fsprogs
             ];
             text = ''
-              var=${bulletLimineLastBootedEntryPath}
+              var=${limineLastBootedEntryPath}
               # efivarfsは変数をimmutable属性付きで公開するため、削除前に解除します。
               chattr -i "$var"
               rm "$var"

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -22,10 +22,6 @@
           # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
           enable = true;
         };
-        # チェックサム不一致を起動時の致命的エラーにします。
-        # enrollConfigのデフォルトはこの値に追従するため、
-        # limine.conf自体のハッシュ検証も同時に有効になります。
-        panicOnChecksumMismatch = true;
         # Nixが直接対応していない設定を直接書き込みます。
         extraConfig = ''
           # 最後に起動したエントリを記憶して次回起動時に自動選択します。

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -22,7 +22,7 @@
           # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
           enable = true;
           # 自動での鍵作成と署名を有効化して、
-          # 確認は手動で`sudo bootctl`で行います。
+          # 確認は手動で`sudo bootctl`や`sudo sbctl status`で行います。
           autoGenerateKeys = true;
           # デフォルトでMicrosoftやファームウェアの鍵は含まれるため設定は基本的に不要です。
           autoEnrollKeys = {

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -21,6 +21,13 @@
         secureBoot = {
           # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
           enable = true;
+          # 自動での鍵作成と署名を有効化して、
+          # 確認は手動で`sudo bootctl`で行います。
+          autoGenerateKeys = true;
+          # デフォルトでMicrosoftやファームウェアの鍵は含まれるため設定は基本的に不要です。
+          autoEnrollKeys = {
+            enable = true;
+          };
         };
         # Nixが直接対応していない設定を直接書き込みます。
         extraConfig = ''


### PR DESCRIPTION
Limine移行(#1319)とセキュアブート有効化(#1323)の続きとして、
bulletのLimine関連設定を整理します。

- `autoGenerateKeys`と`autoEnrollKeys`を有効化して、
  sbctl鍵の作成とUEFIへのenrollを宣言的に自動で行うようにします。
  適用結果の確認は手動で`sudo bootctl`で行います。
  enrollにはデフォルトでMicrosoftやファームウェアの鍵も含まれるため、
  追加の設定は基本的に不要です。
- `panicOnChecksumMismatch`の明示的な指定を削除します。
  セキュアブート有効時にはモジュールによって自動的に有効にされるため冗長でした。
- `LimineLastBootedEntry`のEFI変数名に含まれるUUIDは、
  Limine側の識別子でありホスト固有の値ではないため、
  ローカル変数名からホスト依存の`bullet`プレフィックスを外します。
