### PR TITLE
fix: アプリケーション固有のキーマップを汎用ルールより前に配置

### DIFF
--- a/nixos/native-linux/xremap.nix
+++ b/nixos/native-linux/xremap.nix
@@ -112,7 +112,69 @@ in
             };
           }
         ];
+        # xremapは同じキーが複数のkeymapにマッチする場合、
+        # 先に書かれたkeymapのremapを採用する。
+        # そのためアプリケーション固有の特別ルールは、
+        # 汎用ルールよりも前に書く必要がある。
         keymap = [
+          (keymapEntry {
+            name = "新規チャットのショートカット";
+            application = "/claude/";
+            remap = {
+              "C-o" = "C-k";
+            };
+          })
+          (keymapEntry {
+            name = "チャンネルの切り替え";
+            application = "/Slack|discord/";
+            # チャンネルスイッチのキーバインドを使いやすくします。
+            remap = {
+              # 下に移動。
+              "M-j" = "M-Shift-down";
+              # 上に移動。
+              "M-k" = "M-Shift-up";
+              # 下の未読に移動。
+              "M-n" = "M-down";
+              # 上の未読に移動。
+              "M-t" = "M-up";
+            };
+          })
+          (keymapEntry {
+            name = "改行と投稿を統一する";
+            application = "/Slack/";
+            remap = {
+              "C-m" = [
+                "enter"
+                { set_mark = false; }
+              ];
+              "enter" = [
+                "C-enter"
+                { set_mark = false; }
+              ];
+            };
+          })
+          (keymapEntry {
+            name = "改行と投稿を統一する";
+            application = "/LM Studio|claude|discord/";
+            remap = {
+              "C-m" = [
+                "Shift-enter"
+                { set_mark = false; }
+              ];
+              "enter" = [
+                "enter"
+                { set_mark = false; }
+              ];
+            };
+          })
+          (keymapEntry {
+            name = "`C-,`, `C-.`のショートカットを無効化する";
+            application = "/LM Studio|Slack|claude|discord/";
+            remap = {
+              "C-comma" = "muhenkan";
+              "C-dot" = "henkan";
+            };
+          })
           (keymapEntry {
             name = "Web textarea like Application";
             application =
@@ -235,64 +297,6 @@ in
               "C-Shift-space" = {
                 set_mark = true;
               };
-            };
-          })
-          (keymapEntry {
-            name = "`C-,`, `C-.`のショートカットを無効化する";
-            application = "/LM Studio|Slack|claude|discord/";
-            remap = {
-              "C-comma" = "muhenkan";
-              "C-dot" = "henkan";
-            };
-          })
-          (keymapEntry {
-            name = "改行と投稿を統一する";
-            application = "/LM Studio|claude|discord/";
-            remap = {
-              "C-m" = [
-                "Shift-enter"
-                { set_mark = false; }
-              ];
-              "enter" = [
-                "enter"
-                { set_mark = false; }
-              ];
-            };
-          })
-          (keymapEntry {
-            name = "改行と投稿を統一する";
-            application = "/Slack/";
-            remap = {
-              "C-m" = [
-                "enter"
-                { set_mark = false; }
-              ];
-              "enter" = [
-                "C-enter"
-                { set_mark = false; }
-              ];
-            };
-          })
-          (keymapEntry {
-            name = "チャンネルの切り替え";
-            application = "/Slack|discord/";
-            # チャンネルスイッチのキーバインドを使いやすくします。
-            remap = {
-              # 下に移動。
-              "M-j" = "M-Shift-down";
-              # 上に移動。
-              "M-k" = "M-Shift-up";
-              # 下の未読に移動。
-              "M-n" = "M-down";
-              # 上の未読に移動。
-              "M-t" = "M-up";
-            };
-          })
-          (keymapEntry {
-            name = "新規チャットのショートカット";
-            application = "/claude/";
-            remap = {
-              "C-o" = "C-k";
             };
           })
         ];


### PR DESCRIPTION
xremapは同じキーが複数のkeymapにマッチする場合、
先に書かれたkeymapのremapを採用します。

これまでは汎用の「Web textarea like Application」が先頭にあり、
対象アプリにclaudeやSlackも含まれていたため、
そこで定義されている`C-m` = `enter`が優先されてしまい、
後ろに書かれた「改行と投稿を統一する」の`C-m` = `Shift-enter`や、
「新規チャットのショートカット」の`C-o` = `C-k`に到達していませんでした。

アプリケーション固有の特別ルールを汎用ルールより前に並び替えて、
特別ルールが優先されるようにします。
順序が意味を持つことをコメントとして残しています。

https://claude.ai/code/session_01FVZQJ6f1c1ZNvnpBGXhR9v