### PR TITLE
feat: creepをセキュアブート対応にする

### DIFF
--- a/docs/install/nixos-manual.md
+++ b/docs/install/nixos-manual.md
@@ -32,7 +32,7 @@ sudo fdisk /dev/disk/by-id/your-disk
 ```
 
 Create a new partition for the EFI Partition.
-EFI Partition type is `EFI System` (`C12A7328-F81F-11D2-BA4B-00A0C93EC93B`)
+EFI Partition type is `EFI System` (`C12A7328-F81F-11D2-BA4B-00A0C93EC93B`).
 
 ```text
 n

--- a/docs/install/nixos-manual.md
+++ b/docs/install/nixos-manual.md
@@ -22,9 +22,8 @@ suitable for dual-boot setups where Windows is already installed.
 
 ## Disk Partitioning
 
-Create XBOOTLDR partition for `/boot` (1GB) and root partition.
-Following Boot Loader Specification,
-ESP will be mounted at `/efi` and XBOOTLDR at `/boot`.
+Create EFI partition for `/efi` (1GB) and root partition.
+ESP will be mounted at `/efi`.
 
 Use `lsblk` or `ls /dev/disk/by-id/` to identify your target disk.
 
@@ -32,14 +31,14 @@ Use `lsblk` or `ls /dev/disk/by-id/` to identify your target disk.
 sudo fdisk /dev/disk/by-id/your-disk
 ```
 
-Create a new partition for the boot loader (XBOOTLDR).
-XBOOTLDR type is `Linux extended boot` (`BC13C2FF-59E6-4262-A352-B275FD6F7172`).
+Create a new partition for the EFI Partition.
+EFI Partition type is `EFI System` (`C12A7328-F81F-11D2-BA4B-00A0C93EC93B`)
 
 ```text
 n
 +1G
 t
-142
+1
 ```
 
 Create the root partition:
@@ -57,7 +56,7 @@ w
 ## File System Creation
 
 ```bash
-sudo mkfs.vfat -F32 -n nixos-boot /dev/disk/by-id/your-disk-boot
+sudo mkfs.vfat -F32 -n nixos-esp /dev/disk/by-id/your-disk-nixos-esp
 sudo e2label /dev/disk/by-id/your-disk-root-for-crypt nixos-root-crypt
 sudo cryptsetup luksFormat /dev/disk/by-id/nixos-root-crypt
 sudo cryptsetup open /dev/disk/by-id/nixos-root-crypt nixos-root
@@ -76,13 +75,11 @@ sudo umount /mnt
 sudo mount -o noatime,compress=zstd,subvol=@ /dev/mapper/nixos-root /mnt
 
 sudo mkdir -p /mnt/efi
-sudo mkdir -p /mnt/boot
 sudo mkdir -p /mnt/nix/store
 sudo mkdir -p /mnt/var/log
 sudo mkdir -p /mnt/.snapshots
 
-sudo mount -o noatime,fmask=0077,dmask=0077 /dev/disk/by-label/nixos-boot /mnt/boot
-sudo mount -o noatime,fmask=0077,dmask=0077 /dev/disk/by-label/your-disk-efi /mnt/efi
+sudo mount -o noatime,fmask=0077,dmask=0077 /dev/disk/by-label/nixos-esp /mnt/efi
 sudo mount -o noatime,compress=zstd,subvol=@nix-store /dev/mapper/nixos-root /mnt/nix/store
 sudo mount -o noatime,compress=zstd,subvol=@var-log /dev/mapper/nixos-root /mnt/var/log
 sudo mount -o noatime,compress=zstd,subvol=@snapshots /dev/mapper/nixos-root /mnt/.snapshots

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -1,42 +1,7 @@
-{ lib, pkgs, ... }:
-{
+_: {
   boot = {
     loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
       limine = {
-        enable = true;
-        # ディスク容量を埋め尽くさないように上限を定めます。
-        maxGenerations = 40;
-        style = {
-          interface = {
-            # ブート時はGPUを効率的に使えないことが多いため解像度を下げて負荷を減らします。
-            resolution = "1920x1080";
-          };
-        };
-        # セキュアブート設定。
-        secureBoot = {
-          # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
-          enable = true;
-          # 自動での鍵作成と署名を有効化して、
-          # 確認は手動で`sudo bootctl`や`sudo sbctl status`で行います。
-          autoGenerateKeys = true;
-          autoEnrollKeys = {
-            enable = true;
-            # デフォルトでMicrosoftやファームウェアの鍵が含まれるため、
-            # `extraArgs`の設定は基本的に不要です。
-          };
-        };
-        # Nixが直接対応していない設定を直接書き込みます。
-        extraConfig = ''
-          # 最後に起動したエントリを記憶して次回起動時に自動選択します。
-          remember_last_entry: yes
-          # ブートローダーでも慣れたdvorak入力を使ってトラブルシューティングを楽にします。
-          keyboard_layout: dvorak
-        '';
         # 他のSSDに入っているWindowsのブートマネージャにチェインロードします。
         # vfatのボリュームシリアルはGUID形式ではないため、
         # GPTパーティションGUID(PARTUUID)で指定します。
@@ -51,49 +16,5 @@
         '';
       };
     };
-    initrd = {
-      systemd = {
-        enable = true;
-      };
-    };
   };
-
-  # Limineの`remember_last_entry`はエントリのパス名をEFI変数`LimineLastBootedEntry`に保存します。
-  # 例: `NixOS default profile/Generation 769`
-  # NixOSの世代エントリは名前に世代番号を含むため、
-  # 記憶されたままだとrebuild後も古い世代が延々と選択され続けてしまいます。
-  # そこでNixOS起動時に記憶を消して、
-  # 次回起動は`default_entry`(常に最新世代)に戻します。
-  # Windowsのエントリ名は不変なので、
-  # Windows起動時の記憶はそのまま機能します。
-  # Windows Updateの複数回再起動でもWindowsが選択され続けます。
-  systemd.services.limine-forget-last-entry =
-    let
-      limineLastBootedEntryPath = "/sys/firmware/efi/efivars/LimineLastBootedEntry-513ee0d0-6e43-cb05-b272-f146a2fcb88a";
-    in
-    {
-      description = "Forget Limine last booted entry so the newest NixOS generation boots next";
-      wantedBy = [ "multi-user.target" ];
-      unitConfig = {
-        ConditionPathExists = limineLastBootedEntryPath;
-      };
-      serviceConfig = {
-        Type = "oneshot";
-        ExecStart = lib.getExe (
-          pkgs.writeShellApplication {
-            name = "limine-forget-last-entry";
-            runtimeInputs = with pkgs; [
-              coreutils
-              e2fsprogs
-            ];
-            text = ''
-              var=${limineLastBootedEntryPath}
-              # efivarfsは変数をimmutable属性付きで公開するため、削除前に解除します。
-              chattr -i "$var"
-              rm "$var"
-            '';
-          }
-        );
-      };
-    };
 }

--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -1,5 +1,18 @@
 {
   boot = {
+    loader = {
+      limine = {
+        secureBoot = {
+          autoEnrollKeys = {
+            # ThinkPad P16s Gen 2 AMDのファームウェアは、
+            # `dbDefault`などのEFI変数を公開していないため、
+            # デフォルトの`--firmware-builtin`は失敗します。
+            # Microsoftの鍵だけをvendor鍵として登録します。
+            extraArgs = [ "--microsoft" ];
+          };
+        };
+      };
+    };
     initrd = {
       luks.devices = {
         nixos-root = {

--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -1,22 +1,6 @@
 {
   boot = {
-    loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
-      systemd-boot = {
-        enable = true;
-        consoleMode = "auto";
-        xbootldrMountPoint = "/boot";
-        configurationLimit = 40;
-      };
-    };
     initrd = {
-      systemd = {
-        enable = true;
-      };
       luks.devices = {
         nixos-root = {
           device = "/dev/disk/by-label/nixos-root-crypt";

--- a/nixos/host/creep/boot.nix
+++ b/nixos/host/creep/boot.nix
@@ -11,6 +11,15 @@
             extraArgs = [ "--microsoft" ];
           };
         };
+        # プリインストールされているWindowsのブートマネージャにチェインロードします。
+        # Windowsのブートマネージャは最初からESPとして使われていたパーティションにあります。
+        # vfatのボリュームシリアルはGUID形式ではないため、
+        # GPTパーティションGUID(PARTUUID)で指定します。
+        extraEntries = ''
+          /Windows
+              protocol: efi_chainload
+              path: guid(9fc93af9-07db-45df-a334-97e57e820daf):/EFI/Microsoft/Boot/bootmgfw.efi
+        '';
       };
     };
     initrd = {

--- a/nixos/host/creep/disk.nix
+++ b/nixos/host/creep/disk.nix
@@ -3,16 +3,7 @@ _: {
   # よってプリインストールされているWindowsのパーティションを残す必要があるためdiskoは使えない。
   fileSystems = {
     "/efi" = {
-      device = "/dev/disk/by-label/SYSTEM";
-      fsType = "vfat";
-      options = [
-        "noatime"
-        "fmask=0077"
-        "dmask=0077"
-      ];
-    };
-    "/boot" = {
-      device = "/dev/disk/by-label/nixos-boot";
+      device = "/dev/disk/by-label/nixos-esp";
       fsType = "vfat";
       options = [
         "noatime"

--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -1,11 +1,7 @@
-{
+{ lib, ... }: {
   boot = {
     loader = {
-      efi = {
-        canTouchEfiVariables = true;
-        efiSysMountPoint = "/efi";
-      };
-      timeout = 1;
+      limine.enable = lib.mkForce false; # seminarのlimine対応は後でやります。
       systemd-boot = {
         enable = true;
         consoleMode = "auto";
@@ -14,9 +10,6 @@
       };
     };
     initrd = {
-      systemd = {
-        enable = true;
-      };
       luks.devices = {
         nixos-root = {
           device = "/dev/disk/by-partlabel/disk-main-nixos-root";

--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -1,0 +1,87 @@
+{ lib, pkgs, ... }:
+{
+  boot = {
+    loader = {
+      efi = {
+        canTouchEfiVariables = true;
+        efiSysMountPoint = "/efi";
+      };
+      timeout = 1;
+      limine = {
+        enable = true;
+        # ディスク容量を埋め尽くさないように上限を定めます。
+        maxGenerations = 40;
+        style = {
+          interface = {
+            # ブート時はGPUを効率的に使えないことが多いため解像度を下げて負荷を減らします。
+            resolution = "1920x1080";
+          };
+        };
+        # セキュアブート設定。
+        secureBoot = {
+          # `/var/lib/sbctl`の鍵でlimineバイナリをsbctl署名します。
+          enable = true;
+          # 自動での鍵作成と署名を有効化して、
+          # 確認は手動で`sudo bootctl`や`sudo sbctl status`で行います。
+          autoGenerateKeys = true;
+          autoEnrollKeys = {
+            enable = true;
+            # デフォルトでMicrosoftやファームウェアの鍵が含まれるため、
+            # `extraArgs`の設定は基本的に不要です。
+          };
+        };
+        # Nixが直接対応していない設定を直接書き込みます。
+        extraConfig = ''
+          # 最後に起動したエントリを記憶して次回起動時に自動選択します。
+          remember_last_entry: yes
+          # ブートローダーでも慣れたdvorak入力を使ってトラブルシューティングを楽にします。
+          keyboard_layout: dvorak
+        '';
+      };
+    };
+    initrd = {
+      systemd = {
+        enable = true;
+      };
+    };
+  };
+
+  # Limineの`remember_last_entry`はエントリのパス名をEFI変数`LimineLastBootedEntry`に保存します。
+  # 例: `NixOS default profile/Generation 769`
+  # NixOSの世代エントリは名前に世代番号を含むため、
+  # 記憶されたままだとrebuild後も古い世代が延々と選択され続けてしまいます。
+  # そこでNixOS起動時に記憶を消して、
+  # 次回起動は`default_entry`(常に最新世代)に戻します。
+  # Windowsのエントリ名は不変なので、
+  # Windows起動時の記憶はそのまま機能します。
+  # Windows Updateの複数回再起動でもWindowsが選択され続けます。
+  systemd.services.limine-forget-last-entry =
+    let
+      limineLastBootedEntryPath = "/sys/firmware/efi/efivars/LimineLastBootedEntry-513ee0d0-6e43-cb05-b272-f146a2fcb88a";
+    in
+    {
+      description = "Forget Limine last booted entry so the newest NixOS generation boots next";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        ConditionPathExists = limineLastBootedEntryPath;
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = lib.getExe (
+          pkgs.writeShellApplication {
+            name = "limine-forget-last-entry";
+            runtimeInputs = with pkgs; [
+              coreutils
+              e2fsprogs
+            ];
+            text = ''
+              var=${limineLastBootedEntryPath}
+              # efivarfsは変数をimmutable属性付きで公開するため、削除前に解除します。
+              chattr -i "$var"
+              rm "$var"
+            '';
+          }
+        );
+      };
+    };
+}

--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -27,7 +27,7 @@
           autoEnrollKeys = {
             enable = true;
             # デフォルトでMicrosoftやファームウェアの鍵が含まれるため、
-            # `extraArgs`の設定は基本的に不要です。
+            # ファームウェア特有の事情がない限り`extraArgs`の設定は基本的に不要です。
           };
         };
         # Nixが直接対応していない設定を直接書き込みます。


### PR DESCRIPTION
bullet(#1323, #1326)に続いて、
creepのブートローダーをsystemd-bootからLimineに切り替えて、
セキュアブートを有効にします。

主な変更は以下の通りです。

- bulletで作り上げたLimine設定(セキュアブート、`remember_last_entry`対応など)は、
  概ねそのまま他のホストにも通用するため、
  `nixos/native-linux/boot.nix`に共通設定として移動します。
  seminarは後で対応するのでLimineを無効化してsystemd-bootに留めておきます。
- LimineはXBOOTLDRパーティションに対応していないため、
  これまでXBOOTLDRとして`/boot`に使っていたパーティションを、
  NixOS専用のESPとして`/efi`にマウントする構成に変更します。
  プリインストール時からある共有ESPはWindows専用になります。
  実機ではパーティションタイプとvfatラベルを変更して移行済みです。
  手動パーティション分けのドキュメントも新構成に合わせて更新します。
- ThinkPad P16s Gen 2 AMDのファームウェアは、
  `dbDefault`などのデフォルト鍵のEFI変数を公開しておらず、
  セキュアブート鍵の自動enrollがデフォルト引数の`--firmware-builtin`で失敗するため、
  creepでは`--microsoft`だけに上書きします。
- bulletと同様にWindowsのブートマネージャへのチェインロードエントリを追加します。
  `bootmgfw.efi`はMicrosoft署名済みで、
  Microsoftの鍵をenrollしているためセキュアブート有効のまま起動できます。

実機でセキュアブートが有効な状態でNixOSが起動することを確認済みです。

close #1321

https://claude.ai/code/session_01LAvdYjuCnGdCG7ZTYuEdwV