### PR TITLE
feat: seminarをセキュアブート対応にする

### DIFF
--- a/nixos/host/seminar/boot.nix
+++ b/nixos/host/seminar/boot.nix
@@ -1,12 +1,14 @@
-{ lib, ... }: {
+{
   boot = {
     loader = {
-      limine.enable = lib.mkForce false; # seminarのlimine対応は後でやります。
-      systemd-boot = {
-        enable = true;
-        consoleMode = "auto";
-        xbootldrMountPoint = "/boot";
-        configurationLimit = 40;
+      limine = {
+        secureBoot = {
+          autoEnrollKeys = {
+            # seminarはデュアルブートしていないので、
+            # Microsoftの鍵を登録する必要はありません。
+            extraArgs = [ "--firmware-builtin" ];
+          };
+        };
       };
     };
     initrd = {

--- a/nixos/host/seminar/disk.nix
+++ b/nixos/host/seminar/disk.nix
@@ -8,26 +8,12 @@ _: {
           type = "gpt";
           partitions = {
             ESP = {
-              size = "1G";
+              size = "2G";
               type = "EF00";
               content = {
                 type = "filesystem";
                 format = "vfat";
                 mountpoint = "/efi";
-                mountOptions = [
-                  "noatime"
-                  "fmask=0077"
-                  "dmask=0077"
-                ];
-              };
-            };
-            nixos-boot = {
-              size = "1G";
-              type = "EA00";
-              content = {
-                type = "filesystem";
-                format = "vfat";
-                mountpoint = "/boot";
                 mountOptions = [
                   "noatime"
                   "fmask=0077"


### PR DESCRIPTION
bulletやcreepと同様に、
seminarのブートローダーをsystemd-bootからLimineに切り替えて、
sbctlの鍵によるセキュアブートを有効にします。

seminarはデュアルブートをしていないため、
鍵のenrollでは`--firmware-builtin`だけを指定して、
Microsoftの鍵は登録しません。

LimineはXBOOTLDRに対応していないため、
systemd-boot時代に使っていた`/boot`(XBOOTLDR)パーティションを削除して、
その領域をESPに統合して2Gに拡張します。

実機では以下の作業を完了済みです。

- limine+セキュアブート構成の適用と鍵のenroll
- 旧systemd-bootの残骸の除去とフォールバックパスの署名済みLimineへの置き換え
- `/boot`パーティションの削除とESPの2Gへの拡張
- セキュアブート有効化でPCR 7が変わるため、全LUKSデバイスのTPM2スロットを再登録
- セキュアブート有効(user mode)でのLimine起動とTPM自動解錠を確認

close #1322

https://claude.ai/code/session_014Vh2AywUq9xSCX77mw6fNU