### PR TITLE
feat: ディスプレイマネージャをlightdmからSDDMに切り替え

### DIFF
--- a/nixos/native-linux/display-manager.nix
+++ b/nixos/native-linux/display-manager.nix
@@ -6,7 +6,6 @@ in
   services = {
     xserver = {
       displayManager = {
-        lightdm.enable = true;
         session = [
           {
             manage = "desktop";
@@ -24,6 +23,7 @@ in
     };
     displayManager = {
       enable = true;
+      sddm.enable = true;
       defaultSession = home-manager-session-name;
       autoLogin = {
         enable = true;


### PR DESCRIPTION
lightdmはWaylandセッションへの対応が怪しいと聞いたため、
SDDMに切り替えます。

自動ログイン(`services.displayManager.autoLogin`)と、
デフォルトセッション(`defaultSession = "hm-xsession"`)は、
ディスプレイマネージャ非依存の共通オプションなので変更不要です。
SDDMモジュールはこれらからSDDM設定ファイルの`[Autologin]`セクションを生成します。

SDDMのWaylandグリータ(`sddm.wayland.enable`)はexperimental扱いのため有効にせず、 X11グリータのままにしています。
自動ログインしているのでグリータはほぼ表示されません。

close #1332