### PR TITLE
feat: Lutrisを導入してProton経由のゲームでもgamemodeを有効化

### DIFF
--- a/lib/gamemode-lib-rpath-overlay.nix
+++ b/lib/gamemode-lib-rpath-overlay.nix
@@ -1,0 +1,33 @@
+/**
+  `libgamemodeauto.so`が`dlopen`で`libgamemode.so`を見つけられるように、
+  自身のlibディレクトリをRUNPATHへ追加するoverlay。
+
+  `libgamemodeauto.so`は`LD_PRELOAD`されると、
+  コンストラクタで`libgamemode.so`を`dlopen`してgamemodedへ登録を行う。
+  この`dlopen`はライブラリ名だけで呼ばれるため、
+  呼び出し元である`libgamemodeauto.so`自身のRUNPATHか、
+  `LD_LIBRARY_PATH`などの検索パスに`libgamemode.so`が無いと失敗する。
+
+  nixpkgsのgamemodeはRUNPATHにglibcしか持たせていないので、
+  LutrisがProton(umu)経由でゲームを起動する時のように、
+  pressure-vesselコンテナ内で検索パスがリセットされる環境では、
+
+  ```
+  gamemodeauto: dlopen failed - libgamemode.so: cannot open shared object file
+  ```
+
+  というエラーになりgamemodeが有効化されない。
+  コンテナ内にも`/nix/store`は共有されているため、
+  RUNPATHでstoreパスを直接指せば解決する。
+
+  nixpkgsは同じ理由で`gamemoded`などのバイナリにはrpathを追加済みなので、
+  ライブラリにも同じ措置をするだけであり、
+  upstreamのnixpkgsでも修正されるべきパッケージングバグ。
+*/
+_final: prev: {
+  gamemode = prev.gamemode.overrideAttrs (old: {
+    postFixup = (old.postFixup or "") + ''
+      patchelf --add-rpath "$lib/lib" "$lib/lib/libgamemodeauto.so.0.0.0"
+    '';
+  });
+}

--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -82,9 +82,11 @@
     });
   '';
 
-  # gamescopeセッションを起動する短縮コマンド。
-  environment.systemPackages = [
-    (pkgs.writeShellScriptBin "steamos" ''
+  environment.systemPackages = with pkgs; [
+    # Steam外部も含めたアプリをSteamのProtonを使って管理・起動するためのツール。
+    lutris
+    # gamescopeセッションを起動する短縮コマンド。
+    (writeShellScriptBin "steamos" ''
       exec systemctl start steam-gamescope.service
     '')
   ];

--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -1,5 +1,9 @@
 { pkgs, username, ... }:
 {
+  # LutrisがProton(umu)経由で起動するゲームでもgamemodeが効くように、
+  # `libgamemodeauto.so`のRUNPATHを修正する。
+  nixpkgs.overlays = [ (import ../../lib/gamemode-lib-rpath-overlay.nix) ];
+
   programs = {
     steam = {
       enable = true;
@@ -89,7 +93,9 @@
 
   environment.systemPackages = with pkgs; [
     # Steam外部も含めたアプリをSteamのProtonを使って管理・起動するためのツール。
-    lutris
+    # FHS環境にgamemodeのライブラリを追加して、
+    # gamemodeautoの`dlopen`が`libgamemode.so`を見つけられるようにする。
+    (lutris.override { extraLibraries = pkgs: [ pkgs.gamemode.lib ]; })
     # gamescopeセッションを起動する短縮コマンド。
     (writeShellScriptBin "steamos" ''
       exec systemctl start steam-gamescope.service

--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -23,6 +23,11 @@
     gamescope.enable = true;
   };
 
+  # gamemodedはCPUガバナー変更などの特権操作をpkexecで行う。
+  # gamemodeが同梱するpolkitルールは`gamemode`グループのユーザにだけ認証なしで許可するので、
+  # ユーザをグループに追加する。
+  users.users.${username}.extraGroups = [ "gamemode" ];
+
   # LightDMはWaylandセッションを起動できず、
   # X11上のネスト起動ではHDRなどを通せないため、
   # 埋め込み(DRM)モードのgamescopeセッションをsystemdサービスとして定義する。


### PR DESCRIPTION
Steam外部のゲームもSteamのProtonで管理・起動できるように、
Lutrisを導入します。

導入しただけではgamemodeが実際には機能していなかったため、
合わせて2つの修正を行います。

まずgamemodedはCPUガバナー変更や`split_lock_mitigate`の無効化などの特権操作を、
pkexec経由で行いますが、
同梱のpolkitルールは`gamemode`グループのユーザにだけ認証なしで許可します。
NixOSの`programs.gamemode`モジュールはグループの作成までしか行わないため、
ユーザのグループ追加をこちらで明示します。

次にLutrisからProton(umu)経由でゲームを起動すると、

```
gamemodeauto: dlopen failed - libgamemode.so: cannot open shared object file
```

というエラーが出てgamemodeが有効化されませんでした。
LutrisのFHS環境に`gamemode.lib`を追加するだけでは、
Steam Linux Runtimeのpressure-vesselコンテナ内で検索パスがリセットされるため解決せず、
nixpkgsの`libgamemodeauto.so`がRUNPATHにglibcしか持たないことが根本原因でした。
overlayでRUNPATHに自身のlibディレクトリを追加して、
検索パスに依存せず`dlopen("libgamemode.so")`を解決できるようにします。
nixpkgsは同じ理由で`gamemoded`などのバイナリにはrpathを追加済みなので、
ライブラリにも同じ措置をするだけです。

実機のbulletでLutrisからProtonのゲームを起動して、
エラーが解消しgamemodedへの登録が届くことを確認済みです。