### PR TITLE
fix: gamescopeセッションでSteamがbwrapのエラーで即死する問題を修正

### DIFF
--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -76,6 +76,14 @@
       StandardError = "journal";
       # PAM経由でlogindセッションを登録する。
       PAMName = "login";
+      # systemd v254以降のpam_systemdはローカルセッションへ、
+      # ambient capabilityとして`CAP_WAKE_ALARM`をデフォルトで付与する。
+      # それがsteam(buildFHSEnvのbwrap)まで伝播すると、
+      # bwrapが`Unexpected capabilities but not setuid`エラーで即死してSteamが起動しない。
+      # https://github.com/containers/bubblewrap/issues/380
+      # bounding setから除外しておけば、
+      # PAMセッション開始後にsystemdがambient setを再適用する際に確実に落とされる。
+      CapabilityBoundingSet = "~CAP_WAKE_ALARM";
     };
   };
 


### PR DESCRIPTION
`steamos`コマンドでgamescopeセッションを起動しても、
gamescope自体は初期化に成功するのに、
子プロセスのSteamが即座に終了して環境が立ち上がりませんでした。

```
bwrap: Unexpected capabilities but not setuid, old file caps config?
[gamescope] [Info]  launch: Primary child shut down!
```

原因はsystemd v254以降のpam_systemdの仕様変更です。
ローカルシートに紐づく一般ユーザセッションへ、
ambient capabilityとして`CAP_WAKE_ALARM`をデフォルトで付与するようになりました。
`PAMName = "login"`で起動する`steam-gamescope.service`では、
これがambientのままSteamまで伝播します。
SteamはbuildFHSEnvによりbwrapで起動されますが、
bwrapは非setuidなのにpermitted capabilityを持つ状態を拒否して即死します。
bubblewrap側では既知の問題ですが未修正です。
https://github.com/containers/bubblewrap/issues/380

そこでunitの`CapabilityBoundingSet`から`CAP_WAKE_ALARM`を除外します。
PAMセッション開始後にsystemdがambient setを再適用する際、
bounding setにないcapabilityは明示的に落とされるため、
bwrapまで伝播しなくなります。
unit単位の宣言的な対処なので通常ログインの`login` PAMスタックには影響せず、
`CAP_WAKE_ALARM`はサスペンド復帰タイマー用でゲーム用途には不要です。

なお通常のXセッションからSteamが起動できていたのは、
そちらではambient setが途中でクリアされていてpermittedが空だったためです。

https://claude.ai/code/session_01ESnAk3qsRVS4guFhtPTfJX