### PR TITLE
feat: cdn.ncaq.netをseminarから配信する設定を追加

### DIFF
--- a/nixos/host/seminar/cdn.nix
+++ b/nixos/host/seminar/cdn.nix
@@ -1,0 +1,42 @@
+let
+  # cloudflaredからCaddyへ内部ルーティングするためのポート。
+  # 8081はTailscale Serve用(caddy.nix)に使っているので8082。
+  cdnPort = 8082;
+  # 配信コンテンツの置き場所。
+  # 速度をあまり求めないデータの集積場なので/mnt/noa以下に置きます。
+  cdnRoot = "/mnt/noa/cdn.ncaq.net";
+in
+{
+  services = {
+    # cdn.ncaq.netの静的ファイル配信。
+    # 以前はCloudflare Pagesで配信していましたが、
+    # Pagesには1ファイル25MiBの制限があり配信できないファイルがあるため、
+    # seminarからCloudflare Tunnel経由で配信します。
+    # TLS終端はCloudflare側で行われるためオリジンはHTTPのみで済みます。
+    cloudflared.tunnels.seminar.ingress."cdn.ncaq.net" = "http://127.0.0.1:${toString cdnPort}";
+
+    # コンテンツはcdn.ncaq.netリポジトリのGitHub Actionsが、
+    # セルフホストランナー経由でrsyncしてきます。
+    caddy.virtualHosts.":${toString cdnPort}".extraConfig = ''
+      bind 127.0.0.1
+      # 過去に持っていたコンテンツのリダイレクト定義。
+      redir /dic-nico-intersection-pixiv.txt https://raw.githubusercontent.com/ncaq/dic-nico-intersection-pixiv/master/public/dic-nico-intersection-pixiv-google.txt permanent
+      redir /keymap.txt https://raw.githubusercontent.com/ncaq/dotfiles/master/mozc/keymap.txt permanent
+      redir /nlod.txt https://raw.githubusercontent.com/ncaq/dotfiles/master/mozc/nlod.txt temporary
+      redir /uBlacklist.txt https://raw.githubusercontent.com/ncaq/uBlacklistRule/master/uBlacklist.txt permanent
+      redir /uBlockOrigin.txt https://raw.githubusercontent.com/ncaq/uBlacklistRule/master/uBlockOrigin.txt permanent
+      # ファイルをそのまま配信。
+      root * ${cdnRoot}
+      file_server
+    '';
+  };
+
+  # 配信ディレクトリ。
+  # GitHub Actionsセルフホストランナーがrsyncで書き込み、
+  # Caddyはother権限で読み取ります。
+  # github-runnerコンテナへのbindMountのhostPathとしても使われるため、
+  # コンテナ起動前に存在している必要があります。
+  systemd.tmpfiles.rules = [
+    "d ${cdnRoot} 0755 github-runner github-runner -"
+  ];
+}

--- a/nixos/host/seminar/github-runner/github-runner-share.nix
+++ b/nixos/host/seminar/github-runner/github-runner-share.nix
@@ -16,17 +16,10 @@ let
       cachix
       inputs.niks3.packages.${pkgs.stdenv.hostPlatform.system}.niks3
     ];
-  # GitHub Actionsランナーの並列数。
-  # 上位レベルでリソースを制限しているため、
-  # 複数立ち上げてもサーバの全体のリソース量が破綻する心配はあまりありません。
-  # あまりCPUを使い切れなくても、
-  # Nixが動く時は大抵はキャッシュダウンロードのIO待ちなので、
-  # 並列動作したほうが効率的です。
-  runnerNum = 5;
   # runnerが使うTypeScriptコードをビルドしてGitHub Actionsで利用できるようにします。
   # 吐き出されるコードはピュアなJavaScriptなのでアーキテクチャ非依存です。
-  dotfiles-github-runner = pkgs.buildNpmPackage {
-    pname = "dotfiles-github-runner";
+  github-runner = pkgs.buildNpmPackage {
+    pname = "github-runner";
     version = "0.0.0";
     src = ./.;
     npmDeps = pkgs.importNpmLock { npmRoot = ./.; };
@@ -49,7 +42,7 @@ let
     pkgs.writeShellApplication {
       name = "job-started-hook.sh";
       runtimeInputs = with pkgs; [ nodejs ];
-      text = ''exec node ${dotfiles-github-runner}/job-started-hook.js "$@"'';
+      text = ''exec node ${github-runner}/job-started-hook.js "$@"'';
     }
   );
   # GitHub Actionsランナーはホストのnixデーモンと通信するため、
@@ -89,7 +82,6 @@ in
     inherit
       githubActionsRunnerPackages
       selfHostRunnerPackages
-      runnerNum
       jobStartedHook
       users
       ciNixSettings

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -9,79 +9,125 @@ let
   inherit (githubRunnerShare)
     githubActionsRunnerPackages
     selfHostRunnerPackages
-    runnerNum
     jobStartedHook
     users
     ciNixSettings
     ;
-  addr = config.machineAddresses.github-runner-x64;
-in
-{
-  containers.github-runner-x64 = {
-    autoStart = true;
-    ephemeral = true;
-    privateNetwork = true;
-    privateUsers = "identity";
-    hostAddress = addr.host;
-    localAddress = addr.guest;
-    bindMounts = {
-      "/etc/runner-registration-token" = {
-        hostPath = config.sops.secrets."runner-registration-token".path;
-        isReadOnly = true;
-      };
-      # ホストのnix-daemonがランナーのワークディレクトリ配下に書かれた、
-      # `post-build-hook`を実行できるようにします。
-      # Mic92/niks3-actionなどはhookのshimを、
-      # `${RUNNER_TEMP}/niks3/`(= `/run/github-runner/<name>/_temp/niks3/`)に置き、
-      # nixデーモンはホスト側からその絶対パスを開きます。
-      # コンテナの`/run`tmpfsのままではホストからは見えないため、
-      # 同一パスで両側から到達できるようにbind-mountを張ります。
-      "/run/github-runner" = {
-        hostPath = "/run/github-runner";
-        isReadOnly = false;
+  # リポジトリごとのランナーコンテナ定義。
+  # attr名がそのままコンテナ名になります。
+  # IPアドレスはmachineAddressesの同名エントリを参照するため、
+  # コンテナを追加する時はmachine-mapping.nixにも同名のエントリが必要です。
+  runnerContainerDefs = {
+    github-runner-dotfiles-x64 = {
+      basename = "dotfiles-x64";
+      runnerNum = 5;
+      url = "https://github.com/ncaq/dotfiles";
+    };
+    github-runner-cdn-ncaq-net-x64 = {
+      basename = "cdn-ncaq-net-x64";
+      runnerNum = 1; # デプロイジョブは軽量なので1つで十分です。
+      url = "https://github.com/ncaq/cdn.ncaq.net";
+      extraBindMounts = {
+        # cdn.ncaq.netのデプロイ先。
+        # ランナー上のワークフローがrsyncで直接書き込みます(cdn.nix参照)。
+        "/mnt/noa/cdn.ncaq.net" = {
+          hostPath = "/mnt/noa/cdn.ncaq.net";
+          isReadOnly = false;
+        };
       };
     };
-    config =
-      { lib, ... }:
-      {
-        system.stateVersion = "26.05";
-        # NixデーモンにCI用の設定を渡します。
-        # `trusted-users`などが含まれます。
-        # コンテナはホストのnixデーモンソケットを共有するので、
-        # ある程度設定を同期させる必要があります。
-        inherit users;
-        nix.settings = ciNixSettings;
-        networking = {
-          useHostResolvConf = lib.mkForce false;
-          firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中にリッスンするため全許可
+  };
+  # コンテナ名からmachineAddressesのエントリを引きます。
+  addrOf = name: config.machineAddresses.${name};
+  # GitHub Actionsランナーコンテナを生成する関数。
+  mkRunnerContainer =
+    name:
+    {
+      # ランナー名の基礎となる名前。
+      basename,
+      # GitHub Actionsランナーの並列数。
+      # 上位レベルでリソースを制限しているため、
+      # 複数立ち上げてもサーバの全体のリソース量が破綻する心配はあまりありません。
+      # あまりCPUを使い切れなくても、
+      # Nixが動く時は大抵はキャッシュダウンロードのIO待ちなので、
+      # 並列に動作出来るならした方が効率的です。
+      runnerNum,
+      # リポジトリのURL。
+      url,
+      # 追加のbind-mounts。
+      extraBindMounts ? { },
+    }:
+    let
+      addr = addrOf name;
+    in
+    {
+      autoStart = true;
+      ephemeral = true;
+      privateNetwork = true;
+      privateUsers = "identity";
+      hostAddress = addr.host;
+      localAddress = addr.guest;
+      bindMounts = extraBindMounts // {
+        "/etc/runner-registration-token" = {
+          hostPath = config.sops.secrets."runner-registration-token".path;
+          isReadOnly = true;
         };
-        services = {
-          resolved.enable = true;
-          github-runners =
-            let
-              runnerNumbers = builtins.genList (x: x) runnerNum;
-              args = { inherit pkgs; };
-              extraPkgs = (githubActionsRunnerPackages args).all ++ selfHostRunnerPackages args;
-              mkRunnerDotfilesX64 = number: {
-                name = "dotfiles-x64-${toString number}";
-                value = {
-                  enable = true;
-                  ephemeral = true;
-                  replace = true;
-                  user = "github-runner";
-                  group = "github-runner";
-                  extraLabels = [ "NixOS" ];
-                  extraPackages = extraPkgs;
-                  tokenFile = "/etc/runner-registration-token";
-                  url = "https://github.com/ncaq/dotfiles";
-                  extraEnvironment.ACTIONS_RUNNER_HOOK_JOB_STARTED = jobStartedHook;
-                };
-              };
-            in
-            builtins.listToAttrs (map mkRunnerDotfilesX64 runnerNumbers);
+        # ホストのnix-daemonがランナーのワークディレクトリ配下に書かれた、
+        # `post-build-hook`を実行できるようにします。
+        # Mic92/niks3-actionなどはhookのshimを、
+        # `${RUNNER_TEMP}/niks3/`(= `/run/github-runner/<name>/_temp/niks3/`)に置き、
+        # nixデーモンはホスト側からその絶対パスを開きます。
+        # コンテナの`/run`tmpfsのままではホストからは見えないため、
+        # 同一パスで両側から到達できるようにbind-mountを張ります。
+        "/run/github-runner" = {
+          hostPath = "/run/github-runner";
+          isReadOnly = false;
         };
       };
-  };
+      config =
+        { lib, ... }:
+        {
+          system.stateVersion = "26.05";
+          # NixデーモンにCI用の設定を渡します。
+          # `trusted-users`などが含まれます。
+          # コンテナはホストのnixデーモンソケットを共有するので、
+          # ある程度設定を同期させる必要があります。
+          inherit users;
+          nix.settings = ciNixSettings;
+          networking = {
+            useHostResolvConf = lib.mkForce false;
+            firewall.trustedInterfaces = [ "eth0" ]; # CIジョブ中にリッスンするため全許可
+          };
+          services = {
+            resolved.enable = true;
+            github-runners =
+              let
+                runnerNumbers = builtins.genList (x: x) runnerNum;
+                args = { inherit pkgs; };
+                extraPkgs = (githubActionsRunnerPackages args).all ++ selfHostRunnerPackages args;
+                mkRunner = number: {
+                  name = "${basename}-${toString number}";
+                  value = {
+                    enable = true;
+                    ephemeral = true;
+                    replace = true;
+                    user = "github-runner";
+                    group = "github-runner";
+                    extraLabels = [ "NixOS" ];
+                    extraPackages = extraPkgs;
+                    tokenFile = "/etc/runner-registration-token";
+                    inherit url;
+                    extraEnvironment.ACTIONS_RUNNER_HOOK_JOB_STARTED = jobStartedHook;
+                  };
+                };
+              in
+              builtins.listToAttrs (map mkRunner runnerNumbers);
+          };
+        };
+    };
+in
+{
+  containers = lib.mapAttrs mkRunnerContainer runnerContainerDefs;
 
   systemd = {
     # ホスト側systemd-networkdでvethインターフェースにIPアドレスとルートを設定します。
@@ -90,19 +136,22 @@ in
     # github-runnerサービスの起動にはネットワークが必要なためデッドロックしてしまいます。
     # systemd-networkdはvethインターフェース作成直後に設定を適用するため、
     # コンテナ内のサービスが起動する前にネットワークが使用可能になります。
-    network.networks."20-github-runner-x64-veth" = {
-      # Linuxのインターフェース名はIFNAMSIZ(15文字)制限があるため、
-      # 実際のインターフェース名は`ve-github-rRhHH`のように短縮されます。
-      # しかしsystemd-networkdのmatchConfig.Nameはaltname(代替名)もマッチするため、
-      # コンテナ名から生成される完全な名前で正しくマッチします。
-      matchConfig.Name = "ve-github-runner-x64";
-      addresses = [
-        { Address = "${addr.host}/32"; }
-      ];
-      routes = [
-        { Destination = "${addr.guest}/32"; }
-      ];
-    };
+    network.networks = lib.mapAttrs' (
+      name: _:
+      lib.nameValuePair "20-${name}-veth" {
+        # Linuxのインターフェース名はIFNAMSIZ(15文字)制限があるため、
+        # 実際のインターフェース名は`ve-github-rRhHH`のように短縮されます。
+        # しかしsystemd-networkdのmatchConfig.Nameはaltname(代替名)もマッチするため、
+        # コンテナ名から生成される完全な名前で正しくマッチします。
+        matchConfig.Name = "ve-${name}";
+        addresses = [
+          { Address = "${(addrOf name).host}/32"; }
+        ];
+        routes = [
+          { Destination = "${(addrOf name).guest}/32"; }
+        ];
+      }
+    ) runnerContainerDefs;
 
     # bindMountsのhostPathは起動時に存在している必要があります。
     # `/run`はtmpfsで毎boot消えるため再生成します。
@@ -116,25 +165,32 @@ in
       "d /run/github-runner 0700 github-runner github-runner -"
     ];
 
-    services."container@github-runner-x64" = {
-      # NixOSコンテナモジュールが生成するpostStartは`ip addr add`/`ip route add`を使うため、
-      # systemd-networkdが先に設定済みの場合にEEXISTエラーで失敗します。
-      # 冪等にするために`2>/dev/null || true`を付けます。
-      # 実際の設定はsystemd-networkdに任せるため、postStartの内容が失敗していても問題ありません。
-      postStart = lib.mkForce ''
-        ifaceHost=ve-$INSTANCE
-        ip link set dev "$ifaceHost" up
-        ip addr add ${addr.host} dev "$ifaceHost" 2>/dev/null || true
-        ip route add ${addr.guest} dev "$ifaceHost" 2>/dev/null || true
-      '';
-      serviceConfig = {
-        # CIジョブがホストのリソースを過剰に消費しないよう制限します。
-        # CPUQuotaはコア数×100%で指定する必要があります。
-        # 割り当て可能スレッド数分を割り当てます。
-        CPUQuota = "${toString (config.local.cpuBudgetThreads * 100)}%";
-        MemoryHigh = "16G"; # ソフトリミット。これを超えるとメモリを積極的に解放します。
-        MemoryMax = "32G"; # ハードリミット。これぐらいで十分だろうという推定値。
-      };
-    };
+    services = lib.mapAttrs' (
+      name: _:
+      let
+        addr = addrOf name;
+      in
+      lib.nameValuePair "container@${name}" {
+        # NixOSコンテナモジュールが生成するpostStartは`ip addr add`/`ip route add`を使うため、
+        # systemd-networkdが先に設定済みの場合にEEXISTエラーで失敗します。
+        # 冪等にするために`2>/dev/null || true`を付けます。
+        # 実際の設定はsystemd-networkdに任せるため、
+        # postStartの内容が失敗していても問題ありません。
+        postStart = lib.mkForce ''
+          ifaceHost=ve-$INSTANCE
+          ip link set dev "$ifaceHost" up
+          ip addr add ${addr.host} dev "$ifaceHost" 2>/dev/null || true
+          ip route add ${addr.guest} dev "$ifaceHost" 2>/dev/null || true
+        '';
+        serviceConfig = {
+          # CIジョブがホストのリソースを過剰に消費しないよう制限します。
+          # CPUQuotaはコア数×100%で指定する必要があります。
+          # 割り当て可能スレッド数分を割り当てます。
+          CPUQuota = "${toString (config.local.cpuBudgetThreads * 100)}%";
+          MemoryHigh = "16G"; # ソフトリミット。これを超えるとメモリを積極的に解放します。
+          MemoryMax = "32G"; # ハードリミット。これぐらいで十分だろうという推定値。
+        };
+      }
+    ) runnerContainerDefs;
   };
 }

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -35,6 +35,9 @@ let
           isReadOnly = false;
         };
       };
+      # github-runnersモジュールは`ProtectSystem=strict`でサービスを強化するため、
+      # bind mountがrwでも`ReadWritePaths`に含まれないパスへは書き込めません。
+      extraRunnerOptions.serviceOverrides.ReadWritePaths = [ "/mnt/noa/cdn.ncaq.net" ];
     };
   };
   # コンテナ名からmachineAddressesのエントリを引きます。
@@ -56,6 +59,8 @@ let
       url,
       # 追加のbind-mounts。
       extraBindMounts ? { },
+      # 各ランナー定義にマージする追加オプション。
+      extraRunnerOptions ? { },
     }:
     let
       addr = addrOf name;
@@ -67,7 +72,7 @@ let
       privateUsers = "identity";
       hostAddress = addr.host;
       localAddress = addr.guest;
-      bindMounts = extraBindMounts // {
+      bindMounts = {
         "/etc/runner-registration-token" = {
           hostPath = config.sops.secrets."runner-registration-token".path;
           isReadOnly = true;
@@ -83,7 +88,8 @@ let
           hostPath = "/run/github-runner";
           isReadOnly = false;
         };
-      };
+      }
+      // extraBindMounts;
       config =
         { lib, ... }:
         {
@@ -118,7 +124,8 @@ let
                     tokenFile = "/etc/runner-registration-token";
                     inherit url;
                     extraEnvironment.ACTIONS_RUNNER_HOOK_JOB_STARTED = jobStartedHook;
-                  };
+                  }
+                  // extraRunnerOptions;
                 };
               in
               builtins.listToAttrs (map mkRunner runnerNumbers);

--- a/nixos/host/seminar/github-runner/package-lock.json
+++ b/nixos/host/seminar/github-runner/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dotfiles-github-runner",
+  "name": "github-runner",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dotfiles-github-runner",
+      "name": "github-runner",
       "version": "0.0.0",
       "devDependencies": {
         "@types/node": "24.13.2",

--- a/nixos/host/seminar/github-runner/package.json
+++ b/nixos/host/seminar/github-runner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotfiles-github-runner",
+  "name": "github-runner",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/nixos/host/seminar/machine-mapping.nix
+++ b/nixos/host/seminar/machine-mapping.nix
@@ -39,9 +39,13 @@ in
           host = "192.168.100.30";
           guest = "192.168.100.31";
         };
-        github-runner-x64 = {
+        github-runner-dotfiles-x64 = {
           host = "192.168.100.40";
           guest = "192.168.100.41";
+        };
+        github-runner-cdn-ncaq-net-x64 = {
+          host = "192.168.100.50";
+          guest = "192.168.100.51";
         };
         garage = {
           host = "192.168.100.60";

--- a/nixos/host/seminar/mackerel.nix
+++ b/nixos/host/seminar/mackerel.nix
@@ -296,18 +296,40 @@ in
             max_check_attempts
             ;
         };
-        github-runner-x64 = {
+        github-runner-dotfiles-x64 = {
           command = lib.getExe (
             pkgs.writeShellApplication {
-              name = "check-github-runner-x64";
+              name = "check-github-runner-dotfiles-x64";
               runtimeInputs = [ pkgs.iputils ];
               text = ''
-                runner_host=${config.machineAddresses.github-runner-x64.guest}
+                runner_host=${config.machineAddresses.github-runner-dotfiles-x64.guest}
                 if ping -c 1 -W 2 "$runner_host" > /dev/null 2>&1; then
-                  echo "GitHub Runner x64 OK"
+                  echo "GitHub Runner x64 dotfiles OK"
                   exit 0
                 else
-                  echo "GitHub Runner x64 CRITICAL: ping failed"
+                  echo "GitHub Runner x64 dotfiles CRITICAL: ping failed"
+                  exit 2
+                fi
+              '';
+            }
+          );
+          inherit
+            check_interval
+            max_check_attempts
+            ;
+        };
+        github-runner-cdn-ncaq-net-x64 = {
+          command = lib.getExe (
+            pkgs.writeShellApplication {
+              name = "check-github-runner-cdn-ncaq-net-x64";
+              runtimeInputs = [ pkgs.iputils ];
+              text = ''
+                runner_host=${config.machineAddresses.github-runner-cdn-ncaq-net-x64.guest}
+                if ping -c 1 -W 2 "$runner_host" > /dev/null 2>&1; then
+                  echo "GitHub Runner x64 cdn.ncaq.net OK"
+                  exit 0
+                else
+                  echo "GitHub Runner x64 cdn.ncaq.net CRITICAL: ping failed"
                   exit 2
                 fi
               '';


### PR DESCRIPTION
`cdn.ncaq.net`はCloudflare Pagesで配信していましたが、
Pagesには1ファイル25MiBの制限があり配信できないファイルがあるため、
seminarからCloudflare Tunnel経由で配信するように移行します。

`cdn.nix`を新設して以下を設定します。

- cloudflaredのingressに`cdn.ncaq.net`を追加
- Caddyの`:8082`(127.0.0.1バインド)で`/mnt/noa/cdn.ncaq.net`を静的配信
- Pagesの`_redirects`にあったリダイレクト定義を`redir`へ移植
- 配信ディレクトリをtmpfilesで`github-runner`所有として作成

コンテンツは`cdn.ncaq.net`リポジトリのGitHub Actionsが、
seminar上のセルフホストランナーから配信ディレクトリへrsyncします。
そのためランナーコンテナをリポジトリごとに分離して、
`mkRunnerContainer`関数で生成する構造に変更します。

コンテナごとに別々のvethアドレスが必要なため、
`machineAddresses`を`github-runner-dotfiles-x64`と、
`github-runner-cdn-ncaq-net-x64`の2エントリに分割します。
systemd-networkdのユニットとリソース制限もコンテナごとに生成して、
mackerelの死活監視も2コンテナそれぞれに分割します。
