### PR TITLE
feat: cdn.ncaq.netでディレクトリのファイル一覧を表示

### DIFF
--- a/nixos/host/seminar/cdn.nix
+++ b/nixos/host/seminar/cdn.nix
@@ -27,7 +27,8 @@ in
       redir /uBlockOrigin.txt https://raw.githubusercontent.com/ncaq/uBlacklistRule/master/uBlockOrigin.txt permanent
       # ファイルをそのまま配信。
       root * ${cdnRoot}
-      file_server
+      # browseによりディレクトリアクセス時はファイル一覧ページを表示します。
+      file_server browse
     '';
   };
 


### PR DESCRIPTION
トップページなどのディレクトリにアクセスした時に、
配信されているファイルの一覧を確認できるようにしたいので、
Caddyの`file_server`に`browse`を追加します。

Caddy組み込みのbrowseテンプレートには、
ファイルタイプ別アイコン・ソート・絞り込み検索・ダークモード対応などが備わっているため、
カスタムテンプレートなしでも十分な見た目になります。

https://claude.ai/code/session_01NLetsbYneERvdcP5Uzu7W1