### PR TITLE
feat: 指定のWindowsへ再起動する`reb-windows-{game,work}`コマンドを追加

### DIFF
--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -1,20 +1,54 @@
-_: {
+{ lib, pkgs, ... }:
+let
+  # 他のSSDに入っているWindows環境の一覧。
+  # Limineのメニューエントリ名とESPパーティションのGPT PARTUUIDの対応。
+  windows = {
+    game = {
+      entryName = "Windows Game";
+      espPartUuid = "4df43761-322e-44ef-9219-3b923e95d5b6";
+    };
+    work = {
+      entryName = "Windows Work";
+      espPartUuid = "386d2f0a-f36e-4678-93d1-84c7df8665a0";
+    };
+  };
+  # 次回起動時だけ指定のWindowsを起動するように設定して再起動するコマンド。
+  # LimineはsystemdのBoot Loader Interfaceのone-shot entry指定に対応しているため、
+  # `bootctl set-oneshot`でEFI変数`LoaderEntryOneShot`にエントリのツリーパスを書き込むと、
+  # Limineが次回起動時に一度だけそのエントリを自動選択します。
+  mkRebWindows =
+    name:
+    { entryName, ... }:
+    pkgs.writeShellApplication {
+      name = "reb-windows-${name}";
+      runtimeInputs = with pkgs; [
+        systemd
+      ];
+      text = ''
+        ${lib.getExe' pkgs.systemd "bootctl"} set-oneshot ${lib.escapeShellArg entryName}
+        systemctl reboot
+      '';
+    };
+in
+{
   boot = {
     loader = {
       limine = {
         # 他のSSDに入っているWindowsのブートマネージャにチェインロードします。
         # vfatのボリュームシリアルはGUID形式ではないため、
         # GPTパーティションGUID(PARTUUID)で指定します。
-        extraEntries = ''
-          /Windows Game
-              protocol: efi_chainload
-              path: guid(4df43761-322e-44ef-9219-3b923e95d5b6):/EFI/Microsoft/Boot/bootmgfw.efi
-
-          /Windows Work
-              protocol: efi_chainload
-              path: guid(386d2f0a-f36e-4678-93d1-84c7df8665a0):/EFI/Microsoft/Boot/bootmgfw.efi
-        '';
+        extraEntries = lib.concatMapAttrsStringSep "\n" (
+          _:
+          { entryName, espPartUuid }:
+          ''
+            /${entryName}
+                protocol: efi_chainload
+                path: guid(${espPartUuid}):/EFI/Microsoft/Boot/bootmgfw.efi
+          ''
+        ) windows;
       };
     };
   };
+
+  environment.systemPackages = lib.mapAttrsToList mkRebWindows windows;
 }

--- a/nixos/host/bullet/boot.nix
+++ b/nixos/host/bullet/boot.nix
@@ -25,7 +25,7 @@ let
         systemd
       ];
       text = ''
-        ${lib.getExe' pkgs.systemd "bootctl"} set-oneshot ${lib.escapeShellArg entryName}
+        bootctl set-oneshot ${lib.escapeShellArg entryName}
         systemctl reboot
       '';
     };


### PR DESCRIPTION
再起動してWindowsを起動したい時に、
毎回Limineのメニューで手動選択するのが面倒でした。

そこで次回起動時だけ指定のWindowsエントリを起動するコマンドを追加します。

`Limine 12.4.0`はsystemdのBoot Loader Interfaceの、
one-shot entry指定(`LoaderEntryOneShot`)に対応しているため、
`bootctl set-oneshot`でエントリのツリーパスをEFI変数に書き込んでから、
`systemctl reboot`するだけで実現できます。
`efibootmgr --bootnext`でLimineを迂回する方式と違って、
Limineのメニュー体系を経由するので`remember_last_entry`とも整合して、
Windows Updateの複数回再起動でもWindowsが選択され続けます。

エントリ名とESPのPARTUUIDは単一のattrset `windows`にまとめて、
Limineの`extraEntries`とコマンド定義の両方をそこから生成することで、
エントリ名の変更でコマンド側と食い違わないようにします。
