### PR TITLE
feat: ゲームコントローラのサポートを追加

### DIFF
--- a/nixos/gaming/controller.nix
+++ b/nixos/gaming/controller.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }: {
+  hardware.xpadneo.enable = true;
+  environment.systemPackages = with pkgs; [
+    dualsensectl
+  ];
+  # Switch Proコントローラはsteam-hardware経由で設定済みなので設定不要。
+  # ジョイコンの合体などが必要になったらjoycondが必要。
+}

--- a/nixos/gaming/lutris.nix
+++ b/nixos/gaming/lutris.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  # LutrisがProton(umu)経由で起動するゲームでもgamemodeが効くように、
+  # `libgamemodeauto.so`のRUNPATHを修正する。
+  nixpkgs.overlays = [ (import ../../lib/gamemode-lib-rpath-overlay.nix) ];
+
+  environment.systemPackages = with pkgs; [
+    # Steam外部も含めたアプリをSteamのProtonを使って管理・起動するためのツール。
+    # FHS環境にgamemodeのライブラリを追加して、
+    # gamemodeautoの`dlopen`が`libgamemode.so`を見つけられるようにする。
+    (lutris.override { extraLibraries = pkgs: [ pkgs.gamemode.lib ]; })
+  ];
+}

--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -1,9 +1,5 @@
 { pkgs, username, ... }:
 {
-  # LutrisがProton(umu)経由で起動するゲームでもgamemodeが効くように、
-  # `libgamemodeauto.so`のRUNPATHを修正する。
-  nixpkgs.overlays = [ (import ../../lib/gamemode-lib-rpath-overlay.nix) ];
-
   programs = {
     steam = {
       enable = true;
@@ -31,82 +27,4 @@
   # gamemodeが同梱するpolkitルールは`gamemode`グループのユーザにだけ認証なしで許可するので、
   # ユーザをグループに追加する。
   users.users.${username}.extraGroups = [ "gamemode" ];
-
-  # LightDMはWaylandセッションを起動できず、
-  # X11上のネスト起動ではHDRなどを通せないため、
-  # 埋め込み(DRM)モードのgamescopeセッションをsystemdサービスとして定義する。
-  # nixpkgsの`services.cage`(kioskモジュール)と同じパターンで、
-  # `PAMName`によるPAM経由の起動でlogindセッションを登録して、
-  # ディスプレイマネージャなしでDRMマスターを取得する。
-  # `wantedBy`を指定していないので自動起動はせず、
-  # `steamos`コマンド(後述)で起動した時だけVT4に立ち上がる。
-  # X11のセッションは別VTでそのまま並存して、
-  # gamescopeを終了するとサービスも終了する。
-  systemd.services.steam-gamescope = {
-    description = "Steam gamescope session (embedded DRM) on tty4";
-    after = [
-      "getty@tty4.service"
-      "systemd-logind.service"
-      "systemd-user-sessions.service"
-    ];
-    wants = [
-      "dbus.socket"
-      "systemd-logind.service"
-    ];
-    conflicts = [ "getty@tty4.service" ];
-    # ゲームプレイ中に`nixos-rebuild switch`してもセッションを殺さない。
-    restartIfChanged = false;
-    unitConfig.ConditionPathExists = "/dev/tty4";
-    serviceConfig = {
-      # `+`プレフィックスでroot権限でVTを切り替えてから起動する。
-      ExecStartPre = "+${pkgs.kbd}/bin/chvt 4";
-      ExecStart = "/run/current-system/sw/bin/steam-gamescope";
-      User = username;
-      IgnoreSIGPIPE = "no";
-      # (a)gettyを置き換えるためutmpにセッションを記録する。
-      UtmpIdentifier = "tty4";
-      UtmpMode = "user";
-      TTYPath = "/dev/tty4";
-      TTYReset = "yes";
-      TTYVHangup = "yes";
-      TTYVTDisallocate = "yes";
-      # VTを制御できない場合は起動を失敗させる。
-      StandardInput = "tty-fail";
-      StandardOutput = "journal";
-      StandardError = "journal";
-      # PAM経由でlogindセッションを登録する。
-      PAMName = "login";
-      # systemd v254以降のpam_systemdはローカルセッションへ、
-      # ambient capabilityとして`CAP_WAKE_ALARM`をデフォルトで付与する。
-      # それがsteam(buildFHSEnvのbwrap)まで伝播すると、
-      # bwrapが`Unexpected capabilities but not setuid`エラーで即死してSteamが起動しない。
-      # https://github.com/containers/bubblewrap/issues/380
-      # bounding setから除外しておけば、
-      # PAMセッション開始後にsystemdがambient setを再適用する際に確実に落とされる。
-      CapabilityBoundingSet = "~CAP_WAKE_ALARM";
-    };
-  };
-
-  # `steam-gamescope.service`に限って一般ユーザがpolkit認証なしで操作できるようにして、
-  # `steamos`コマンドをsudoなしで打てるようにする。
-  security.polkit.extraConfig = ''
-    polkit.addRule(function(action, subject) {
-      if (action.id == "org.freedesktop.systemd1.manage-units" &&
-          action.lookup("unit") == "steam-gamescope.service" &&
-          subject.user == "${username}") {
-        return polkit.Result.YES;
-      }
-    });
-  '';
-
-  environment.systemPackages = with pkgs; [
-    # Steam外部も含めたアプリをSteamのProtonを使って管理・起動するためのツール。
-    # FHS環境にgamemodeのライブラリを追加して、
-    # gamemodeautoの`dlopen`が`libgamemode.so`を見つけられるようにする。
-    (lutris.override { extraLibraries = pkgs: [ pkgs.gamemode.lib ]; })
-    # gamescopeセッションを起動する短縮コマンド。
-    (writeShellScriptBin "steamos" ''
-      exec systemctl start steam-gamescope.service
-    '')
-  ];
 }

--- a/nixos/gaming/steamos.nix
+++ b/nixos/gaming/steamos.nix
@@ -1,0 +1,76 @@
+{ pkgs, username, ... }:
+{
+  # LightDMはWaylandセッションを起動できず、
+  # X11上のネスト起動ではHDRなどを通せないため、
+  # 埋め込み(DRM)モードのgamescopeセッションをsystemdサービスとして定義する。
+  # nixpkgsの`services.cage`(kioskモジュール)と同じパターンで、
+  # `PAMName`によるPAM経由の起動でlogindセッションを登録して、
+  # ディスプレイマネージャなしでDRMマスターを取得する。
+  # `wantedBy`を指定していないので自動起動はせず、
+  # `steamos`コマンド(後述)で起動した時だけVT4に立ち上がる。
+  # X11のセッションは別VTでそのまま並存して、
+  # gamescopeを終了するとサービスも終了する。
+  systemd.services.steam-gamescope = {
+    description = "Steam gamescope session (embedded DRM) on tty4";
+    after = [
+      "getty@tty4.service"
+      "systemd-logind.service"
+      "systemd-user-sessions.service"
+    ];
+    wants = [
+      "dbus.socket"
+      "systemd-logind.service"
+    ];
+    conflicts = [ "getty@tty4.service" ];
+    # ゲームプレイ中に`nixos-rebuild switch`してもセッションを殺さない。
+    restartIfChanged = false;
+    unitConfig.ConditionPathExists = "/dev/tty4";
+    serviceConfig = {
+      # `+`プレフィックスでroot権限でVTを切り替えてから起動する。
+      ExecStartPre = "+${pkgs.kbd}/bin/chvt 4";
+      ExecStart = "/run/current-system/sw/bin/steam-gamescope";
+      User = username;
+      IgnoreSIGPIPE = "no";
+      # (a)gettyを置き換えるためutmpにセッションを記録する。
+      UtmpIdentifier = "tty4";
+      UtmpMode = "user";
+      TTYPath = "/dev/tty4";
+      TTYReset = "yes";
+      TTYVHangup = "yes";
+      TTYVTDisallocate = "yes";
+      # VTを制御できない場合は起動を失敗させる。
+      StandardInput = "tty-fail";
+      StandardOutput = "journal";
+      StandardError = "journal";
+      # PAM経由でlogindセッションを登録する。
+      PAMName = "login";
+      # systemd v254以降のpam_systemdはローカルセッションへ、
+      # ambient capabilityとして`CAP_WAKE_ALARM`をデフォルトで付与する。
+      # それがsteam(buildFHSEnvのbwrap)まで伝播すると、
+      # bwrapが`Unexpected capabilities but not setuid`エラーで即死してSteamが起動しない。
+      # https://github.com/containers/bubblewrap/issues/380
+      # bounding setから除外しておけば、
+      # PAMセッション開始後にsystemdがambient setを再適用する際に確実に落とされる。
+      CapabilityBoundingSet = "~CAP_WAKE_ALARM";
+    };
+  };
+
+  # `steam-gamescope.service`に限って一般ユーザがpolkit認証なしで操作できるようにして、
+  # `steamos`コマンドをsudoなしで打てるようにする。
+  security.polkit.extraConfig = ''
+    polkit.addRule(function(action, subject) {
+      if (action.id == "org.freedesktop.systemd1.manage-units" &&
+          action.lookup("unit") == "steam-gamescope.service" &&
+          subject.user == "${username}") {
+        return polkit.Result.YES;
+      }
+    });
+  '';
+
+  environment.systemPackages = with pkgs; [
+    # gamescopeセッションを起動する短縮コマンド。
+    (writeShellScriptBin "steamos" ''
+      exec systemctl start steam-gamescope.service
+    '')
+  ];
+}

--- a/nixos/native-linux/bluetooth.nix
+++ b/nixos/native-linux/bluetooth.nix
@@ -1,0 +1,4 @@
+{
+  hardware.bluetooth.enable = true;
+  services.blueman.enable = true;
+}


### PR DESCRIPTION
ゲームコントローラをNixOSホストで使えるようにするための設定をまとめて追加します。

ワイヤレスコントローラの接続手段としてBluetoothを有効化して、
ペアリング操作をGUIから行えるように`blueman`も有効にします。

コントローラ本体のサポートとして`nixos/gaming/controller.nix`を新設します。
Xboxコントローラの無線接続を改善する`xpadneo`ドライバを有効にして、
DualSense系コントローラの設定用CLIである`dualsensectl`を導入します。
Switch Proコントローラは`steam-hardware`のudevルールで既に対応済みなので、
追加の設定は不要です。

また肥大化していた`steam.nix`から、
gamescopeセッション(steamos)とLutrisの設定をそれぞれ別ファイルに分離して、
gamingディレクトリ内の見通しを良くします。
