### PR TITLE
fix(comfyui): systemd-socket-proxydのパスを`lib/systemd/`に修正

### DIFF
--- a/nixos/host/bullet/comfyui.nix
+++ b/nixos/host/bullet/comfyui.nix
@@ -123,7 +123,9 @@ in
         requires = [ "container@comfyui.service" ];
         after = [ "container@comfyui.service" ];
         serviceConfig = {
-          ExecStart = "${lib.getExe' pkgs.systemd "systemd-socket-proxyd"} ${localAddress}:${toString port}";
+          # systemd-socket-proxydは`bin/`ではなく`lib/systemd/`に配置されるため、
+          # `lib.getExe'`は使えない。
+          ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${localAddress}:${toString port}";
           DynamicUser = true;
           PrivateTmp = true;
         };


### PR DESCRIPTION
`systemd-socket-proxyd`は`bin/`ではなく`lib/systemd/`に配置されるため、
`lib.getExe'`が生成する`bin/systemd-socket-proxyd`は存在せず、
`comfyui-proxy.service`が203/EXECで起動に失敗していました。
これによりソケットアクティベーションによるオンデマンド起動が、
壊れていたのを修正します。
