### PR TITLE
fix(comfyui): Qwen系モデル実行時のサーバクラッシュを修正

### DIFF
--- a/nixos/host/bullet/comfyui.nix
+++ b/nixos/host/bullet/comfyui.nix
@@ -94,6 +94,11 @@ in
           dataDir = "/var/lib/comfyui";
           # コンテナ内のfirewallを開ける。到達できるのはvethを持つホストのみ。
           openFirewall = true;
+          # xformers 0.0.30のflash-attentionカーネルはBlackwell(sm_120)のカーネルイメージを含まず、
+          # Qwen系モデルのサンプリング開始時に、
+          # `CUDA error: no kernel image is available for execution on the device`
+          # でクラッシュするためPyTorch組み込みのSDPAを使う。
+          extraArgs = [ "--use-pytorch-cross-attention" ];
         };
       };
   };


### PR DESCRIPTION
Qwen-Imageなどを使うワークフローを実行すると、
サンプリング開始の瞬間にComfyUIが以下のエラーで即クラッシュして、
フロントエンドが「Reconnecting」になっていました。

```
CUDA error (flash-attention/hopper/flash_fwd_launch_template.h:175):
no kernel image is available for execution on the device
```

原因はattention実装として使われていた`xformers 0.0.30`に同梱の、
flash-attentionカーネルがBlackwell(sm_120)のカーネルイメージを含まないことです。
単純なSD系ワークフローはattentionの形状が違い別カーネルで処理されるため動きますが、
Qwen系のattention形状はflash-attentionカーネルにディスパッチされて即死します。

`--use-pytorch-cross-attention`でPyTorch組み込みのSDPAに切り替えます。
`PyTorch 2.10.0`+`cu128`はBlackwellにネイティブ対応しているため問題ありません。
Qwen-Image fp8 + illustration LoRAのワークフローが、
完走して画像が生成されることを確認済みです。
