### PR TITLE
feat(comfyui): アニメ・ゲーム風画像生成環境を宣言的に構築

### DIFF
--- a/nixos/host/bullet/comfyui/autocomplete-plus-new-frontend.patch
+++ b/nixos/host/bullet/comfyui/autocomplete-plus-new-frontend.patch
@@ -1,0 +1,104 @@
+diff --git a/web/js/autocomplete.js b/web/js/autocomplete.js
+index f87f680..7484535 100644
+--- a/web/js/autocomplete.js
++++ b/web/js/autocomplete.js
+@@ -385,7 +385,8 @@ function insertTagToTextArea(inputElement, tagDataToInsert) {
+ // --- Autocomplete UI Class ---
+ 
+ class AutocompleteUI {
+-    constructor() {
++    constructor(onAfterInsert) {
++        this.onAfterInsert = onAfterInsert;
+         this.root = document.createElement('div'); // Use table instead of div
+         this.root.id = 'autocomplete-plus-root';
+ 
+@@ -724,6 +725,10 @@ class AutocompleteUI {
+         insertTagToTextArea(this.target, selectedTag);
+ 
+         this.hide();
++
++        // Cancel any pending debounce timer so the just-inserted tag doesn't
++        // re-trigger autocomplete display (e.g. when autoInsertComma is disabled).
++        this.onAfterInsert?.();
+     }
+ 
+     /**
+@@ -885,21 +890,21 @@ class AutocompleteUI {
+         const body = document.body;
+         if (!body) return 0;
+ 
+-        const tempNode = document.createElement(nodeName);
++        // Use a div rather than the original nodeName (which may be "TEXTAREA") so that
++        // MutationObservers watching for textarea additions (e.g. syntax-highlighting
++        // extensions) are not triggered by this transient measurement node.
++        // Line-height under "normal" is a font metric and is identical across element types.
++        const tempNode = document.createElement('div');
+         tempNode.innerHTML = "&nbsp;";
+         Object.assign(tempNode.style, {
+             fontSize: computedStyle.fontSize,
+             fontFamily: computedStyle.fontFamily,
+             padding: "0",
+             position: "absolute",
++            visibility: "hidden",
+         });
+         body.appendChild(tempNode);
+ 
+-        // Make sure textarea has only 1 row
+-        if (tempNode instanceof HTMLTextAreaElement) {
+-            tempNode.rows = 1;
+-        }
+-
+         // Assume the height of the element is the line-height
+         const height = tempNode.offsetHeight;
+         body.removeChild(tempNode);
+@@ -939,9 +944,14 @@ class AutocompleteUI {
+ // --- Autocomplete Event Handling Class ---
+ export class AutocompleteEventHandler {
+     constructor() {
+-        this.autocompleteUI = new AutocompleteUI();
+-        this.keyDownWithModifier = new Map(); // Keep track of keydown events with modifiers
+         this._debounceTimer = null; // Timer ID for debounced search
++        this.autocompleteUI = new AutocompleteUI(() => {
++            // Cancel pending debounce when autocomplete inserts a tag itself,
++            // so the just-inserted text doesn't immediately re-trigger suggestions.
++            clearTimeout(this._debounceTimer);
++            this._debounceTimer = null;
++        });
++        this.keyDownWithModifier = new Map(); // Keep track of keydown events with modifiers
+     }
+ 
+     /**
+@@ -963,9 +973,9 @@ export class AutocompleteEventHandler {
+     }
+ 
+     /**
+-     * 
+-     * @param {InputEvent} event 
+-     * @returns 
++     *
++     * @param {InputEvent} event
++     * @returns
+      */
+     handleInput(event) {
+         if (!settingValues.enabled) return;
+@@ -975,6 +985,10 @@ export class AutocompleteEventHandler {
+         if (partialTag.length <= 0) {
+             clearTimeout(this._debounceTimer); // Cancel pending debounced search
+             this.autocompleteUI.hide();
++        } else {
++            // Also trigger from input events so suggestions appear even when keyup
++            // is intercepted by the host application (e.g. recent ComfyUI frontend).
++            this._triggerUpdateDisplay(event.target);
+         }
+     }
+ 
+@@ -1023,6 +1037,9 @@ export class AutocompleteEventHandler {
+                         insertTagToTextArea(event.target, this.autocompleteUI.getSelectedTagData());
+                     }
+                     this.autocompleteUI.hide();
++                    // Cancel any debounce started by the input event that insertTagToTextArea fired.
++                    clearTimeout(this._debounceTimer);
++                    this._debounceTimer = null;
+                     break;
+                 case 'F1':
+                     event.preventDefault();

--- a/nixos/host/bullet/comfyui/caddy.nix
+++ b/nixos/host/bullet/comfyui/caddy.nix
@@ -1,0 +1,24 @@
+# `https://comfy-ui.localhost.ncaq.net`でComfyUIにアクセスできるようにするリバースプロキシ。
+# DNSはCloudflare側でループバックアドレスを返すため、
+# アクセスは自マシンのループバック内で完結する。
+# 証明書はacmeとDNS-01により取得したLet's Encrypt証明書を使う。
+# ローカルホストにのみbindして外部公開はしない。
+{ config, ... }:
+let
+  port = config.containers.comfyui.config.services.comfyui.port;
+in
+{
+  services.caddy = {
+    enable = true;
+    virtualHosts."comfy-ui.localhost.ncaq.net" = {
+      useACMEHost = "comfy-ui.localhost.ncaq.net";
+      extraConfig = ''
+        # `bind localhost`だとCaddyは127.0.0.1にしかbindしない一方、
+        # DNSはAAAAレコードの::1を返すため接続できなくなる。
+        # 両方のループバックアドレスに明示的にbindする。
+        bind 127.0.0.1 ::1
+        reverse_proxy http://localhost:${toString port}
+      '';
+    };
+  };
+}

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -1,6 +1,6 @@
+# ComfyUI本体を隔離して動かすNixOS Containersの定義。
 {
   lib,
-  pkgs,
   inputs,
   ...
 }:
@@ -28,6 +28,7 @@ let
     "/dev/nvidia0"
     "/dev/nvidiactl"
   ];
+  dataDir = "/var/lib/comfyui";
 in
 {
   # コンテナ内と同じIDでホスト側にもユーザとグループを作る。
@@ -67,8 +68,8 @@ in
           isReadOnly = true;
         };
         # モデルやカスタムノードなどのデータはホスト側に永続化する。
-        "/var/lib/comfyui" = {
-          hostPath = "/var/lib/comfyui";
+        ${dataDir} = {
+          hostPath = dataDir;
           isReadOnly = false;
         };
       };
@@ -91,7 +92,7 @@ in
           # ホストからvethを通してアクセスするので全インターフェースでlistenする。
           # privateNetworkなのでLANには露出しない。
           listenAddress = "0.0.0.0";
-          dataDir = "/var/lib/comfyui";
+          inherit dataDir;
           # コンテナ内のfirewallを開ける。到達できるのはvethを持つホストのみ。
           openFirewall = true;
           # xformers 0.0.30のflash-attentionカーネルはBlackwell(sm_120)のカーネルイメージを含まず、
@@ -115,62 +116,6 @@ in
     # NetworkManagerがコンテナのvethを管理しようとして競合するのを防ぐ。
     networkmanager.unmanaged = [ "interface-name:ve-*" ];
   };
-  # GPUを触るサービスを常時起動させたくないので、
-  # ソケットアクティベーションによるオンデマンド起動にする。
-  # `comfyui-proxy.socket`がホスト側でlistenし、
-  # 初回アクセス時にsystemd-socket-proxyd経由でコンテナごと起動する。
-  # アイドル時の自動停止は誤爆が怖いので設定しない。
-  # 停止したい時は手動で`systemctl stop container@comfyui.service`する。
-  systemd = {
-    services = {
-      comfyui-proxy = {
-        description = "systemd-socket-proxyd for on-demand ComfyUI activation";
-        requires = [ "container@comfyui.service" ];
-        after = [ "container@comfyui.service" ];
-        serviceConfig = {
-          # systemd-socket-proxydは`bin/`ではなく`lib/systemd/`に配置されるため、
-          # `lib.getExe'`は使えない。
-          ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${localAddress}:${toString port}";
-          DynamicUser = true;
-          PrivateTmp = true;
-        };
-      };
-      "container@comfyui" = {
-        # コンテナが起動してもComfyUIがlistenするまでは時間がかかり、
-        # その前にproxydが接続すると初回リクエストが失敗してしまう。
-        # HTTP疎通を確認してから起動完了扱いにする。
-        postStart = ''
-          until ${lib.getExe pkgs.curl} --fail --silent --output /dev/null "http://${localAddress}:${toString port}/"; do
-            ${pkgs.coreutils}/bin/sleep 1
-          done
-        '';
-      };
-    };
-    sockets.comfyui-proxy = {
-      description = "Socket for on-demand ComfyUI activation";
-      listenStreams = [
-        "127.0.0.1:${toString port}"
-        "[::1]:${toString port}"
-      ];
-      wantedBy = [ "sockets.target" ];
-    };
-  };
-  # `https://comfy-ui.localhost.ncaq.net`でComfyUIにアクセスできるようにするリバースプロキシ。
-  # DNSはCloudflare側でループバックアドレスを返すため、
-  # アクセスは自マシンのループバック内で完結する。
-  # 証明書はacmeとDNS-01により取得したLet's Encrypt証明書を使う。
-  # ローカルホストにのみbindして外部公開はしない。
-  services.caddy = {
-    enable = true;
-    virtualHosts."comfy-ui.localhost.ncaq.net" = {
-      useACMEHost = "comfy-ui.localhost.ncaq.net";
-      extraConfig = ''
-        # `bind localhost`だとCaddyは127.0.0.1にしかbindしない一方、
-        # DNSはAAAAレコードの::1を返すため接続できなくなる。
-        # 両方のループバックアドレスに明示的にbindする。
-        bind 127.0.0.1 ::1
-        reverse_proxy http://localhost:${toString port}
-      '';
-    };
-  };
+  # bind mountするデータディレクトリをホスト側で用意する。
+  systemd.tmpfiles.rules = [ "d ${dataDir} 0750 comfyui comfyui - -" ];
 }

--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -1,0 +1,86 @@
+# ComfyUIのカスタムノードを宣言的に導入する。
+#
+# `services.comfyui.customNodes`の属性名が、
+# `custom_nodes/`配下のディレクトリ名になり、
+# サービス起動時にNix storeからシンボリックリンクで配置される。
+#
+# comfyui-nixのPython環境には主要カスタムノードの依存
+# (ultralytics, segment-anything, opencv4など)が同梱されているので、
+# ここではソースを配置するだけでよい。
+{ config, pkgs, ... }:
+let
+  dataDir = config.containers.comfyui.config.services.comfyui.dataDir;
+  # ComfyUI-Autocomplete-PlusがタグCSVをダウンロードする先。
+  # Nix storeは読み取り専用なので可変領域に逃がす。
+  autocompletePlusDataDir = "${dataDir}/autocomplete-plus";
+in
+{
+  containers.comfyui.config = {
+    services.comfyui.customNodes = {
+      # FaceDetailerなどディテール修復ノード群。ADetailer相当。
+      # comfyui-nixがパッケージ済みのものを使う。
+      "ComfyUI-Impact-Pack" = pkgs.comfyui-custom-nodes.impact-pack;
+      # Power Lora Loaderなどワークフロー整理のノード群。
+      # comfyui-nixがパッケージ済みのものを使う。
+      "rgthree-comfy" = pkgs.comfyui-custom-nodes.rgthree-comfy;
+      # UltralyticsDetectorProvider(YOLOによる顔検出)を提供する。
+      # FaceDetailerに検出器を渡すために必要。
+      "ComfyUI-Impact-Subpack" = pkgs.fetchFromGitHub {
+        owner = "ltdrdata";
+        repo = "ComfyUI-Impact-Subpack";
+        tag = "1.3.4";
+        hash = "sha256-BHtfkaqCPf/YXfGbF/xyryjt+M8izkdoUAKNJLfyvqI=";
+      };
+      # danbooruタグのオートコンプリート。
+      # 日本語からの検索とpost count表示に対応していて、
+      # メジャーなタグかどうかを確認しながら入力できる。
+      "ComfyUI-Autocomplete-Plus" = pkgs.stdenv.mkDerivation (finalAttrs: {
+        pname = "comfyui-autocomplete-plus";
+        version = "1.11.0";
+        src = pkgs.fetchFromGitHub {
+          owner = "newtextdoc1111";
+          repo = "ComfyUI-Autocomplete-Plus";
+          tag = "v${finalAttrs.version}";
+          hash = "sha256-MjhGd38G5Wz46t1AchTe/IqmTzVO43mlXPDHie5i3EE=";
+        };
+        # 新しいComfyUIフロントエンド(1.43以降)では、
+        # keyupの時点でカーソル位置がリセットされていて候補が表示されない。
+        # upstreamのissueコメントで提示されている修正パッチを適用する。
+        # https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus/issues/73#issuecomment-4761276962
+        # 修正がリリースされたらこのパッチは削除する。
+        #
+        # なおパッチとは別に、
+        # フロントエンド設定のVue DOMモード(Vueノード描画)が有効だと、
+        # この拡張はテキスト欄にattachできず一切動作しないので無効にしておくこと。
+        patches = [ ./autocomplete-plus-new-frontend.patch ];
+        # タグCSVを起動時に自ディレクトリ配下へダウンロードする作りだが、
+        # Nix storeは読み取り専用なので、書き込み先を可変領域に差し替える。
+        postPatch = ''
+          substituteInPlace modules/api.py modules/downloader.py \
+            --replace-fail \
+            'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "data"))' \
+            '"${autocompletePlusDataDir}/data"'
+          substituteInPlace modules/downloader.py \
+            --replace-fail \
+            'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", CSV_META_FILE_NAME))' \
+            'os.path.join("${autocompletePlusDataDir}", CSV_META_FILE_NAME)'
+        '';
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out
+          cp -r . $out/
+          runHook postInstall
+        '';
+        meta = {
+          description = "Danbooru tag autocomplete with Japanese search support for ComfyUI";
+          homepage = "https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus";
+          license = pkgs.lib.licenses.mit;
+        };
+      });
+    };
+  };
+  systemd.tmpfiles.rules = [
+    "d ${autocompletePlusDataDir} 0755 comfyui comfyui - -"
+    "d ${autocompletePlusDataDir}/data 0755 comfyui comfyui - -"
+  ];
+}

--- a/nixos/host/bullet/comfyui/default.nix
+++ b/nixos/host/bullet/comfyui/default.nix
@@ -1,0 +1,4 @@
+{ importDirModules, ... }:
+{
+  imports = importDirModules ./.;
+}

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -22,13 +22,13 @@ let
   fetchHuggingface =
     {
       owner,
-      model,
+      repo,
       rev,
       file,
       hash,
     }:
     pkgs.fetchurl {
-      url = "https://huggingface.co/${owner}/${model}/resolve/${rev}/${file}";
+      url = "https://huggingface.co/${owner}/${repo}/resolve/${rev}/${file}";
       inherit hash;
     };
   # 属性名は`models/`配下のディレクトリ名、
@@ -39,7 +39,7 @@ let
       # CivitAIオリジナルの非公式ミラーなので消失リスクがある。
       "waiIllustriousSDXL_v170.safetensors" = fetchHuggingface {
         owner = "LyliaEngine";
-        model = "waiIllustriousSDXL_v170";
+        repo = "waiIllustriousSDXL_v170";
         rev = "5ef4e2da7173a160ad04aebcaa2fdcd6d20ed792";
         file = "waiIllustriousSDXL_v170.safetensors";
         hash = "sha256-8Rawx4/0QUZ7DNyPGTbh7RjqMemZfHsTKxuNtTPwvQQ=";
@@ -48,7 +48,7 @@ let
       # 画質とタグ網羅性に強い。非商用ライセンス。
       "NoobAI-XL-v1.1.safetensors" = fetchHuggingface {
         owner = "Laxhar";
-        model = "noobai-XL-1.1";
+        repo = "noobai-XL-1.1";
         rev = "814a274af2b8097c0828819d561ec74c7d0c6cea";
         file = "NoobAI-XL-v1.1.safetensors";
         hash = "sha256-ZoHo5LE0yB8WUzrO2w1AbX5eNm4WJLQQUXjGTQCwXVE=";
@@ -56,7 +56,7 @@ let
       # SDXLをアニメ画像で再学習したモデル。タグ設計が分かりやすい。
       "animagine-xl-4.0.safetensors" = fetchHuggingface {
         owner = "cagliostrolab";
-        model = "animagine-xl-4.0";
+        repo = "animagine-xl-4.0";
         rev = "2b7c1b397761bf5bd3cc42e5b39ec99314a75a96";
         file = "animagine-xl-4.0.safetensors";
         hash = "sha256-HVtD/3W2q1mFAtTHedL7+j3OylHGDDtglkCmB3IzORY=";
@@ -64,7 +64,7 @@ let
       # Illustrious系の公式ベースモデル。素の状態やマージ元として。
       "Illustrious-XL-v2.0.safetensors" = fetchHuggingface {
         owner = "OnomaAIResearch";
-        model = "Illustrious-XL-v2.0";
+        repo = "Illustrious-XL-v2.0";
         rev = "69459c1fe6f46db41ab31e6114f05acc0e06bcaa";
         file = "Illustrious-XL-v2.0.safetensors";
         hash = "sha256-wqGj6qE9TBB9x+AMP+gwyrQnqgJjYnQOoJR0WzQiozE=";
@@ -75,7 +75,7 @@ let
       # openpose/lineart/tileなど複数のコントロールをこれ1つで扱える。
       "controlnet-union-sdxl-promax.safetensors" = fetchHuggingface {
         owner = "xinsir";
-        model = "controlnet-union-sdxl-1.0";
+        repo = "controlnet-union-sdxl-1.0";
         rev = "801a4a3fa3d4c936f4feea95b98607bc6726f80c";
         file = "diffusion_pytorch_model_promax.safetensors";
         hash = "sha256-n64uUMtDG/y+BYIrWewiKN9UXvJ/cR3qiUnp9O2ffNw=";
@@ -86,7 +86,7 @@ let
       # FaceDetailerでの顔検出に使うYOLOモデル。
       "face_yolov8m.pt" = fetchHuggingface {
         owner = "Bingsu";
-        model = "adetailer";
+        repo = "adetailer";
         rev = "53cc19de382014514d9d4038601d261a7faa9b7b";
         file = "face_yolov8m.pt";
         hash = "sha256-cXkjwZs/S79SULco8fprLLcqM67R0jbqnK8OIa2UPl8=";
@@ -96,7 +96,7 @@ let
       # アニメ絵向けの定番アップスケーラ。
       "4x-AnimeSharp.safetensors" = fetchHuggingface {
         owner = "Kim2091";
-        model = "AnimeSharp";
+        repo = "AnimeSharp";
         rev = "7696d95ced82b0c1f2a41f6ac73336133f0a90e1";
         file = "4x-AnimeSharp.safetensors";
         hash = "sha256-f8YAVNKRV5rKxPtTfv2RyAYRy9KB74uQ9DQEjMExOzk=";

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -1,0 +1,136 @@
+# ComfyUIの`models/`配下に宣言的に配置するモデルファイル群。
+#
+# モデルはNix storeへfetchurlで取得して、
+# ComfyUIのmodelsディレクトリへシンボリックリンクで配置する。
+# storeのパスはホストのシステムクロージャから参照されるのでGCされない。
+# コンテナはephemeralだがホスト側のtmpfilesルールなので再起動しても残る。
+#
+# CivitAIのダウンロードURLはAPIキーが必要なことがあるため、
+# 認証なしで安定して取得できるHugging FaceのURLのみを使う。
+# リポジトリの更新でハッシュがずれないように、
+# URLは`resolve/main`ではなくcommit hashで固定する。
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  dataDir = config.containers.comfyui.config.services.comfyui.dataDir;
+  # Hugging Faceからモデルファイルを取得するヘルパー。
+  # revにはリポジトリのcommit hashを指定する。
+  fetchHuggingface =
+    {
+      owner,
+      model,
+      rev,
+      file,
+      hash,
+    }:
+    pkgs.fetchurl {
+      url = "https://huggingface.co/${owner}/${model}/resolve/${rev}/${file}";
+      inherit hash;
+    };
+  # 属性名は`models/`配下のディレクトリ名、
+  # その中の属性名が配置するファイル名に対応する。
+  models = {
+    checkpoints = {
+      # Illustrious-XLベースの人気マージモデル。日常使いの定番。
+      # CivitAIオリジナルの非公式ミラーなので消失リスクがある。
+      "waiIllustriousSDXL_v170.safetensors" = fetchHuggingface {
+        owner = "LyliaEngine";
+        model = "waiIllustriousSDXL_v170";
+        rev = "5ef4e2da7173a160ad04aebcaa2fdcd6d20ed792";
+        file = "waiIllustriousSDXL_v170.safetensors";
+        hash = "sha256-8Rawx4/0QUZ7DNyPGTbh7RjqMemZfHsTKxuNtTPwvQQ=";
+      };
+      # Illustrious-XLにdanbooru/e621約1300万枚を追加学習したモデル。
+      # 画質とタグ網羅性に強い。非商用ライセンス。
+      "NoobAI-XL-v1.1.safetensors" = fetchHuggingface {
+        owner = "Laxhar";
+        model = "noobai-XL-1.1";
+        rev = "814a274af2b8097c0828819d561ec74c7d0c6cea";
+        file = "NoobAI-XL-v1.1.safetensors";
+        hash = "sha256-ZoHo5LE0yB8WUzrO2w1AbX5eNm4WJLQQUXjGTQCwXVE=";
+      };
+      # SDXLをアニメ画像で再学習したモデル。タグ設計が分かりやすい。
+      "animagine-xl-4.0.safetensors" = fetchHuggingface {
+        owner = "cagliostrolab";
+        model = "animagine-xl-4.0";
+        rev = "2b7c1b397761bf5bd3cc42e5b39ec99314a75a96";
+        file = "animagine-xl-4.0.safetensors";
+        hash = "sha256-HVtD/3W2q1mFAtTHedL7+j3OylHGDDtglkCmB3IzORY=";
+      };
+      # Illustrious系の公式ベースモデル。素の状態やマージ元として。
+      "Illustrious-XL-v2.0.safetensors" = fetchHuggingface {
+        owner = "OnomaAIResearch";
+        model = "Illustrious-XL-v2.0";
+        rev = "69459c1fe6f46db41ab31e6114f05acc0e06bcaa";
+        file = "Illustrious-XL-v2.0.safetensors";
+        hash = "sha256-wqGj6qE9TBB9x+AMP+gwyrQnqgJjYnQOoJR0WzQiozE=";
+      };
+    };
+    controlnet = {
+      # SDXL系全般で使えるControlNet統合モデル(ProMax版)。
+      # openpose/lineart/tileなど複数のコントロールをこれ1つで扱える。
+      "controlnet-union-sdxl-promax.safetensors" = fetchHuggingface {
+        owner = "xinsir";
+        model = "controlnet-union-sdxl-1.0";
+        rev = "801a4a3fa3d4c936f4feea95b98607bc6726f80c";
+        file = "diffusion_pytorch_model_promax.safetensors";
+        hash = "sha256-n64uUMtDG/y+BYIrWewiKN9UXvJ/cR3qiUnp9O2ffNw=";
+      };
+    };
+    # Impact SubpackのUltralyticsDetectorProviderが読む検出モデル。
+    "ultralytics/bbox" = {
+      # FaceDetailerでの顔検出に使うYOLOモデル。
+      "face_yolov8m.pt" = fetchHuggingface {
+        owner = "Bingsu";
+        model = "adetailer";
+        rev = "53cc19de382014514d9d4038601d261a7faa9b7b";
+        file = "face_yolov8m.pt";
+        hash = "sha256-cXkjwZs/S79SULco8fprLLcqM67R0jbqnK8OIa2UPl8=";
+      };
+    };
+    upscale_models = {
+      # アニメ絵向けの定番アップスケーラ。
+      "4x-AnimeSharp.safetensors" = fetchHuggingface {
+        owner = "Kim2091";
+        model = "AnimeSharp";
+        rev = "7696d95ced82b0c1f2a41f6ac73336133f0a90e1";
+        file = "4x-AnimeSharp.safetensors";
+        hash = "sha256-f8YAVNKRV5rKxPtTfv2RyAYRy9KB74uQ9DQEjMExOzk=";
+      };
+      # Real-ESRGANのアニメ特化軽量版。
+      "RealESRGAN_x4plus_anime_6B.pth" = pkgs.fetchurl {
+        url = "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth";
+        hash = "sha256-+HLYN9PJDtLgUie+1xGvVnGm/RyffX6RyRGmHxVemdo=";
+      };
+    };
+  };
+  # カテゴリ名(ultralytics/bboxのような入れ子含む)から、
+  # 作成するべきディレクトリの前置パス一覧を求める。
+  modelDirs = lib.unique (
+    lib.concatMap (
+      category:
+      let
+        parts = lib.splitString "/" category;
+      in
+      lib.genList (i: lib.concatStringsSep "/" (lib.take (i + 1) parts)) (lib.length parts)
+    ) (lib.attrNames models)
+  );
+  modelDirRules = map (dir: "d ${dataDir}/models/${dir} 0755 comfyui comfyui - -") modelDirs;
+  modelLinkRules = lib.flatten (
+    lib.mapAttrsToList (
+      category:
+      lib.mapAttrsToList (name: file: "L+ ${dataDir}/models/${category}/${name} - - - - ${file}")
+    ) models
+  );
+in
+{
+  systemd.tmpfiles.rules = [
+    "d ${dataDir}/models 0755 comfyui comfyui - -"
+  ]
+  ++ modelDirRules
+  ++ modelLinkRules;
+}

--- a/nixos/host/bullet/comfyui/socket-activation.nix
+++ b/nixos/host/bullet/comfyui/socket-activation.nix
@@ -1,0 +1,52 @@
+# GPUを触るサービスを常時起動させたくないので、
+# ソケットアクティベーションによるオンデマンド起動にする。
+# `comfyui-proxy.socket`がホスト側でlistenし、
+# 初回アクセス時にsystemd-socket-proxyd経由でコンテナごと起動する。
+# アイドル時の自動停止は誤爆が怖いので設定しない。
+# 停止したい時は手動で`systemctl stop container@comfyui.service`する。
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  port = config.containers.comfyui.config.services.comfyui.port;
+  localAddress = config.containers.comfyui.localAddress;
+in
+{
+  systemd = {
+    services = {
+      comfyui-proxy = {
+        description = "systemd-socket-proxyd for on-demand ComfyUI activation";
+        requires = [ "container@comfyui.service" ];
+        after = [ "container@comfyui.service" ];
+        serviceConfig = {
+          # systemd-socket-proxydは`bin/`ではなく`lib/systemd/`に配置されるため、
+          # `lib.getExe'`は使えない。
+          ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${localAddress}:${toString port}";
+          DynamicUser = true;
+          PrivateTmp = true;
+        };
+      };
+      "container@comfyui" = {
+        # コンテナが起動してもComfyUIがlistenするまでは時間がかかり、
+        # その前にproxydが接続すると初回リクエストが失敗してしまう。
+        # HTTP疎通を確認してから起動完了扱いにする。
+        postStart = ''
+          until ${lib.getExe pkgs.curl} --fail --silent --output /dev/null "http://${localAddress}:${toString port}/"; do
+            ${pkgs.coreutils}/bin/sleep 1
+          done
+        '';
+      };
+    };
+    sockets.comfyui-proxy = {
+      description = "Socket for on-demand ComfyUI activation";
+      listenStreams = [
+        "127.0.0.1:${toString port}"
+        "[::1]:${toString port}"
+      ];
+      wantedBy = [ "sockets.target" ];
+    };
+  };
+}

--- a/nixos/host/bullet/comfyui/workflow.nix
+++ b/nixos/host/bullet/comfyui/workflow.nix
@@ -158,7 +158,7 @@ let
         widgets = [
           width
           height
-          1
+          1 # batch_size
         ];
       })
       (mkNode {
@@ -181,11 +181,11 @@ let
         ];
         outputs = [ (mkOutput "LATENT" "LATENT" [ 7 ]) ];
         widgets = seedWidgets ++ [
-          28
-          5.5
+          28 # steps
+          5.5 # cfg
           samplerName
           schedulerName
-          1
+          1 # denoise
         ];
       })
     ];
@@ -404,8 +404,8 @@ let
             inputs = [ (mkInput "image" "IMAGE" 11) ];
             outputs = [ (mkOutput "IMAGE" "IMAGE" [ 12 ]) ];
             widgets = [
-              "lanczos"
-              0.375
+              "lanczos" # upscale_method
+              0.375 # scale_by
             ];
           })
           (mkNode {
@@ -447,11 +447,11 @@ let
             ];
             outputs = [ (mkOutput "LATENT" "LATENT" [ 18 ]) ];
             widgets = seedWidgets ++ [
-              20
-              5.5
+              20 # steps
+              5.5 # cfg
               samplerName
               schedulerName
-              0.45
+              0.45 # denoise
             ];
           })
           (mkNode {
@@ -519,42 +519,37 @@ let
               (mkOutput "detailer_pipe" "DETAILER_PIPE" [ ])
               (mkOutput "cnet_images" "IMAGE" [ ])
             ];
-            # 並び: guide_size, guide_size_for, max_size, seed(+挙動),
-            # steps, cfg, sampler_name, scheduler, denoise, feather,
-            # noise_mask, force_inpaint, bbox系, sam系, drop_size,
-            # wildcard, cycle, optionalのinpaint_model,
-            # noise_mask_feather, tiled_encode, tiled_decode
             widgets = [
-              512
-              true
-              1024
+              512 # guide_size
+              true # guide_size_for(bbox)
+              1024 # max_size
             ]
             ++ seedWidgets
             ++ [
-              20
-              5.5
+              20 # steps
+              5.5 # cfg
               samplerName
               schedulerName
-              0.5
-              5
-              true
-              true
-              0.5
-              10
-              3.0
-              "center-1"
-              0
-              0.93
-              0
-              0.7
-              "False"
-              10
-              ""
-              1
-              false
-              20
-              false
-              false
+              0.5 # denoise
+              5 # feather
+              true # noise_mask
+              true # force_inpaint
+              0.5 # bbox_threshold
+              10 # bbox_dilation
+              3.0 # bbox_crop_factor
+              "center-1" # sam_detection_hint
+              0 # sam_dilation
+              0.93 # sam_threshold
+              0 # sam_bbox_expansion
+              0.7 # sam_mask_hint_threshold
+              "False" # sam_mask_hint_use_negative
+              10 # drop_size
+              "" # wildcard
+              1 # cycle
+              false # inpaint_model
+              20 # noise_mask_feather
+              false # tiled_encode
+              false # tiled_decode
             ];
           })
           (mkNode {

--- a/nixos/host/bullet/comfyui/workflow.nix
+++ b/nixos/host/bullet/comfyui/workflow.nix
@@ -292,7 +292,7 @@ let
           ];
           order = 6;
           inputs = [ (mkInput "images" "IMAGE" 9) ];
-          widgets = [ "ComfyUI" ];
+          widgets = [ "anime-basic" ];
         })
       ];
       links = promptLinks ++ [
@@ -570,7 +570,7 @@ let
             ];
             order = 14;
             inputs = [ (mkInput "images" "IMAGE" 27) ];
-            widgets = [ "ComfyUI" ];
+            widgets = [ "anime-hires-face" ];
           })
         ];
       links = promptLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow.nix
+++ b/nixos/host/bullet/comfyui/workflow.nix
@@ -1,0 +1,745 @@
+# ComfyUIのワークフローJSON(UI形式)をNix式から生成して、
+# ComfyUIのuserディレクトリへシンボリックリンクで配置する。
+#
+# UI形式のノードの`widgets_values`は配列で、
+# 並び順はノード定義のINPUT_TYPESのウィジェット順に一致させる必要がある。
+# FaceDetailerの並びはComfyUI-Impact-Pack 8.28の定義に合わせている。
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  dataDir = config.containers.comfyui.config.services.comfyui.dataDir;
+  jsonFormat = pkgs.formats.json { };
+  checkpoint = "waiIllustriousSDXL_v170.safetensors";
+  positivePrompt = "best quality, amazing quality, masterpiece, 1girl";
+  negativePrompt = "bad quality, worst quality, worst detail, sketch, censored, watermark, signature";
+  # Illustrious系モデルの定番サンプリング設定。
+  samplerName = "euler_ancestral";
+  schedulerName = "normal";
+  # SDXLのポートレートバケット解像度。
+  width = 832;
+  height = 1216;
+  # seedウィジェットは値の直後に実行後の挙動(randomizeなど)が並ぶ。
+  seedWidgets = [
+    0
+    "randomize"
+  ];
+
+  mkNode =
+    {
+      id,
+      type,
+      pos,
+      size,
+      order,
+      inputs ? [ ],
+      outputs ? [ ],
+      widgets ? null,
+    }:
+    {
+      inherit
+        id
+        type
+        pos
+        size
+        order
+        inputs
+        outputs
+        ;
+      flags = { };
+      mode = 0;
+      properties = {
+        "Node name for S&R" = type;
+      };
+    }
+    // lib.optionalAttrs (widgets != null) { widgets_values = widgets; };
+  mkInput = name: type: link: { inherit name type link; };
+  mkOutput = name: type: links: { inherit name type links; };
+  mkWorkflow =
+    { nodes, links }:
+    {
+      inherit nodes links;
+      last_node_id = lib.foldl' lib.max 0 (map (node: node.id) nodes);
+      last_link_id = lib.foldl' lib.max 0 (map lib.head links);
+      groups = [ ];
+      config = { };
+      extra = { };
+      version = 0.4;
+    };
+
+  # checkpoint読み込みとプロンプトエンコードの共通部分。
+  # 基本形もフル構成も同じノードIDとリンクIDで始まる。
+  # リンク: 1=MODEL→KSampler, 2/3=CLIP→TextEncode,
+  # 4/5=CONDITIONING→KSampler, 6=LATENT→KSampler
+  # フル構成では同じ出力を後段ノードにも繋ぐので、
+  # 追加のリンクIDを引数で受け取る。
+  promptNodes =
+    {
+      extraModelLinks ? [ ],
+      extraClipLinks ? [ ],
+      extraVaeLinks ? [ ],
+      extraPositiveLinks ? [ ],
+      extraNegativeLinks ? [ ],
+    }:
+    [
+      (mkNode {
+        id = 1;
+        type = "CheckpointLoaderSimple";
+        pos = [
+          (-40)
+          200
+        ];
+        size = [
+          385
+          98
+        ];
+        order = 0;
+        outputs = [
+          (mkOutput "MODEL" "MODEL" ([ 1 ] ++ extraModelLinks))
+          (mkOutput "CLIP" "CLIP" (
+            [
+              2
+              3
+            ]
+            ++ extraClipLinks
+          ))
+          (mkOutput "VAE" "VAE" ([ 8 ] ++ extraVaeLinks))
+        ];
+        widgets = [ checkpoint ];
+      })
+      (mkNode {
+        id = 2;
+        type = "CLIPTextEncode";
+        pos = [
+          420
+          60
+        ];
+        size = [
+          420
+          160
+        ];
+        order = 1;
+        inputs = [ (mkInput "clip" "CLIP" 2) ];
+        outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" ([ 4 ] ++ extraPositiveLinks)) ];
+        widgets = [ positivePrompt ];
+      })
+      (mkNode {
+        id = 3;
+        type = "CLIPTextEncode";
+        pos = [
+          420
+          280
+        ];
+        size = [
+          420
+          160
+        ];
+        order = 2;
+        inputs = [ (mkInput "clip" "CLIP" 3) ];
+        outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" ([ 5 ] ++ extraNegativeLinks)) ];
+        widgets = [ negativePrompt ];
+      })
+      (mkNode {
+        id = 4;
+        type = "EmptyLatentImage";
+        pos = [
+          420
+          500
+        ];
+        size = [
+          315
+          106
+        ];
+        order = 3;
+        outputs = [ (mkOutput "LATENT" "LATENT" [ 6 ]) ];
+        widgets = [
+          width
+          height
+          1
+        ];
+      })
+      (mkNode {
+        id = 5;
+        type = "KSampler";
+        pos = [
+          920
+          200
+        ];
+        size = [
+          315
+          262
+        ];
+        order = 4;
+        inputs = [
+          (mkInput "model" "MODEL" 1)
+          (mkInput "positive" "CONDITIONING" 4)
+          (mkInput "negative" "CONDITIONING" 5)
+          (mkInput "latent_image" "LATENT" 6)
+        ];
+        outputs = [ (mkOutput "LATENT" "LATENT" [ 7 ]) ];
+        widgets = seedWidgets ++ [
+          28
+          5.5
+          samplerName
+          schedulerName
+          1
+        ];
+      })
+    ];
+  promptLinks = [
+    [
+      1
+      1
+      0
+      5
+      0
+      "MODEL"
+    ]
+    [
+      2
+      1
+      1
+      2
+      0
+      "CLIP"
+    ]
+    [
+      3
+      1
+      1
+      3
+      0
+      "CLIP"
+    ]
+    [
+      4
+      2
+      0
+      5
+      1
+      "CONDITIONING"
+    ]
+    [
+      5
+      3
+      0
+      5
+      2
+      "CONDITIONING"
+    ]
+    [
+      6
+      4
+      0
+      5
+      3
+      "LATENT"
+    ]
+    [
+      7
+      5
+      0
+      6
+      0
+      "LATENT"
+    ]
+    [
+      8
+      1
+      2
+      6
+      1
+      "VAE"
+    ]
+  ];
+  # 属性名がワークフロー名(ファイル名)になり、
+  # 値はそのままJSONへ変換できるNixの値。
+  workflows = {
+    # txt2imgの基本形。
+    anime-basic = mkWorkflow {
+      nodes = promptNodes { } ++ [
+        (mkNode {
+          id = 6;
+          type = "VAEDecode";
+          pos = [
+            1290
+            200
+          ];
+          size = [
+            210
+            46
+          ];
+          order = 5;
+          inputs = [
+            (mkInput "samples" "LATENT" 7)
+            (mkInput "vae" "VAE" 8)
+          ];
+          outputs = [ (mkOutput "IMAGE" "IMAGE" [ 9 ]) ];
+        })
+        (mkNode {
+          id = 7;
+          type = "SaveImage";
+          pos = [
+            1560
+            200
+          ];
+          size = [
+            420
+            470
+          ];
+          order = 6;
+          inputs = [ (mkInput "images" "IMAGE" 9) ];
+          widgets = [ "ComfyUI" ];
+        })
+      ];
+      links = promptLinks ++ [
+        [
+          9
+          6
+          0
+          7
+          0
+          "IMAGE"
+        ]
+      ];
+    };
+
+    # hires fix(アップスケールモデル+2パス目のKSampler)と、
+    # FaceDetailerによる顔の修復を加えたフル構成。
+    anime-hires-face = mkWorkflow {
+      nodes =
+        promptNodes {
+          # KSampler2とFaceDetailerへ。
+          extraModelLinks = [
+            14
+            21
+          ];
+          # FaceDetailerへ。
+          extraClipLinks = [ 22 ];
+          # VAEEncode、VAEDecode2、FaceDetailerへ。
+          extraVaeLinks = [
+            13
+            19
+            23
+          ];
+          # KSampler2とFaceDetailerへ。
+          extraPositiveLinks = [
+            15
+            24
+          ];
+          extraNegativeLinks = [
+            16
+            25
+          ];
+        }
+        ++ [
+          (mkNode {
+            id = 6;
+            type = "VAEDecode";
+            pos = [
+              1290
+              200
+            ];
+            size = [
+              210
+              46
+            ];
+            order = 7;
+            inputs = [
+              (mkInput "samples" "LATENT" 7)
+              (mkInput "vae" "VAE" 8)
+            ];
+            outputs = [ (mkOutput "IMAGE" "IMAGE" [ 10 ]) ];
+          })
+          (mkNode {
+            id = 7;
+            type = "UpscaleModelLoader";
+            pos = [
+              1290
+              60
+            ];
+            size = [
+              315
+              58
+            ];
+            order = 5;
+            outputs = [ (mkOutput "UPSCALE_MODEL" "UPSCALE_MODEL" [ 9 ]) ];
+            widgets = [ "4x-AnimeSharp.safetensors" ];
+          })
+          (mkNode {
+            id = 8;
+            type = "ImageUpscaleWithModel";
+            pos = [
+              1560
+              200
+            ];
+            size = [
+              240
+              46
+            ];
+            order = 8;
+            inputs = [
+              (mkInput "upscale_model" "UPSCALE_MODEL" 9)
+              (mkInput "image" "IMAGE" 10)
+            ];
+            outputs = [ (mkOutput "IMAGE" "IMAGE" [ 11 ]) ];
+          })
+          # 4倍アップスケール後に0.375倍へ縮小して、
+          # 全体で1.5倍のhires fixにする。
+          (mkNode {
+            id = 9;
+            type = "ImageScaleBy";
+            pos = [
+              1560
+              300
+            ];
+            size = [
+              315
+              82
+            ];
+            order = 9;
+            inputs = [ (mkInput "image" "IMAGE" 11) ];
+            outputs = [ (mkOutput "IMAGE" "IMAGE" [ 12 ]) ];
+            widgets = [
+              "lanczos"
+              0.375
+            ];
+          })
+          (mkNode {
+            id = 10;
+            type = "VAEEncode";
+            pos = [
+              1560
+              440
+            ];
+            size = [
+              210
+              46
+            ];
+            order = 10;
+            inputs = [
+              (mkInput "pixels" "IMAGE" 12)
+              (mkInput "vae" "VAE" 13)
+            ];
+            outputs = [ (mkOutput "LATENT" "LATENT" [ 17 ]) ];
+          })
+          # 2パス目。低めのdenoiseで書き込みを増やす。
+          (mkNode {
+            id = 11;
+            type = "KSampler";
+            pos = [
+              1940
+              200
+            ];
+            size = [
+              315
+              262
+            ];
+            order = 11;
+            inputs = [
+              (mkInput "model" "MODEL" 14)
+              (mkInput "positive" "CONDITIONING" 15)
+              (mkInput "negative" "CONDITIONING" 16)
+              (mkInput "latent_image" "LATENT" 17)
+            ];
+            outputs = [ (mkOutput "LATENT" "LATENT" [ 18 ]) ];
+            widgets = seedWidgets ++ [
+              20
+              5.5
+              samplerName
+              schedulerName
+              0.45
+            ];
+          })
+          (mkNode {
+            id = 12;
+            type = "VAEDecode";
+            pos = [
+              2310
+              200
+            ];
+            size = [
+              210
+              46
+            ];
+            order = 12;
+            inputs = [
+              (mkInput "samples" "LATENT" 18)
+              (mkInput "vae" "VAE" 19)
+            ];
+            outputs = [ (mkOutput "IMAGE" "IMAGE" [ 20 ]) ];
+          })
+          (mkNode {
+            id = 13;
+            type = "UltralyticsDetectorProvider";
+            pos = [
+              2310
+              60
+            ];
+            size = [
+              315
+              78
+            ];
+            order = 6;
+            outputs = [
+              (mkOutput "BBOX_DETECTOR" "BBOX_DETECTOR" [ 26 ])
+              (mkOutput "SEGM_DETECTOR" "SEGM_DETECTOR" [ ])
+            ];
+            widgets = [ "bbox/face_yolov8m.pt" ];
+          })
+          (mkNode {
+            id = 14;
+            type = "FaceDetailer";
+            pos = [
+              2580
+              200
+            ];
+            size = [
+              400
+              800
+            ];
+            order = 13;
+            inputs = [
+              (mkInput "image" "IMAGE" 20)
+              (mkInput "model" "MODEL" 21)
+              (mkInput "clip" "CLIP" 22)
+              (mkInput "vae" "VAE" 23)
+              (mkInput "positive" "CONDITIONING" 24)
+              (mkInput "negative" "CONDITIONING" 25)
+              (mkInput "bbox_detector" "BBOX_DETECTOR" 26)
+            ];
+            outputs = [
+              (mkOutput "image" "IMAGE" [ 27 ])
+              (mkOutput "cropped_refined" "IMAGE" [ ])
+              (mkOutput "cropped_enhanced_alpha" "IMAGE" [ ])
+              (mkOutput "mask" "MASK" [ ])
+              (mkOutput "detailer_pipe" "DETAILER_PIPE" [ ])
+              (mkOutput "cnet_images" "IMAGE" [ ])
+            ];
+            # 並び: guide_size, guide_size_for, max_size, seed(+挙動),
+            # steps, cfg, sampler_name, scheduler, denoise, feather,
+            # noise_mask, force_inpaint, bbox系, sam系, drop_size,
+            # wildcard, cycle, optionalのinpaint_model,
+            # noise_mask_feather, tiled_encode, tiled_decode
+            widgets = [
+              512
+              true
+              1024
+            ]
+            ++ seedWidgets
+            ++ [
+              20
+              5.5
+              samplerName
+              schedulerName
+              0.5
+              5
+              true
+              true
+              0.5
+              10
+              3.0
+              "center-1"
+              0
+              0.93
+              0
+              0.7
+              "False"
+              10
+              ""
+              1
+              false
+              20
+              false
+              false
+            ];
+          })
+          (mkNode {
+            id = 15;
+            type = "SaveImage";
+            pos = [
+              3040
+              200
+            ];
+            size = [
+              420
+              470
+            ];
+            order = 14;
+            inputs = [ (mkInput "images" "IMAGE" 27) ];
+            widgets = [ "ComfyUI" ];
+          })
+        ];
+      links = promptLinks ++ [
+        [
+          9
+          7
+          0
+          8
+          0
+          "UPSCALE_MODEL"
+        ]
+        [
+          10
+          6
+          0
+          8
+          1
+          "IMAGE"
+        ]
+        [
+          11
+          8
+          0
+          9
+          0
+          "IMAGE"
+        ]
+        [
+          12
+          9
+          0
+          10
+          0
+          "IMAGE"
+        ]
+        [
+          13
+          1
+          2
+          10
+          1
+          "VAE"
+        ]
+        [
+          14
+          1
+          0
+          11
+          0
+          "MODEL"
+        ]
+        [
+          15
+          2
+          0
+          11
+          1
+          "CONDITIONING"
+        ]
+        [
+          16
+          3
+          0
+          11
+          2
+          "CONDITIONING"
+        ]
+        [
+          17
+          10
+          0
+          11
+          3
+          "LATENT"
+        ]
+        [
+          18
+          11
+          0
+          12
+          0
+          "LATENT"
+        ]
+        [
+          19
+          1
+          2
+          12
+          1
+          "VAE"
+        ]
+        [
+          20
+          12
+          0
+          14
+          0
+          "IMAGE"
+        ]
+        [
+          21
+          1
+          0
+          14
+          1
+          "MODEL"
+        ]
+        [
+          22
+          1
+          1
+          14
+          2
+          "CLIP"
+        ]
+        [
+          23
+          1
+          2
+          14
+          3
+          "VAE"
+        ]
+        [
+          24
+          2
+          0
+          14
+          4
+          "CONDITIONING"
+        ]
+        [
+          25
+          3
+          0
+          14
+          5
+          "CONDITIONING"
+        ]
+        [
+          26
+          13
+          0
+          14
+          6
+          "BBOX_DETECTOR"
+        ]
+        [
+          27
+          14
+          0
+          15
+          0
+          "IMAGE"
+        ]
+      ];
+    };
+  };
+in
+{
+  # シンボリックリンク先はUIから上書き保存できないので、
+  # 編集したものを残したい場合は別名で保存する。
+  systemd.tmpfiles.rules = [
+    "d ${dataDir}/user 0755 comfyui comfyui - -"
+    "d ${dataDir}/user/default 0755 comfyui comfyui - -"
+    "d ${dataDir}/user/default/workflows 0755 comfyui comfyui - -"
+  ]
+  ++ lib.mapAttrsToList (
+    name: workflow:
+    "L+ ${dataDir}/user/default/workflows/${name}.json - - - - ${jsonFormat.generate "${name}.json" workflow}"
+  ) workflows;
+}

--- a/nixos/host/bullet/default.nix
+++ b/nixos/host/bullet/default.nix
@@ -1,4 +1,4 @@
 { importDirModules, ... }:
 {
-  imports = importDirModules ./.;
+  imports = importDirModules ./. ++ [ ./comfyui ];
 }


### PR DESCRIPTION
danbooruタグベースのアニメ・ゲーム風画像生成に必要な、
モデル・カスタムノード・ワークフローを全てNix式で宣言的に管理します。

`comfyui.nix`は肥大化するため`comfyui/`ディレクトリに分割して、
`default.nix`は慣習に合わせて`importDirModules`をするだけにします。
コンテナ本体・ソケットアクティベーション・Caddy・モデル・
カスタムノード・ワークフローをそれぞれ意味ごとのモジュールに分けます。
port/dataDirなどの共有値は重複定義せずに、
`config.containers.comfyui.config.services.comfyui.*`経由で参照します。

モデルは`fetchurl`でNix storeへ取得して、
ホスト側の`systemd.tmpfiles.rules`の`L+`で`models/`配下へリンクします。
storeのパスはシステムクロージャから参照されるのでGCされず、
コンテナはephemeralですがホスト側のルールなので再起動しても残ります。
CivitAIはダウンロードにAPIキーが必要なことがあるため、
認証なしで取得できるHugging Faceのみを使い、
可読性のために`fetchHuggingface`ヘルパーを定義して、
URLはリポジトリのcommit hashで固定します。

- checkpoints: WAI-illustrious/NoobAI-XL/Animagine XL 4.0/Illustrious-XL
- controlnet: ControlNet Union SDXL ProMax
- upscale_models: 4x-AnimeSharp/RealESRGAN_x4plus_anime_6B
- ultralytics/bbox: face_yolov8m(FaceDetailerの顔検出用)

カスタムノードは`services.comfyui.customNodes`で宣言します。
Impact Packとrgthree-comfyはcomfyui-nixのパッケージ済みを使い、
FaceDetailerの検出器に必要なImpact Subpackと、
日本語検索とpost count表示に対応したタグ補完のAutocomplete-Plusを追加します。

Autocomplete-PlusはタグCSVを自ディレクトリ配下へダウンロードする作りで、
Nix storeの読み取り専用リンクでは失敗するため、
書き込み先を`/var/lib/comfyui/autocomplete-plus`へ差し替えます。
また新しいComfyUIフロントエンド(1.43以降)では、
keyup時点でカーソル位置がリセットされて候補が表示されないため、
upstreamのissueで提示されている修正パッチを適用します。
ref https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus/issues/73

ワークフローはUI形式のJSONをNix式から生成して、
`user/default/workflows/`へリンクして配置します。
txt2img基本形のanime-basicと、
hires fixとFaceDetailerを加えたanime-hires-faceの2つを用意します。
`widgets_values`の並び順はノード定義のINPUT_TYPES順に合わせる必要があり、
FaceDetailerはImpact Pack 8.28の定義から順序を確定しています。
保存画像の`filename_prefix`もワークフロー名にして、
どのワークフローで生成した画像かファイル名から分かるようにします。

既知のアニメキャラの生成と日本語からのタグ補完が、
動作することを実機で確認済みです。

https://claude.ai/code/session_016ArYupcQVVV1sjuyZds6Cj