### PR TITLE
build: comfyui-nixのinput名を変更してrootのnixpkgsノード名を維持

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,27 +23,6 @@
         "type": "github"
       }
     },
-    "comfyui-nix": {
-      "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1781842085,
-        "narHash": "sha256-uGt5HQ+hm0EeIjWoJUq7HefgkSc1h7kf1vFKvOl0tcs=",
-        "owner": "utensils",
-        "repo": "comfyui-nix",
-        "rev": "308a863c136ffc35fce293a81eac5d229b31d56d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "utensils",
-        "repo": "comfyui-nix",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1766774972,
@@ -433,16 +412,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766902085,
-        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
+        "lastModified": 1784160687,
+        "narHash": "sha256-iYL/bixrb6FlHFu/gIuBYzq6c6lM5AAXsXNSWXtIgQc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+        "rev": "4382ed2b7a6839d4280a9b386db49cbc5907414d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -512,16 +491,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784160687,
-        "narHash": "sha256-iYL/bixrb6FlHFu/gIuBYzq6c6lM5AAXsXNSWXtIgQc=",
+        "lastModified": 1766902085,
+        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4382ed2b7a6839d4280a9b386db49cbc5907414d",
+        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-26.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -583,7 +562,6 @@
     "root": {
       "inputs": {
         "claude-desktop": "claude-desktop",
-        "comfyui-nix": "comfyui-nix",
         "disko": "disko",
         "dot-emacs": "dot-emacs",
         "dot-xmonad": "dot-xmonad",
@@ -597,10 +575,11 @@
         "nix-on-droid": "nix-on-droid",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix",
+        "utensils-comfyui-nix": "utensils-comfyui-nix",
         "www-ncaq-net": "www-ncaq-net",
         "xremap-flake": "xremap-flake"
       }
@@ -689,6 +668,27 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "utensils-comfyui-nix": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1781842085,
+        "narHash": "sha256-uGt5HQ+hm0EeIjWoJUq7HefgkSc1h7kf1vFKvOl0tcs=",
+        "owner": "utensils",
+        "repo": "comfyui-nix",
+        "rev": "308a863c136ffc35fce293a81eac5d229b31d56d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "utensils",
+        "repo": "comfyui-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -67,13 +67,21 @@
       };
     };
 
-    comfyui-nix = {
+    # 依存関係が繊細であり、
+    # nixpkgsをfollowするとstableでもunstableでもビルドに失敗します。
+    # 例えば、
+    # torch wheelのCUDAランタイム依存やwebsocketsのバージョン制約が、
+    # 上流がpinしたnixpkgsリビジョンに強く紐付いているため。
+    # 上流のREADMEもfollowsなしを標準構成としており、
+    # 上流に自動追随するためには自前のpinも避けたいので、
+    # nixpkgsノードの重複は意図的に許容します。
+    # flake.lockのノード名はrootからのDFS(兄弟はアルファベット順)で決まるため、
+    # input名を`nixpkgs`より後ろに来る名前にすることで、
+    # root直下のnixpkgsがプレーンな`nixpkgs`ノード名を保ち、
+    # `nixpkgs_2`はこちら側の推移的nixpkgsに割り当てられます。
+    utensils-comfyui-nix = {
       url = "github:utensils/comfyui-nix";
-      inputs = {
-        # 依存関係が繊細であり、
-        # nixpkgsをfollowするとstableでもunstableでもビルドに失敗する。
-        flake-parts.follows = "flake-parts";
-      };
+      inputs.flake-parts.follows = "flake-parts";
     };
 
     git-hooks = {
@@ -146,7 +154,7 @@
       # 全環境で共通のoverlays。
       overlays = [
         (import ./lib/snapper-btrfs-bin-overlay.nix)
-        inputs.comfyui-nix.overlays.default
+        inputs.utensils-comfyui-nix.overlays.default
         inputs.firge-nix.overlays.default
       ];
       # system固有のpkgsを生成する関数。

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -76,7 +76,7 @@ in
     config =
       { lib, ... }:
       {
-        imports = [ inputs.comfyui-nix.nixosModules.default ];
+        imports = [ inputs.utensils-comfyui-nix.nixosModules.default ];
         system.stateVersion = "26.05";
         networking.useHostResolvConf = lib.mkForce false;
         services.resolved.enable = true;


### PR DESCRIPTION
comfyui-nixのnixpkgsをfollowしていない影響で、
`flake.lock`でroot直下のnixpkgs(`nixos-26.05`)が`nixpkgs_2`ノードに割り当てられ、
comfyui-nix側の推移的nixpkgs(`nixos-unstable`)がプレーンな`nixpkgs`名を取っていました。

`flake.lock`のノード名はNixがrootからのDFS(兄弟はアルファベット順)で機械的に決めるため、
ユーザが直接制御する構文は存在しません。
`comfyui-nix` < `nixpkgs`のアルファベット順が原因なので、
input名を`nixpkgs`より後ろに来る`utensils-comfyui-nix`(上流のオーナ名前置)にリネームして、
root直下のnixpkgsがプレーンな`nixpkgs`名を保つようにします。
`nixpkgs_2`はcomfyui-nix側の推移的nixpkgsに移りますが、
followしない限り重複ノード自体を消すことは仕様上不可能です。

followが今も壊れることは実機で再検証済みです。
`nixpkgs-unstable`にfollowさせると、
torch wheelのCUDAランタイム依存の`pythonRuntimeDepsCheckHook`不整合や、
gradio-clientの`websockets<16.0`制約違反などでビルドに失敗しました。
上流のREADMEもfollowsなしを標準構成としているため、
重複を意図的に許容する判断とその根拠をコメントに記録します。

comfyui-nix自体のリビジョンは変更前後で同一であり、
bulletのシステムビルドとnix-fast-buildの統合チェックの成功を確認済みです。
