### PR TITLE
feat: nixのmax-jobsをautoから3に変更して過負荷を抑制

### DIFF
--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -25,7 +25,7 @@
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       ];
       cores = 0; # `make -j$NIX_BUILD_CORES`のようにコンパイルの並列度に使われます。0だと全コア。
-      max-jobs = "auto"; # Nixが同時に実行するビルド(derivation)の数。
+      max-jobs = 3; # Nixが同時に実行するビルド(derivation)の数。
       accept-flake-config = true;
       trusted-users = [
         "root"

--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -24,8 +24,8 @@
         "ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       ];
-      cores = 0;
-      max-jobs = "auto";
+      cores = 0; # `make -j$NIX_BUILD_CORES`のようにコンパイルの並列度に使われます。0だと全コア。
+      max-jobs = "auto"; # Nixが同時に実行するビルド(derivation)の数。
       accept-flake-config = true;
       trusted-users = [
         "root"


### PR DESCRIPTION
`max-jobs = "auto"`で最大並列度にした結果、
ビルドジョブが最大限に並列実行されてloadavgが160を超えてしまいました。
メモリ容量の危惧が発生したりキャッシュ効率が悪くなってしまったので、
ジョブ並列度を3に下げます。

理想の並列度のパッケージだけをビルドする場合は、
ビルドジョブを並列にする必要はなくコア並列だけでも問題ありません。
しかしビルド時(特にテスト実行時)にシングルスレッドしか使わないようなパッケージが多い場合は、
コア並列だけではCPUコアを使い切れずに効率が悪いため、
折衷案として少なめの数を指定しておきます。

あわせて`cores`と`max-jobs`の役割の違いが分かりにくいため、
それぞれの意味を説明するコメントを追加します。
