### PR TITLE
docs: 設定の適用に`./install.sh`を使う理由を説明

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -154,6 +154,33 @@ nix-fast-buildコマンドで統合チェックを実行できます。
 nix-fast-build --option eval-cache false --no-link --skip-cached --no-nom
 ```
 
+## 設定の適用は`./install.sh`を使う
+
+設定をシステムに適用する時は、
+`nixos-rebuild`や`home-manager`を直接実行せずに、
+リポジトリルートの`./install.sh`を実行してください。
+
+```console
+./install.sh
+```
+
+このスクリプトは実行環境を自動判別して適切な適用コマンドを呼び分けます。
+
+- NixOS: `sudo nixos-rebuild switch --flake ".#$(hostname)"`
+- Termux(nix-on-droid): `nix-on-droid switch --flake .`
+- その他のLinux: アーキテクチャに応じた`home-manager switch`
+
+単なるラッパーではなく、
+NixOSでは適用前に最新コミットの情報を`last-commit.json`として一時的にstagingします。
+この情報は`nixos/core/label.nix`がブートエントリのラベル生成に使うため、
+`nixos-rebuild`を直接実行するとブートエントリからコミット情報が欠落します。
+
+実行にあたって知っておくべきこと:
+
+- NixOSではsudoを使いますがユーザ側によって解決されるので気にしなくても良いです
+- 実行中は`last-commit.json`のstagingにより一時的にgitがdirty状態に見えますが、
+  終了時に自動でクリーンアップされます
+
 # リポジトリ構成
 
 ## ルートディレクトリ


### PR DESCRIPTION
LLMが設定を適用する際に`./install.sh`を使わず、
`nixos-rebuild`を直接実行してしまうことが多いためです。

`install.sh`は環境の自動判別に加えて、
ブートエントリのラベル生成(`nixos/core/label.nix`)に使う`last-commit.json`を、
一時的にstagingしてから適用します。
直接`nixos-rebuild`を実行するとこの情報が欠落するため、
実装の詳細には踏み込まず、
なぜ使うべきかと実行時に知っておくべき挙動だけを記載します。
