### PR TITLE
build: git lfsを導入してバイナリファイルを自前のForgejoで管理

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,14 +46,27 @@ indent_size = 2
 [*.{cs,csx,java,kt,kts,php,py,pyi,rs}]
 indent_size = 4
 
-# 標準インデントがタブの言語。
-[{*.go,*.make,*.mk,Makefile}]
+# Goのエコシステムは標準インデントがタブ。
+[{*.go,go.mod,go.work}]
 indent_style = tab
 indent_size = unset
 
-# 変則的に2インデントや3インデントが混ざり合ったりして、
-# インデントが倍数になるとは限らない言語。
-[*.{chs,el,hs,hsc,hsig,lhs,lhsig}]
+# Gitの設定ファイルは標準インデントがタブ。
+[{.gitconfig,.gitmodules,.lfsconfig}]
+indent_style = tab
+indent_size = unset
+
+# Make系の設定ファイルは標準インデントがタブ。
+[{*.make,*.mk,GNUmakefile,Makefile,Makefile.am}]
+indent_style = tab
+indent_size = unset
+
+# Haskellは文法の都合で3文字インデントが必要な場合があるので未設定。
+[*.{chs,hs,hsc,hsig,lhs,lhsig}]
+indent_size = unset
+
+# Emacs Lispは文法の都合で3文字インデントが必要な場合があるので未設定。
+[*.el]
 indent_size = unset
 
 [*.md]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,62 @@
+# archive
+*.7z filter=lfs diff=lfs merge=lfs -text
+*.bz2 filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.rar filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text
+*.tgz filter=lfs diff=lfs merge=lfs -text
+*.xz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.zst filter=lfs diff=lfs merge=lfs -text
+
+# executable binary
+*.a filter=lfs diff=lfs merge=lfs -text
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.dat filter=lfs diff=lfs merge=lfs -text
+*.dll filter=lfs diff=lfs merge=lfs -text
+*.dylib filter=lfs diff=lfs merge=lfs -text
+*.exe filter=lfs diff=lfs merge=lfs -text
+*.lib filter=lfs diff=lfs merge=lfs -text
+*.so filter=lfs diff=lfs merge=lfs -text
+
+# font
+*.otf filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+
+# video
+*.avi filter=lfs diff=lfs merge=lfs -text
+*.flv filter=lfs diff=lfs merge=lfs -text
+*.mkv filter=lfs diff=lfs merge=lfs -text
+*.mov filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+*.wmv filter=lfs diff=lfs merge=lfs -text
+
+# image
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.avif filter=lfs diff=lfs merge=lfs -text
+*.bmp filter=lfs diff=lfs merge=lfs -text
+*.eps filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.hdp filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jxl filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.tif filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text
+*.wdp filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+
+# audio
+*.aac filter=lfs diff=lfs merge=lfs -text
+*.flac filter=lfs diff=lfs merge=lfs -text
+*.m4a filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+*.opus filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	url = https://forgejo.ncaq.net/ncaq/dotfiles.git/info/lfs


### PR DESCRIPTION
バイナリファイルをリポジトリに含める場合に備えて、
git lfsの設定を導入します。

lfsの保存先はGitHubのlfsストレージではなく、
自前で運用しているForgejoのエンドポイントを`.lfsconfig`で指定します。
GitHubのlfsストレージには容量と帯域の制限があり、
超過すると課金が必要になるためです。

`.gitattributes`を追加して、
アーカイブ・実行バイナリ・フォント・動画・画像・音声などの、
バイナリ形式の拡張子をlfs管理対象として指定します。

あわせて`.editorconfig`をnix-templatesの内容に合わせて更新します。
`.lfsconfig`などGit系設定ファイルのタブインデント指定の追加や、
言語ごとのインデント設定の分類の整理が含まれます。
