### PR TITLE
feat(boot): ブートローダLimineに壁紙を設定

### DIFF
--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -16,6 +16,9 @@
             # ブート時はGPUを効率的に使えないことが多いため解像度を下げて負荷を減らします。
             resolution = "1920x1080";
           };
+          # 画像は`resolution`と同じ1920x1080なので、
+          # デフォルトのwallpaperStyle(stretched)でも歪みません。
+          wallpapers = [ ../../wallpaper/hare-sitting-at-the-pc-and-looking-back.png ];
         };
         # セキュアブート設定。
         secureBoot = {

--- a/wallpaper/README.md
+++ b/wallpaper/README.md
@@ -1,0 +1,11 @@
+# wallpaper
+
+This directory contains images used as wallpapers for the bootloader, desktop, and so on.
+
+## Copyright
+
+The images in this directory are intentionally treated with ambiguous copyright status from a fair use perspective.
+
+The repository owner claims no copyright over these images.
+
+If a legitimate copyright holder raises a claim, the corresponding images will be removed.

--- a/wallpaper/hare-sitting-at-the-pc-and-looking-back.png
+++ b/wallpaper/hare-sitting-at-the-pc-and-looking-back.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1598f85d99814a67ae2489ad86051aae1956b8a908416dc67f8e63f4c5be8211
+size 2242744


### PR DESCRIPTION
デフォルトのNixOS壁紙の代わりに、
自分で用意した画像をLimineの壁紙として表示するようにします。

壁紙画像を置く`wallpaper/`ディレクトリを新設して、
画像はgit lfsで管理します。
READMEには置かれる画像の著作権の扱いとして、
フェアユースの観点から著作権をあえて曖昧に扱っており、
リポジトリ所有者は著作権を主張しないこと、
正当な著作者からクレームがあれば該当画像を削除することを明記します。

画像は`interface.resolution`と同じ1920x1080なので、
デフォルトの`wallpaperStyle`(stretched)のままでも歪みは出ません。

Nix storeにコピーされるファイルがlfsのポインタではなく実体のPNGであることと、
生成される`limine-install.json`の`wallpapers`に、
画像のstoreパスが入ることを確認済みです。