### PR TITLE
ci: パッケージに大きな変動が起きたときのビルドの無駄な並列実行を削減

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,15 +76,19 @@ jobs:
           --skip-cached
           --no-nom
 
-  # x64_64のhome-managerと、
-  # Nix-on-Droidのビルドを行います。
-  # 関係性は薄いですが、
-  # 並列数を減らすために負荷の軽いジョブをまとめています。
-  # 一応Nix-on-Droidはhome-managerベースで構築しているので、
-  # 全く関係がないわけではないです。
   build-home-manager:
     name: build-home-manager
-    needs: is-trusted
+    needs:
+      - is-trusted
+      # 無駄なビルドを避けるため事前にキャッシュを貯めるために先に`build-nixos`を実行。
+      # 普段は並列に実行した方が効率が良いですが、
+      # パッケージに大きな変動が起きてビルドが必要になった時は、
+      # CPUのスレッド数が足りなくなるため、
+      # 先にビルドだけを済ませてキャッシュにビルド結果を貯めておくほうが効率が良いです。
+      # 普段はそんなに時間がかからず、
+      # 大きな変動が起きた時だけ異様に時間がかかるので、
+      # そちらを優先してケアするほうがリソース配分的に合理的です。
+      - build-nixos
     permissions:
       contents: read # リポジトリコンテンツの読み取り
       id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
@@ -98,6 +102,26 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-nix
       - run: nix build -L .#homeConfigurations.x86_64-linux.activationPackage
+
+  build-nix-on-droid:
+    name: build-nix-on-droid
+    # こちらでビルドするものはどうせaarch64なので、
+    # パッケージに大きな変動が起きても、
+    # どうせ現状build-nixosでビルドされないので、
+    # こちらのビルドは並列で実行しても問題ないです。
+    needs: is-trusted
+    permissions:
+      contents: read # リポジトリコンテンツの読み取り
+      id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用
+    # セルフホステッドランナーは未認証のソースからは実行しない。
+    if: needs.is-trusted.result == 'success'
+    runs-on: [self-hosted, Linux]
+    timeout-minutes: 360 # キャッシュが切れている時は時間がかかるため長めに設定。
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
       # Nix-on-Droidのビルドはimpureモードで行う必要があります
       - run: nix build -L .#nixOnDroidConfigurations.default.activationPackage --impure
 
@@ -124,7 +148,10 @@ jobs:
 
   test-nixos-boot:
     name: test-nixos-boot
-    needs: is-trusted
+    needs:
+      - is-trusted
+      # 無駄なビルドを避けるため事前にキャッシュを貯めるために先に`build-nixos`を実行。
+      - build-nixos
     permissions:
       contents: read # リポジトリコンテンツの読み取り
       id-token: write # `ncaq/nix-composite-action`内のniks3-publicとのOIDC認証に使用


### PR DESCRIPTION
先にnixos全体をビルドしてキャッシュすることで並列実行数を抑えます。
