### PR TITLE
feat: btopを環境に合わせたカスタマイズ付きで追加

### DIFF
--- a/home/native-linux/btop.nix
+++ b/home/native-linux/btop.nix
@@ -20,6 +20,11 @@ in
     btop = {
       enable = true;
       package = btop-usable;
+      settings = {
+        # btrfsのサブボリュームはルートと同じデバイスなので、
+        # I/Oも空き容量も同じ内容が重複表示されるだけになるため除外する。
+        disks_filter = "exclude=/.snapshots /var/log /nix/store /swap";
+      };
     };
   };
 }

--- a/home/native-linux/btop.nix
+++ b/home/native-linux/btop.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  osConfig ? null,
+  ...
+}:
+let
+  hasNvidia = osConfig != null && (osConfig.hardware.nvidia.enabled or false);
+  hasAmd = osConfig != null && (osConfig.hardware.amdgpu.initrd.enable or false);
+  btop-usable =
+    with pkgs;
+    if hasNvidia then
+      btop-cuda
+    else if hasAmd then
+      btop-rocm
+    else
+      btop;
+in
+{
+  programs = {
+    btop = {
+      enable = true;
+      package = btop-usable;
+    };
+  };
+}


### PR DESCRIPTION
システムモニタとしてbtopをhome-managerで導入します。

ホストのGPU構成をosConfigから判別して、
NVIDIA環境では`btop-cuda`、
AMD環境では`btop-rocm`、
それ以外では素の`btop`を選択することで、
どのホストでもGPUの情報を表示できるようにします。
nvtopとロジックが少し被っていますが、
この程度なら抽象化しないほうが楽だと判断してまだ抽象化はしていません。

またbtrfsのサブボリューム(`/.snapshots`・`/var/log`・`/nix/store`・`/swap`)は、
ルートと同じデバイスなのでI/Oも空き容量も同じ内容が重複表示されるだけでした。
btopにはZFS向けの`zfs_hide_datasets`のような、
btrfsサブボリューム専用のオプションは存在しないため、
`disks_filter`のexclude指定で除外します。
サブボリュームのマウントポイントは全ホストで共通の構成なので、
共通の`native-linux`層に置きます。
除外方式なのでseminarの`/mnt/noa`のような別ファイルシステムは引き続き表示されます。

`nix eval`で生成される`btop.conf`に、
`disks_filter`が正しく出力されることを確認済みです。
