### PR TITLE
perf(flake): `nix flake show`が全ホストの完全評価をしてしまう問題を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -290,15 +290,24 @@
 
           checks =
             let
-              # NixOS構成の評価チェック(評価のみ、ビルドしない)
+              # NixOS構成の評価チェック(評価のみ、ビルドしない)。
+              # env属性の中の`builtins.seq`がinstantiation時にのみ完全評価を強制する。
+              # この形には2つの理由がある。
+              # チェック対象の値自体を`builtins.seq`や`writeText`のtextで強制すると、
+              # `nix flake show`のような属性値に触れるだけのコマンドでも、
+              # 全ホストの完全評価が走り数GBのメモリを消費してしまう。
+              # (`writeText`は関数適用の時点でtextを強制評価する。)
+              # かといって`drvPath`の文字列をそのままenv属性に含めると、
+              # 文字列コンテキスト経由でtoplevelへのビルド依存が発生してしまい、
+              # チェックのビルドがシステム全体の実ビルドになってしまう。
               nixosEvalChecks =
                 lib.mapAttrs'
                   (
                     name: nixosConfig:
                     lib.nameValuePair "nixos-eval-${name}" (
-                      builtins.seq nixosConfig.config.system.build.toplevel.drvPath (
-                        pkgs.writeText "nixos-eval-${name}" name
-                      )
+                      pkgs.runCommand "nixos-eval-${name}" {
+                        evaluated = builtins.seq nixosConfig.config.system.build.toplevel.drvPath name;
+                      } ''echo "$evaluated" > "$out"''
                     )
                   )
                   (
@@ -312,9 +321,9 @@
                   hmConfig = homeConfigurations.${system} or null;
                 in
                 lib.optionalAttrs (hmConfig != null) {
-                  "hm-eval" = builtins.seq hmConfig.activationPackage.drvPath (
-                    pkgs.writeText "hm-eval-${system}" system
-                  );
+                  "hm-eval" = pkgs.runCommand "hm-eval-${system}" {
+                    evaluated = builtins.seq hmConfig.activationPackage.drvPath system;
+                  } ''echo "$evaluated" > "$out"'';
                 };
             in
             nixosEvalChecks // hmEvalChecks;


### PR DESCRIPTION
これまでのchecksは`builtins.seq`でcheckの値自体を強制する形だったため、
`nix flake show`のような属性値に触れるだけのコマンドでも、
全NixOS構成+home-manager構成の完全評価が走っていました。
実測でピークRSS 5.57GB・21.4秒を消費し、
IFDに到達する構成は"omitted due to use of import from derivation"として、
表示すらされない状態でした。

`runCommand`のenv属性の中で`builtins.seq`により`drvPath`を強制する形に変えます。
`runCommand`はWHNF化の時点ではenv属性を評価しないため、
`nix flake show`はピークRSS 727MB・2.2秒で済むようになり、
全checkが正常に表示されるようになります。
一方でinstantiation時にはenv属性が強制されるため、
`nix flake check`やnix-fast-buildでは従来通り完全評価が走り、
評価チェックとしての機能は維持されます。

なお単純に`writeText`のtextとして`drvPath`を参照する形は、
`writeText`が関数適用の時点でtextを強制評価するため効果がなく、
`drvPath`文字列をそのままenv属性に含める形は、
文字列コンテキスト経由でtoplevelへのビルド依存(DrvDeep)が発生して、
チェックがシステム全体の実ビルドになってしまうため、
どちらも採用できません。
この経緯はコメントとして残しています。

checkのderivationの入力がbashとstdenvのみであることと、
nix-fast-buildの統合チェックが評価のみで成功することを確認済みです。

Claude-Session: https://claude.ai/code/session_0128xGZSD9GEwwF6nffk2gWb
