### PR TITLE
feat(gpg): GPG秘密鍵を専用ユーザgpg-vaultに隔離

### DIFF
--- a/home/core/gpg.nix
+++ b/home/core/gpg.nix
@@ -1,13 +1,18 @@
 {
+  lib,
   pkgs,
   config,
-  lib,
   isTermux,
+  osConfig ? null,
   ...
 }:
 let
   inherit (lib.hm.dag) entryBetween;
   keyConfig = import ../../key;
+  # NixOSホストではnixos/core/gpg-vault.nixのgpg-vaultユーザが秘密鍵を保持し、
+  # ncaq側ではgpg-agentを起動せずソケットだけをvaultに向けます。
+  # コーディングエージェントなどによる秘密鍵ファイルのうっかり流出防止です。
+  useVault = osConfig != null;
 in
 lib.mkMerge [
   {
@@ -40,64 +45,89 @@ lib.mkMerge [
       packages = with pkgs; [
         # 最終復旧手段として印刷するためのパッケージ。
         paperkey
-        # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
-        # こちらを優先して使っていきます。
-        # `pinentry-curses`は`pinentry-qt`パッケージに含まれています。
-        pinentry-qt
       ];
     };
   }
-  (
-    if !isTermux then
-      {
-        # 通常環境: systemdサービスでgpg-agentを管理
-        services.gpg-agent = {
-          enable = true;
-          enableSshSupport = true;
-          pinentry.package = pkgs.pinentry-qt;
-          sshKeys = [ keyConfig.sshKeygrip ];
-        };
-        # gpg-agentのssh-agentエミュレーションソケットをsystemdユーザーセッション全体に伝える。
-        # gpg-agentのSSH_AUTH_SOCK設定はインタラクティブなシェル初期化でしか行われないため、
-        # GUIアプリやsystemdサービス(`emacs.service`など)には届かない。
-        # その結果magitのssh経由のpullなどが失敗していた。
-        # `environment.d`経由で設定すればsystemdユーザーマネージャ配下の全プロセスに伝播する。
-        # `$XDG_RUNTIME_DIR`は`environment.d`が展開するのでUIDのハードコードは不要。
-        # デフォルトのgpg homedirを使う限りソケットパスは、
-        # `$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh`で固定。
-        systemd.user.sessionVariables.SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh";
-      }
-    else
-      {
-        # Termux環境: systemdが使えないためシェル初期化でgpg-agentを起動
-        programs.zsh.initContent = ''
-          # gpg-agentをSSHサポート付きで起動
-          export GPG_TTY=$(tty)
-          gpgconf --launch gpg-agent
-          export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+  (lib.mkIf (!isTermux && useVault) {
+    # NixOS環境: 秘密鍵はgpg-vaultユーザのagentが保持するため、
+    # ncaq側ではgpg-agentを起動しません。
+    # ソケットが見つからない時にgpgが鍵を持たないagentを勝手にspawnすると、
+    # 「秘密鍵が見つからない」という紛らわしいエラーになるため、
+    # autostartを無効化してソケット不在を明示的なエラーにします。
+    programs.gpg.settings.no-autostart = true;
+
+    systemd.user = {
+      # gpgクライアントは標準のソケットパス(`$XDG_RUNTIME_DIR/gnupg/`)を参照するため、
+      # symlinkでvault agentのソケットへ誘導します。
+      # `%t`はユーザtmpfilesでは`$XDG_RUNTIME_DIR`に展開されます。
+      tmpfiles.rules = [
+        "d %t/gnupg 0700 - -"
+        "L+ %t/gnupg/S.gpg-agent - - - - /run/gpg-vault/S.gpg-agent"
+        "L+ %t/gnupg/S.gpg-agent.ssh - - - - /run/gpg-vault/S.gpg-agent.ssh"
+      ];
+
+      # systemdユーザーサービス(`emacs.service`など)向けにenvironment.d経由で設定します。
+      # インタラクティブなシェル初期化だけではGUIアプリやsystemdサービスに届きません。
+      sessionVariables.SSH_AUTH_SOCK = "/run/gpg-vault/S.gpg-agent.ssh";
+    };
+
+    # インタラクティブシェル向け。
+    home.sessionVariables.SSH_AUTH_SOCK = "/run/gpg-vault/S.gpg-agent.ssh";
+  })
+  (lib.mkIf (!isTermux && !useVault) {
+    # standalone home-manager環境: systemdサービスでgpg-agentを管理
+    services.gpg-agent = {
+      enable = true;
+      enableSshSupport = true;
+      pinentry.package = pkgs.pinentry-qt;
+      sshKeys = [ keyConfig.sshKeygrip ];
+    };
+    home.packages = with pkgs; [
+      # `pinentry-gnome3`はモーダルでウィンドウを固定するのでパスワードマネージャが使いづらいため、
+      # こちらを優先して使っていきます。
+      # `pinentry-curses`は`pinentry-qt`パッケージに含まれています。
+      pinentry-qt
+    ];
+    # gpg-agentのssh-agentエミュレーションソケットをsystemdユーザーセッション全体に伝える。
+    # gpg-agentのSSH_AUTH_SOCK設定はインタラクティブなシェル初期化でしか行われないため、
+    # GUIアプリやsystemdサービス(`emacs.service`など)には届かない。
+    # その結果magitのssh経由のpullなどが失敗していた。
+    # `environment.d`経由で設定すればsystemdユーザーマネージャ配下の全プロセスに伝播する。
+    # `$XDG_RUNTIME_DIR`は`environment.d`が展開するのでUIDのハードコードは不要。
+    # デフォルトのgpg homedirを使う限りソケットパスは、
+    # `$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh`で固定。
+    systemd.user.sessionVariables.SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/gnupg/S.gpg-agent.ssh";
+  })
+  (lib.mkIf isTermux {
+    # Termux環境: 単一ユーザ環境で鍵の隔離は不可能なため従来構成。
+    # systemdが使えないためシェル初期化でgpg-agentを起動
+    programs.zsh.initContent = ''
+      # gpg-agentをSSHサポート付きで起動
+      export GPG_TTY=$(tty)
+      gpgconf --launch gpg-agent
+      export SSH_AUTH_SOCK=$(gpgconf --list-dirs agent-ssh-socket)
+    '';
+    home = {
+      file = {
+        ".gnupg/gpg-agent.conf".text = ''
+          enable-ssh-support
+          pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
         '';
-        home = {
-          file = {
-            ".gnupg/gpg-agent.conf".text = ''
-              enable-ssh-support
-              pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
-            '';
-            ".gnupg/sshcontrol".text = ''
-              # SSH認証に使用するGPGサブキーのkeygrip
-              ${keyConfig.sshKeygrip}
-            '';
-          };
-          # Termux環境ではsystemdによるGPGデーモンのライフサイクル管理がないため、
-          # keyboxdのdotlockファイルが残留しsops-nixの復号化を妨げることがあります。
-          # importGpgKeysの前にkeyboxdをkillしてpublic-keys.d/を削除し、
-          # stale lockのない状態で鍵を再インポートします。
-          activation.cleanGpgKeyboxd = entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
-            $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
-            $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash \
-              "${config.home.homeDirectory}/.gnupg/public-keys.d/" \
-              2>/dev/null || true
-          '';
-        };
-      }
-  )
+        ".gnupg/sshcontrol".text = ''
+          # SSH認証に使用するGPGサブキーのkeygrip
+          ${keyConfig.sshKeygrip}
+        '';
+      };
+      # Termux環境ではsystemdによるGPGデーモンのライフサイクル管理がないため、
+      # keyboxdのdotlockファイルが残留しsops-nixの復号化を妨げることがあります。
+      # importGpgKeysの前にkeyboxdをkillしてpublic-keys.d/を削除し、
+      # stale lockのない状態で鍵を再インポートします。
+      activation.cleanGpgKeyboxd = entryBetween [ "importGpgKeys" ] [ "createGpgHomedir" ] ''
+        $DRY_RUN_CMD ${pkgs.gnupg}/bin/gpgconf --kill keyboxd 2>/dev/null || true
+        $DRY_RUN_CMD ${pkgs.trash-cli}/bin/trash \
+          "${config.home.homeDirectory}/.gnupg/public-keys.d/" \
+          2>/dev/null || true
+      '';
+    };
+  })
 ]

--- a/key/README.md
+++ b/key/README.md
@@ -4,6 +4,29 @@
 
 公開鍵のフィンガープリント: `7DDE3BC405DC58D94BF661D342248C7D0FB73D57`
 
+## 秘密鍵の隔離(gpg-vault)
+
+NixOSホストでは秘密鍵ファイルの実体を通常ユーザから隔離しています。
+コーディングエージェントなどが通常ユーザ権限でディレクトリを一括アップロードしても、
+秘密鍵ファイル自体は流出しないようにするための「うっかり防止」です。
+
+- 秘密鍵の実体: `/var/lib/gpg-vault/.gnupg/private-keys-v1.d/`(gpg-vaultユーザ所有、mode 700)
+- gpg-agent: `gpg-vault-agent.service`がgpg-vaultユーザで稼働
+- ソケット: `/run/gpg-vault/`にありgpg-vaultグループのみ接続可能
+- 通常ユーザの`~/.gnupg`: 公開鍵リングと設定のみで秘密鍵は置かない
+
+通常ユーザのgpg/sshはソケット経由でvaultのagentを使うため、
+使い勝手は通常とほぼ同じです。
+
+設定はNixOS側が`nixos/core/gpg-vault.nix`、
+クライアント側が`home/core/gpg.nix`です。
+
+トラブル時にvault側を直接調査する場合:
+
+```zsh
+sudo -u gpg-vault env GNUPGHOME=/var/lib/gpg-vault/.gnupg gpg --list-secret-keys
+```
+
 ## 鍵の構成
 
 - 暗号副鍵: 全端末で共通
@@ -85,15 +108,20 @@ gpgconf --kill gpg-agent
 ### 端末にimport
 
 副鍵をimportします。
+秘密鍵はソケット経由でvaultのagentに送られ、
+`/var/lib/gpg-vault/.gnupg/private-keys-v1.d/`に保存されます。
 
 ```zsh
 gpg --import subkeys-secret.asc
 ```
 
 パスフレーズを削除します。
+vaultのagentはgpg-vaultユーザで動いており、
+pinentryがユーザ境界を跨いで端末を開けないため、
+loopbackモードでgpg自身にパスフレーズを入力します。
 
 ```zsh
-gpg --edit-key ncaq@ncaq.net
+gpg --pinentry-mode loopback --edit-key ncaq@ncaq.net
 ```
 
 ```console
@@ -110,7 +138,7 @@ gpg> save
 動作確認。
 
 ```zsh
-gpgconf --kill gpg-agent
+sudo systemctl restart gpg-vault-agent.service
 echo "test" | gpg --sign --armor
 ```
 

--- a/key/default.nix
+++ b/key/default.nix
@@ -1,4 +1,7 @@
 {
+  # 公開鍵のフィンガープリント。
+  fingerprint = "7DDE3BC405DC58D94BF661D342248C7D0FB73D57";
+
   # 署名と認証機能のある鍵のフィンガープリント。
   identityKey = "ACA66AB679E75544";
 

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -106,12 +106,23 @@ in
         RuntimeDirectoryMode = "0750";
         StateDirectory = "gpg-vault";
         StateDirectoryMode = "0700";
-        # 軽いハードニング。
-        # 秘密鍵を扱うプロセスなので不要な場所を見せません。
+        # ハードニング。
+        # 秘密鍵を扱うプロセスなので、
+        # 不要な場所を見せず不要な特権と通信経路を断ちます。
+        CapabilityBoundingSet = [ ];
+        LockPersonality = true;
         NoNewPrivileges = true;
+        PrivateDevices = true;
         PrivateTmp = true;
+        ProtectControlGroups = true;
         ProtectHome = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
         ProtectSystem = "strict";
+        # gpg-agentのソケットはUNIXドメインのみでネットワーク通信は不要です。
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        RestrictNamespaces = true;
+        SystemCallFilter = [ "@system-service" ];
       };
     };
 

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -141,8 +141,10 @@ in
         # forkingなら起動完了時点でソケットが利用可能です。
         Type = "forking";
         ExecStart = "${pkgs.gnupg}/bin/gpg-agent --daemon";
-        # ソケットのパーミッションはumaskに依存するため、
-        # グループ書き込み(=接続)可能に揃えます。
+        # gpg-agentはumaskに関係なくソケットを0700で生成することを検証済みなので、
+        # このchmodによるグループ書き込み(=接続)許可は必須です。
+        # ExecStartPostの完了までunitはstartedにならないため、
+        # After=で順序付けされた依存サービスが0700の窓に当たることはありません。
         ExecStartPost = "${pkgs.coreutils}/bin/chmod 0660 ${socketDir}/S.gpg-agent ${socketDir}/S.gpg-agent.ssh";
         Restart = "on-failure";
         Environment = [ "GNUPGHOME=${gnupgHome}" ];

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -36,15 +36,17 @@ let
     trusted-key ${keyConfig.fingerprint}
   '';
 
-  # パスフレーズなし運用なのでpinentryが実際に呼ばれることはありませんが、
-  # 設定として有効なパスは必要です。
-  # allow-loopback-pinentryは鍵更新時にncaq側から、
-  # `--pinentry-mode loopback`でパスフレーズ操作をするために必要です。
-  # pinentryはユーザ境界を跨いでncaqの端末を開けないためloopbackを使います。
   gpgAgentConf = pkgs.writeText "gpg-vault-gpg-agent.conf" ''
     enable-ssh-support
+    # 鍵更新時にncaq側から`--pinentry-mode loopback`でパスフレーズ操作をするために必要です。
+    # pinentryはユーザ境界を跨いでncaqの端末を開けないためloopbackを使います。
     allow-loopback-pinentry
+    # パスフレーズなし運用なのでpinentryが実際に呼ばれることはありませんが、
+    # 設定として有効なパスは必要です。
     pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
+    # スマートカードは使わない運用なので、
+    # 鍵操作時にscdaemonがカード探索のためにspawnされるのを止めます。
+    disable-scdaemon
   '';
 
   # SSH認証に使用するGPGサブキーのkeygrip。
@@ -114,6 +116,15 @@ in
     gpg-vault-agent = {
       description = "gpg-agent holding secret keys isolated from normal users";
       wantedBy = [ "multi-user.target" ];
+      # agentが読む設定はtmpfilesで配置されていてunit定義に含まれないため、
+      # 内容が変わってもそのままではサービスが再起動されません。
+      # 設定変更時に確実に再起動させます。
+      restartTriggers = [
+        gpgAgentConf
+        sshcontrolFile
+        (socketRedirect "S.gpg-agent")
+        (socketRedirect "S.gpg-agent.ssh")
+      ];
       # rootで動くsops-install-secretsがこのGNUPGHOMEで復号する際に、
       # 鍵IDを解決できるよう公開鍵をvault側のpubringにも取り込みます。
       # importは冪等ですが手続き的な処理なので、

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -29,6 +29,42 @@ let
   vaultHome = "/var/lib/gpg-vault";
   gnupgHome = "${vaultHome}/.gnupg";
   socketDir = "/run/gpg-vault";
+
+  # `trusted-key`で主鍵をultimate信頼として宣言します。
+  # これによりpreStartでの`--import-ownertrust`によるgpg起動が不要になります。
+  gpgConf = pkgs.writeText "gpg-vault-gpg.conf" ''
+    trusted-key ${keyConfig.fingerprint}
+  '';
+
+  # パスフレーズなし運用なのでpinentryが実際に呼ばれることはありませんが、
+  # 設定として有効なパスは必要です。
+  # allow-loopback-pinentryは鍵更新時にncaq側から、
+  # `--pinentry-mode loopback`でパスフレーズ操作をするために必要です。
+  # pinentryはユーザ境界を跨いでncaqの端末を開けないためloopbackを使います。
+  gpgAgentConf = pkgs.writeText "gpg-vault-gpg-agent.conf" ''
+    enable-ssh-support
+    allow-loopback-pinentry
+    pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses
+  '';
+
+  # SSH認証に使用するGPGサブキーのkeygrip。
+  sshcontrolFile = pkgs.writeText "gpg-vault-sshcontrol" ''
+    ${keyConfig.sshKeygrip}
+  '';
+
+  # gpg-vaultはシステムユーザで/run/user/<uid>を持たないため、
+  # 何もしないとソケットはGNUPGHOME直下に作られ、
+  # mode 700のディレクトリ内なので通常ユーザから届かなくなります。
+  # Assuanソケットリダイレクトで共有ディレクトリにソケットを作らせます。
+  # gpg-agentはリダイレクトファイル自体は終了時に削除しない
+  # (削除するのはリダイレクト先の実ソケットだけ)ことを検証済みなので、
+  # storeへのsymlinkとして配置してもサービス再起動を跨いで機能します。
+  socketRedirect =
+    socketName:
+    pkgs.writeText "gpg-vault-redirect-${socketName}" ''
+      %Assuan%
+      socket=${socketDir}/${socketName}
+    '';
 in
 {
   users = {
@@ -45,49 +81,47 @@ in
     groups.gpg-vault = { };
   };
 
+  # GNUPGHOMEの静的な内容は宣言的に配置します。
+  # ディレクトリと空のcommon.confを実体として作り、
+  # 内容を持つ設定ファイルはstoreへのsymlinkにします。
+  # common.confを空にするのはkeyboxdを有効化しないためで、
+  # 理由はhome/core/gpg.nixのncaq側common.confと同じです。
+  systemd.tmpfiles.settings."50-gpg-vault" =
+    let
+      vaultDir = {
+        user = "gpg-vault";
+        group = "gpg-vault";
+        mode = "0700";
+      };
+    in
+    {
+      ${vaultHome}.d = vaultDir;
+      ${gnupgHome}.d = vaultDir;
+      "${gnupgHome}/private-keys-v1.d".d = vaultDir;
+      "${gnupgHome}/common.conf".f = {
+        user = "gpg-vault";
+        group = "gpg-vault";
+        mode = "0600";
+      };
+      "${gnupgHome}/gpg.conf"."L+".argument = "${gpgConf}";
+      "${gnupgHome}/gpg-agent.conf"."L+".argument = "${gpgAgentConf}";
+      "${gnupgHome}/sshcontrol"."L+".argument = "${sshcontrolFile}";
+      "${gnupgHome}/S.gpg-agent"."L+".argument = "${socketRedirect "S.gpg-agent"}";
+      "${gnupgHome}/S.gpg-agent.ssh"."L+".argument = "${socketRedirect "S.gpg-agent.ssh"}";
+    };
+
   systemd.services = {
     gpg-vault-agent = {
       description = "gpg-agent holding secret keys isolated from normal users";
       wantedBy = [ "multi-user.target" ];
-      # GNUPGHOMEを毎回起動時に整備します。
-      # 全て冪等な操作です。
+      # rootで動くsops-install-secretsがこのGNUPGHOMEで復号する際に、
+      # 鍵IDを解決できるよう公開鍵をvault側のpubringにも取り込みます。
+      # importは冪等ですが手続き的な処理なので、
+      # ここだけpreStartに残しています。
       # ExecStartPreは`User=`で指定したgpg-vaultユーザで実行されます。
       preStart = ''
         umask 077
-        mkdir -p "${gnupgHome}/private-keys-v1.d"
-
-        # keyboxdを有効化しないための空のcommon.conf。
-        # 理由はhome/core/gpg.nixのncaq側common.confと同じです。
-        : > "${gnupgHome}/common.conf"
-
-        # パスフレーズなし運用なのでpinentryが実際に呼ばれることはありませんが、
-        # 設定として有効なパスは必要です。
-        # allow-loopback-pinentryは鍵更新時にncaq側から、
-        # `--pinentry-mode loopback`でパスフレーズ操作をするために必要です。
-        # pinentryはユーザ境界を跨いでncaqの端末を開けないためloopbackを使います。
-        {
-          echo "enable-ssh-support"
-          echo "allow-loopback-pinentry"
-          echo "pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses"
-        } > "${gnupgHome}/gpg-agent.conf"
-
-        # SSH認証に使用するGPGサブキーのkeygrip。
-        echo "${keyConfig.sshKeygrip}" > "${gnupgHome}/sshcontrol"
-
-        # gpg-vaultはシステムユーザで/run/user/<uid>を持たないため、
-        # 何もしないとソケットはGNUPGHOME直下に作られ、
-        # mode 700のディレクトリ内なので通常ユーザから届かなくなります。
-        # Assuanソケットリダイレクトで共有ディレクトリにソケットを作らせます。
-        printf '%%Assuan%%\nsocket=%s\n' "${socketDir}/S.gpg-agent" \
-          > "${gnupgHome}/S.gpg-agent"
-        printf '%%Assuan%%\nsocket=%s\n' "${socketDir}/S.gpg-agent.ssh" \
-          > "${gnupgHome}/S.gpg-agent.ssh"
-
-        # rootで動くsops-install-secretsがこのGNUPGHOMEで復号する際に、
-        # 鍵IDを解決できるよう公開鍵をvault側のpubringにも取り込みます。
         ${pkgs.gnupg}/bin/gpg --batch --no-autostart --quiet --import ${keyConfig.publicKeyFile}
-        echo "${keyConfig.fingerprint}:6:" | \
-          ${pkgs.gnupg}/bin/gpg --batch --no-autostart --quiet --import-ownertrust
       '';
       serviceConfig = {
         User = "gpg-vault";

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -1,0 +1,133 @@
+/**
+  GPG秘密鍵を通常ユーザから隔離するための専用ユーザとgpg-agentサービス。
+
+  コーディングエージェントなどが通常ユーザ権限でディレクトリを一括アップロードしても、
+  秘密鍵ファイル自体は流出しないようにする「うっかり防止」の仕組みです。
+
+  GnuPGは設計上、
+  gpgクライアントは秘密鍵ファイルを直接読まず、
+  秘密鍵操作は全てgpg-agentにソケット経由で委譲します。
+  この性質を利用して、
+  秘密鍵の実体はgpg-vaultユーザのGNUPGHOME(mode 700)に置き、
+  gpg-agentをgpg-vaultユーザで動かし、
+  ソケットだけをgpg-vaultグループ経由で通常ユーザに公開します。
+
+  通常ユーザ側のクライアント設定はhome/core/gpg.nixにあります。
+
+  厳密なアクセス制御ではありません:
+  通常ユーザはソケット経由で署名・復号・SSH認証・鍵のエクスポートを引き続き利用できます。
+  防げるのはうっかりアップロードさせるミスだけです。
+  悪意は防げません。
+*/
+{
+  pkgs,
+  username,
+  ...
+}:
+let
+  keyConfig = import ../../key;
+  vaultHome = "/var/lib/gpg-vault";
+  gnupgHome = "${vaultHome}/.gnupg";
+  socketDir = "/run/gpg-vault";
+in
+{
+  users = {
+    users = {
+      gpg-vault = {
+        isSystemUser = true;
+        group = "gpg-vault";
+        home = vaultHome;
+        description = "GPG secret key vault";
+      };
+      # ソケットへの接続はgpg-vaultグループで制限します。
+      ${username}.extraGroups = [ "gpg-vault" ];
+    };
+    groups.gpg-vault = { };
+  };
+
+  systemd.services = {
+    gpg-vault-agent = {
+      description = "gpg-agent holding secret keys isolated from normal users";
+      wantedBy = [ "multi-user.target" ];
+      # GNUPGHOMEを毎回起動時に整備します。
+      # 全て冪等な操作です。
+      # ExecStartPreは`User=`で指定したgpg-vaultユーザで実行されます。
+      preStart = ''
+        umask 077
+        mkdir -p "${gnupgHome}/private-keys-v1.d"
+
+        # keyboxdを有効化しないための空のcommon.conf。
+        # 理由はhome/core/gpg.nixのncaq側common.confと同じです。
+        : > "${gnupgHome}/common.conf"
+
+        # パスフレーズなし運用なのでpinentryが実際に呼ばれることはありませんが、
+        # 設定として有効なパスは必要です。
+        # allow-loopback-pinentryは鍵更新時にncaq側から、
+        # `--pinentry-mode loopback`でパスフレーズ操作をするために必要です。
+        # pinentryはユーザ境界を跨いでncaqの端末を開けないためloopbackを使います。
+        {
+          echo "enable-ssh-support"
+          echo "allow-loopback-pinentry"
+          echo "pinentry-program ${pkgs.pinentry-curses}/bin/pinentry-curses"
+        } > "${gnupgHome}/gpg-agent.conf"
+
+        # SSH認証に使用するGPGサブキーのkeygrip。
+        echo "${keyConfig.sshKeygrip}" > "${gnupgHome}/sshcontrol"
+
+        # gpg-vaultはシステムユーザで/run/user/<uid>を持たないため、
+        # 何もしないとソケットはGNUPGHOME直下に作られ、
+        # mode 700のディレクトリ内なので通常ユーザから届かなくなります。
+        # Assuanソケットリダイレクトで共有ディレクトリにソケットを作らせます。
+        printf '%%Assuan%%\nsocket=%s\n' "${socketDir}/S.gpg-agent" \
+          > "${gnupgHome}/S.gpg-agent"
+        printf '%%Assuan%%\nsocket=%s\n' "${socketDir}/S.gpg-agent.ssh" \
+          > "${gnupgHome}/S.gpg-agent.ssh"
+
+        # rootで動くsops-install-secretsがこのGNUPGHOMEで復号する際に、
+        # 鍵IDを解決できるよう公開鍵をvault側のpubringにも取り込みます。
+        ${pkgs.gnupg}/bin/gpg --batch --no-autostart --quiet --import ${keyConfig.publicKeyFile}
+        echo "${keyConfig.fingerprint}:6:" | \
+          ${pkgs.gnupg}/bin/gpg --batch --no-autostart --quiet --import-ownertrust
+      '';
+      serviceConfig = {
+        User = "gpg-vault";
+        Group = "gpg-vault";
+        # gpg-agentはソケットを作り終えてからforkするため、
+        # forkingなら起動完了時点でソケットが利用可能です。
+        Type = "forking";
+        ExecStart = "${pkgs.gnupg}/bin/gpg-agent --daemon";
+        # ソケットのパーミッションはumaskに依存するため、
+        # グループ書き込み(=接続)可能に揃えます。
+        ExecStartPost = "${pkgs.coreutils}/bin/chmod 0660 ${socketDir}/S.gpg-agent ${socketDir}/S.gpg-agent.ssh";
+        Restart = "on-failure";
+        Environment = [ "GNUPGHOME=${gnupgHome}" ];
+        UMask = "0007";
+        RuntimeDirectory = "gpg-vault";
+        RuntimeDirectoryMode = "0750";
+        StateDirectory = "gpg-vault";
+        StateDirectoryMode = "0700";
+        # 軽いハードニング。
+        # 秘密鍵を扱うプロセスなので不要な場所を見せません。
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+      };
+    };
+
+    # sops-install-secretsはvault agent経由で復号するため順序を保証します。
+    # agentが未起動だとgpgのautostartがリダイレクト先の、
+    # 存在しない${socketDir}にソケットを作ろうとして失敗します。
+    sops-install-secrets = {
+      after = [ "gpg-vault-agent.service" ];
+      wants = [ "gpg-vault-agent.service" ];
+    };
+
+    # home-manager activationのimportGpgKeysなどはgpg-agentに接続するため、
+    # vault agentの起動を待ちます。
+    "home-manager-${username}" = {
+      after = [ "gpg-vault-agent.service" ];
+      wants = [ "gpg-vault-agent.service" ]; # 失敗してもなるべく起動してほしいので弱い依存。
+    };
+  };
+}

--- a/nixos/core/sops.nix
+++ b/nixos/core/sops.nix
@@ -1,11 +1,15 @@
-{ pkgs, username, ... }:
+{ pkgs, ... }:
 {
   sops = {
     # sops-install-secrets.serviceを生成し、他のサービスから明示的に依存可能にする。
     useSystemdActivation = true;
     # gnupgの設定を明示的に指定します。
+    # 秘密鍵はgpg-vaultユーザに隔離されているため(gpg-vault.nix)、
+    # そちらのGNUPGHOMEを参照します。
+    # sops-install-secretsはrootで動くので、
+    # vault agentのソケット経由またはファイル直接読み取りで復号できます。
     gnupg = {
-      home = "/home/${username}/.gnupg";
+      home = "/var/lib/gpg-vault/.gnupg";
       sshKeyPaths = [ ];
     };
   };

--- a/nixos/core/sops.nix
+++ b/nixos/core/sops.nix
@@ -6,8 +6,8 @@
     # gnupgの設定を明示的に指定します。
     # 秘密鍵はgpg-vaultユーザに隔離されているため(gpg-vault.nix)、
     # そちらのGNUPGHOMEを参照します。
-    # sops-install-secretsはrootで動くので、
-    # vault agentのソケット経由またはファイル直接読み取りで復号できます。
+    # 復号はvault agentにソケット経由で委譲されるため、
+    # gpg-vault.nix側で`gpg-vault-agent.service`への順序依存を設定しています。
     gnupg = {
       home = "/var/lib/gpg-vault/.gnupg";
       sshKeyPaths = [ ];


### PR DESCRIPTION
コーディングエージェントなどが通常ユーザ権限でディレクトリを一括アップロードした場合でも、
秘密鍵ファイル自体は流出しないようにする「うっかり防止」の仕組みを導入します。
sops-nixのシークレットは暗号化されていても、
復号鍵であるGPG秘密鍵が一緒に流出すると意味がなくなるためです。

GnuPGは設計上、
gpgクライアントは秘密鍵ファイルを直接読まず、
秘密鍵操作は全てgpg-agentにソケット経由で委譲します。
この性質を利用して以下の構成にします。

- 秘密鍵の実体は`gpg-vault`システムユーザの`/var/lib/gpg-vault/.gnupg`(mode 700)に置く
- gpg-agentは`gpg-vault-agent.service`として`gpg-vault`ユーザで稼働させる
- ソケットは`/run/gpg-vault/`に置き、`gpg-vault`グループのみ接続可能にする
- 通常ユーザ側はagentを起動せず、
  標準ソケットパスからのsymlinkと`SSH_AUTH_SOCK`でvaultのソケットを参照する

これにより通常ユーザのgpg/ssh/git署名は今まで通り使えますが、
秘密鍵ファイルの読み出しはファイルパーミッションで拒否されます。
厳密なアクセス制御ではなく、
ソケット経由の署名・復号・エクスポートは引き続き可能です。

gpg-vaultはシステムユーザで`/run/user/<uid>`を持たないため、
ソケットの配置はAssuanソケットリダイレクトファイルで誘導します。
またgpg-agentはumaskを無視してソケットを0700で作るため、
`ExecStartPost`のchmodでグループ接続を許可します。
どちらもuser namespaceでの実地テストで動作確認済みです。

rootで動くsops-install-secretsの`gnupg.home`はvault側に変更します。
鍵ID解決に必要な公開鍵はサービスのpreStartでvault側pubringにも取り込みます。

standalone home-manager環境は`osConfig`の有無で判別して従来構成を維持し、
Termuxは単一ユーザ環境で隔離が不可能なため従来構成のままです。

鍵更新手順の変更はkey/README.mdに記載しています。

全ホストのNixOS評価とstandalone home構成とTermux分岐の評価と、
nix-fast-buildの統合チェックが通ることを確認済みです。
またseminarで実際に移行を完了し、
署名・SSH認証・システム/ユーザ両sopsの正常動作を確認済みです。

Claude-Session: https://claude.ai/code/session_013L9LZ34X3QqZ9zWUgrcrh6