### PR TITLE
feat(opencode): Claude Code代替用にOpenCodeの基礎設定を追加

### DIFF
--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -1,0 +1,19 @@
+{ pkgs-unstable, config, ... }:
+{
+  programs.opencode = {
+    enable = true;
+    # コーディングエージェントは更新が早くサーバも最新バージョンを要求しがちなのでunstableを使います。
+    package = pkgs-unstable.opencode;
+    # グローバル指示です。
+    # `~/.config/opencode/AGENTS.md`に配置されます。
+    context = config.prompt.codingAgent;
+    # `mcp.nix`と連携します。
+    enableMcpIntegration = true;
+    # `~/.config/opencode/opencode.json`に配置されます。
+    settings = {
+      # パッケージはNixで管理しているため自己アップデートは無効にします。
+      autoupdate = false;
+      # デフォルトモデルは現在あえて宣言しません。
+    };
+  };
+}


### PR DESCRIPTION
Claude Codeがインフラトラブルで動かない時や、
他のモデルを使いたい時のための代替コーディングエージェントとして、
OpenCodeをhome-managerの`programs.opencode`モジュールで宣言的に設定します。

codex.nixと同じパターンで、
更新の早さからパッケージはunstableを使い、
`context`でClaude Codeと同じグローバル指示を`AGENTS.md`として配置し、 `enableMcpIntegration`で`mcp.nix`のMCPサーバ定義を共有します。
sopsのシークレットはOpenCodeの`{file:...}`参照形式に変換されることを、
生成された`opencode.json`のビルドで確認済みです。

パッケージはNixで管理しているため自己アップデートは無効にします。

デフォルトモデルはあえて宣言しません。
主バックエンドに想定しているGitHub Copilotは、
OpenCode内の`/connect`コマンドによる対話認証が必須で、
利用可能なモデルIDも契約プランや時期によって変動するためです。
初回に`/models`で選択したモデルが記憶されます。

nix-fast-buildの統合チェックが全ホストで成功することを確認済みです。

ref https://github.com/ncaq/dotfiles/issues/1373

Claude-Session: https://claude.ai/code/session_017t9huxUBwHYDgGyaFrMBiT