### PR TITLE
fix(cifs): 起動時にsambaのマウントがたまに失敗する問題を修正

### DIFF
--- a/nixos/core/tailscale.nix
+++ b/nixos/core/tailscale.nix
@@ -25,9 +25,16 @@
       ExecStart = lib.getExe (
         pkgs.writeShellApplication {
           name = "wait-for-tailscale";
-          runtimeInputs = [ config.services.tailscale.package ];
+          runtimeInputs = with pkgs; [
+            config.services.tailscale.package
+            jq
+          ];
+          # `tailscale status`の終了コードはtailscaledが応答するだけで成功になり、
+          # キャッシュされたログイン状態でも通ってしまうため接続性の保証にならない。
+          # `.Self.Online`はコーディネーションサーバに実際に接続できているかを示すので、
+          # これがtrueになるまで待つ。
           text = ''
-            until tailscale status --peers=false > /dev/null 2>&1; do
+            until tailscale status --json --peers=false | jq -e '.Self.Online == true' > /dev/null 2>&1; do
               sleep 1
             done
           '';

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -130,6 +130,14 @@ lib.mkMerge [
         # 到達性が回復するまで待ってから再マウントする。
         mnt-chihiro-retry = {
           description = "Retry mounting /mnt/chihiro after failure";
+          unitConfig = {
+            # mount側のStartLimitだけに停止保証を頼らない。
+            # mountがstart-limit-hitで拒否された場合にOnFailureが再発火するかは、
+            # systemdのバージョンで挙動が異なるため(systemd/systemd#33710)、
+            # 再発火する環境でもこのサービス自身の起動制限でループを確実に打ち切る。
+            StartLimitIntervalSec = 600;
+            StartLimitBurst = 5;
+          };
           serviceConfig = {
             Type = "oneshot";
             TimeoutStartSec = 600;

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -99,12 +99,6 @@ lib.mkMerge [
         }
       ];
 
-      # systemd.target(5)により、
-      # ターゲットが`Wants=`で引き込んだユニットの両方が`DefaultDependencies=yes`の場合、
-      # 暗黙的に`After=`が追加される。
-      # `DefaultDependencies=false`を設定することで、
-      # `multi-user.target`が暗黙的に`After=cifs-mount.target`を追加するのを防ぎ、
-      # ブートをブロックしない。
       services = {
         # seminarのSMBポートへの実到達性を確認するサービス。
         # `tailscale-online.service`はtailnetへの接続までしか保証せず、
@@ -164,6 +158,12 @@ lib.mkMerge [
       targets.cifs-mount = {
         description = "CIFS Network Mounts";
         wantedBy = [ "multi-user.target" ];
+        # systemd.target(5)により、
+        # ターゲットが`Wants=`で引き込んだユニットの両方が`DefaultDependencies=yes`の場合、
+        # 暗黙的に`After=`が追加される。
+        # `DefaultDependencies=false`を設定することで、
+        # `multi-user.target`が暗黙的に`After=cifs-mount.target`を追加するのを防ぎ、
+        # ブートをブロックしない。
         unitConfig.DefaultDependencies = false;
       };
 

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -8,6 +8,22 @@
 }:
 let
   userConfig = config.users.users.${username};
+  # seminarのSMBポートへ実際にTCP接続できるまで待つスクリプト。
+  # `network-online.target`や`tailscale-online.service`はどちらも
+  # 「seminarに到達できる」ことまでは保証しないため、
+  # マウント前に実到達性を確認する必要がある。
+  waitForSeminar = pkgs.writeShellApplication {
+    name = "wait-for-seminar";
+    runtimeInputs = with pkgs; [
+      bash
+      coreutils
+    ];
+    text = ''
+      until timeout 5 bash -c ': < /dev/tcp/seminar/445'; do
+        sleep 2
+      done
+    '';
+  };
 in
 lib.mkMerge [
   (lib.mkIf (hostName != "seminar") {
@@ -24,14 +40,25 @@ lib.mkMerge [
         {
           requires = [ "network-online.target" ];
           wants = [
+            "seminar-online.service"
             "sops-install-secrets.service"
             "tailscale-online.service"
           ];
           after = [
             "network-online.target"
+            "seminar-online.service"
             "sops-install-secrets.service"
             "tailscale-online.service"
           ];
+          unitConfig = {
+            # マウント失敗時はリトライ用サービスに委ねる。
+            # mountユニット自体はRestart=を持てないため、
+            # 到達性を待ってから再マウントする別サービスで補う。
+            OnFailure = [ "mnt-chihiro-retry.service" ];
+            # リトライが恒久的な失敗(認証エラーなど)で無限ループしないよう起動回数を制限する。
+            StartLimitIntervalSec = 600;
+            StartLimitBurst = 5;
+          };
           # `cifs-mount.target`に向けてwantedByする。
           # `cifs-mount.target`は`DefaultDependencies=false`のため、
           # `multi-user.target`からの暗黙的な順序依存が追加されず、ブートをブロックしない。
@@ -78,6 +105,54 @@ lib.mkMerge [
       # `DefaultDependencies=false`を設定することで、
       # `multi-user.target`が暗黙的に`After=cifs-mount.target`を追加するのを防ぎ、
       # ブートをブロックしない。
+      services = {
+        # seminarのSMBポートへの実到達性を確認するサービス。
+        # `tailscale-online.service`はtailnetへの接続までしか保証せず、
+        # seminar自体が起動していて到達可能かは別問題のため独立したサービスにしている。
+        seminar-online = {
+          description = "Wait for seminar SMB port to be reachable";
+          wants = [ "tailscale-online.service" ];
+          after = [
+            "network-online.target"
+            "tailscale-online.service"
+          ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            # seminarがダウンしている場合に永久に待たないよう上限を設ける。
+            # 失敗してもマウント側はwantsなので試行自体は行われ、nofailで害はない。
+            TimeoutStartSec = 300;
+            ExecStart = lib.getExe waitForSeminar;
+          };
+        };
+
+        # マウント失敗時にOnFailureから起動されるリトライサービス。
+        # 到達性が回復するまで待ってから再マウントする。
+        mnt-chihiro-retry = {
+          description = "Retry mounting /mnt/chihiro after failure";
+          serviceConfig = {
+            Type = "oneshot";
+            TimeoutStartSec = 600;
+            ExecStart = lib.getExe (
+              pkgs.writeShellApplication {
+                name = "retry-mnt-chihiro";
+                runtimeInputs = with pkgs; [
+                  coreutils
+                  systemd
+                  waitForSeminar
+                ];
+                # 失敗直後の即時再試行は同じ理由で失敗しやすいので少し置く。
+                text = ''
+                  sleep 10
+                  wait-for-seminar
+                  systemctl restart mnt-chihiro.mount
+                '';
+              }
+            );
+          };
+        };
+      };
+
       targets.cifs-mount = {
         description = "CIFS Network Mounts";
         wantedBy = [ "multi-user.target" ];

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -105,7 +105,10 @@ lib.mkMerge [
         # seminar自体が起動していて到達可能かは別問題のため独立したサービスにしている。
         seminar-online = {
           description = "Wait for seminar SMB port to be reachable";
-          wants = [ "tailscale-online.service" ];
+          wants = [
+            "network-online.target"
+            "tailscale-online.service"
+          ];
           after = [
             "network-online.target"
             "tailscale-online.service"


### PR DESCRIPTION
ブート時に`/mnt/chihiro`のCIFSマウントがたまに失敗する原因を調査したところ、
NICドライバ(r8169)のロードがwait-onlineより遅れたブートでは、
NetworkManager-wait-onlineが待つべきデバイスを認識できず即座に完了してしまい、
物理リンクが上がる前にマウントを試みて接続タイムアウトで失敗していました。
`nofail`のため失敗後のリトライも存在しませんでした。

依存サービスの判定を実態に合わせて厳密にし、
念のためのリトライも追加します。

- `tailscale-online.service`は`tailscale status`の終了コードではなく、
  `.Self.Online`がtrueになるまで待つように変更します。
  従来はtailscaledがキャッシュされたログイン状態で応答するだけで成功してしまい、
  tailnetへの実際の接続を保証していませんでした。
- `seminar-online.service`を新設し、
  seminarのSMBポート(445)へ実際にTCP接続できるまで待ってからマウントします。
  tailnetに接続できてもseminar自体に到達可能かは別問題のためです。
- マウント失敗時は`OnFailure`から`mnt-chihiro-retry.service`を起動し、
  到達性の回復を待ってから再マウントします。
  恒久的な失敗での無限ループは`StartLimitIntervalSec`と`StartLimitBurst`で防ぎます。

automountによる遅延マウントは、
ブート時にシンボリックリンク経由のアクセスで、
Tailscale接続前のマウントが誘発されてブートをブロックした前歴があるため採用しません。

bulletでビルドと適用を行い、
新チェックの成立とマウントの成功を確認済みです。

Claude-Session: https://claude.ai/code/session_01EnmwzP6wPxLLfeWFSBgZHd
