### PR TITLE
feat(konoka): プラグインをflake input参照に切り替えOpenCodeでも利用可能にする

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,6 +273,32 @@
         "type": "github"
       }
     },
+    "konoka": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784772874,
+        "narHash": "sha256-UlgVhk2UJKh101EzJFhWRQoOz/n2wodpLUAKk0PGRME=",
+        "owner": "ncaq",
+        "repo": "konoka",
+        "rev": "d742d1f5b4871a1c75702fd0131b2979bcb78016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ncaq",
+        "repo": "konoka",
+        "type": "github"
+      }
+    },
     "microvm": {
       "inputs": {
         "nixpkgs": [
@@ -570,6 +596,7 @@
         "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
+        "konoka": "konoka",
         "microvm": "microvm",
         "niks3": "niks3",
         "nix-on-droid": "nix-on-droid",

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,15 @@
       };
     };
 
+    konoka = {
+      url = "github:ncaq/konoka";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
     claude-desktop = {
       url = "github:k3d3/claude-desktop-linux-flake";
       inputs = {

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -1,19 +1,14 @@
 {
+  lib,
   pkgs,
   pkgs-unstable,
   config,
-  lib,
-  inputs,
+  konoka,
   osConfig ? null,
   ...
 }:
 let
   ccstatusline = pkgs.callPackage ../../pkgs/ccstatusline.nix { };
-
-  # flake input経由でkonokaプラグインを取得します。
-  # ユーザレベルのプラグインはClaude Codeのmarketplace経由ではなく、
-  # ビルド済みプラグインを直接読み込みます。
-  konokaPlugins = inputs.konoka.packages.${pkgs.stdenv.hostPlatform.system};
 
   # コーディングエージェントの作業ディレクトリ。
   # konokaプラグインは`${XDG_RUNTIME_DIR:-/tmp}/coding-agent-work/`を使用します。
@@ -40,19 +35,7 @@ in
     enableMcpIntegration = true;
 
     # ビルド済みのプラグインパッケージを直接リンクします。
-    plugins = with konokaPlugins; [
-      commit
-      haskell-tasuke
-      kyosei
-      log-analyzer
-      nix-tasuke
-      pr
-      programming-tasuke
-      proofreading-ja
-      research
-      rm-to-trash
-      web-tasuke
-    ];
+    plugins = map (n: konoka.plugins.${n}) konoka.allPluginNames;
 
     settings = {
       # 応答に使う自然言語です。

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -3,11 +3,17 @@
   pkgs-unstable,
   config,
   lib,
+  inputs,
   osConfig ? null,
   ...
 }:
 let
   ccstatusline = pkgs.callPackage ../../pkgs/ccstatusline.nix { };
+
+  # flake input経由でkonokaプラグインを取得します。
+  # ユーザレベルのプラグインはClaude Codeのmarketplace経由ではなく、
+  # ビルド済みプラグインを直接読み込みます。
+  konokaPlugins = inputs.konoka.packages.${pkgs.stdenv.hostPlatform.system};
 
   # コーディングエージェントの作業ディレクトリ。
   # konokaプラグインは`${XDG_RUNTIME_DIR:-/tmp}/coding-agent-work/`を使用します。
@@ -32,6 +38,21 @@ in
 
     # `mcp.nix`と連携します。
     enableMcpIntegration = true;
+
+    # ビルド済みのプラグインパッケージを直接リンクします。
+    plugins = with konokaPlugins; [
+      commit
+      haskell-tasuke
+      kyosei
+      log-analyzer
+      nix-tasuke
+      pr
+      programming-tasuke
+      proofreading-ja
+      research
+      rm-to-trash
+      web-tasuke
+    ];
 
     settings = {
       # 応答に使う自然言語です。
@@ -110,13 +131,6 @@ in
             repo = "anthropics/claude-plugins-official";
           };
         };
-        konoka = {
-          source = {
-            source = "github";
-            repo = "ncaq/konoka";
-            ref = "v8.6.4";
-          };
-        };
       };
       # pluginを記述しておくことで起動時にインストールされていない場合自動でインストールされます。
       enabledPlugins = {
@@ -126,18 +140,6 @@ in
         "pyright-lsp@claude-plugins-official" = true;
         "rust-analyzer-lsp@claude-plugins-official" = true;
         "typescript-lsp@claude-plugins-official" = true;
-        # konoka
-        "commit@konoka" = true;
-        "haskell-tasuke@konoka" = true;
-        "kyosei@konoka" = true;
-        "log-analyzer@konoka" = true;
-        "nix-tasuke@konoka" = true;
-        "pr@konoka" = true;
-        "programming-tasuke@konoka" = true;
-        "proofreading-ja@konoka" = true;
-        "research@konoka" = true;
-        "rm-to-trash@konoka" = true;
-        "web-tasuke@konoka" = true;
       };
       skipAutoPermissionPrompt = true; # auto modeをdefaultModeにしているので許可を求めない。
       permissions = {

--- a/home/core/konoka.nix
+++ b/home/core/konoka.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  # flake input経由でkonokaプラグインを取得します。
+  # marketplace経由ではなくビルド済みプラグインを直接読み込むことで、
+  # ヘルパースクリプトまでnixで管理できます。
+  konokaPlugins = inputs.konoka.packages.${pkgs.stdenv.hostPlatform.system};
+
+  # konokaリポジトリの`plugins/`直下のディレクトリ名をそのままプラグイン名として使います。
+  # konoka側のflake.nixがpluginsディレクトリの走査でパッケージ集合を導出しているのと同じ方針で、
+  # プラグインの追加削除にこちら側の一覧を手動追随させる必要をなくします。
+  # Claude Codeはこのリスト全てを`programs.claude-code.plugins`にリンクします。
+  allPluginNames = lib.attrNames (
+    lib.filterAttrs (_: type: type == "directory") (builtins.readDir "${inputs.konoka.outPath}/plugins")
+  );
+
+  # skillsを持つkonokaプラグインの名前リストです。
+  # `skills/`ディレクトリの有無で判定するため、
+  # hookのみで構成されるプラグイン(例: `rm-to-trash`)は自動的に除外されます。
+  skillPluginNames = lib.filter (
+    pluginName: builtins.pathExists "${inputs.konoka.outPath}/plugins/${pluginName}/skills"
+  ) allPluginNames;
+
+  # 各konokaプラグイン内のskillsサブディレクトリをフラットに展開します。
+  # ソース側のskillsディレクトリで一覧を取り、
+  # 実際のパスにはbin/やhooks/のビルド生成物まで揃ったパッケージ側を参照します。
+  skillEntries = builtins.concatMap (
+    pluginName:
+    let
+      pluginPkg = konokaPlugins.${pluginName};
+      skillsSrcDir = "${inputs.konoka.outPath}/plugins/${pluginName}/skills";
+      skillNames = builtins.attrNames (builtins.readDir skillsSrcDir);
+    in
+    map (skillName: {
+      inherit pluginName skillName;
+      path = "${pluginPkg}/skills/${skillName}";
+    }) skillNames
+  ) skillPluginNames;
+
+  # スキル名からそれを提供するプラグイン名のリストへの辞書。
+  # 複数プラグインが同名のスキルを持つとフラット展開時に片方が消えるため、
+  # 検出できるようにここで所有者一覧を組み立てます。
+  skillOwners = lib.foldl' (
+    acc: entry:
+    acc
+    // {
+      ${entry.skillName} = (acc.${entry.skillName} or [ ]) ++ [ entry.pluginName ];
+    }
+  ) { } skillEntries;
+
+  skillNameConflicts = lib.filterAttrs (_: owners: lib.length owners > 1) skillOwners;
+
+  skills =
+    assert lib.assertMsg (
+      skillNameConflicts == { }
+    ) "konokaプラグイン間でスキル名が衝突しています: ${builtins.toJSON skillNameConflicts}";
+    lib.listToAttrs (map (entry: lib.nameValuePair entry.skillName entry.path) skillEntries);
+in
+{
+  # konoka関連の情報を他のhome-managerモジュールに公開します。
+  # `konoka`引数として`programs.claude-code`や`programs.opencode`の設定モジュールから参照できます。
+  _module.args.konoka = {
+    plugins = konokaPlugins;
+    inherit allPluginNames skillPluginNames skills;
+  };
+}

--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -1,4 +1,9 @@
-{ pkgs-unstable, config, ... }:
+{
+  pkgs-unstable,
+  config,
+  konoka,
+  ...
+}:
 {
   programs.opencode = {
     enable = true;
@@ -9,6 +14,16 @@
     context = config.prompt.codingAgent;
     # `mcp.nix`と連携します。
     enableMcpIntegration = true;
+    # konokaのスキルをflake input経由で読み込みます。
+    # `~/.config/opencode/skills/<skill>/`にそれぞれsymlinkされます。
+    inherit (konoka) skills;
+    # OpenCodeプロセスのPATHにkonokaプラグインの`bin/`を追加します。
+    # スキルの埋め込みコマンド(`commit-prepare`など)を呼び出せるようにします。
+    # `home.packages`と違いユーザ全体のPATHは汚さず、
+    # `opencode`実行時のみに限定できます。
+    # `bin/`を持たないプラグインが混ざっても`makeBinPath`が単に空を返すだけで害はないため、
+    # 対象を絞らず全プラグインをまとめて渡します。
+    extraPackages = map (n: konoka.plugins.${n}) konoka.allPluginNames;
     # `~/.config/opencode/opencode.json`に配置されます。
     settings = {
       # パッケージはNixで管理しているため自己アップデートは無効にします。


### PR DESCRIPTION
konokaのプラグインをClaude Codeのmarketplace経由ではなくflake input経由でビルド済みパッケージとして直接読み込み、
同じスキル群をOpenCodeからも呼び出せるようにします。

marketplace経由ではプラグインのバージョンが`v8.6.4`のようにハードコードされ、
nixのflake.lockによる一元的な追随管理から外れていました。
konoka側のflakeが各プラグインをビルド済みパッケージとして提供しており、
ヘルパースクリプトのwrapperまで同梱するため、
`programs.claude-code.plugins`と`programs.opencode.extraPackages`から直接読み込む形が宣言的で自然です。

konoka関連の参照ロジックはClaude Codeとopencode両方で必要になるため、
`home/core/konoka.nix`を新設して`_module.args.konoka`として一箇所に集約します。
プラグイン名やスキル名は`inputs.konoka.outPath`の`plugins/`ディレクトリの走査から機械的に導出するので、
konoka側でプラグインが追加削除されてもこちら側の一覧を手動追随させる必要はありません。

スキル名はプラグイン間で衝突しないことを`assert`で検証します。
衝突があった場合は衝突しているスキル名と所属プラグイン名をJSONで表示して評価を停止します。

OpenCode側のbin配線には`programs.opencode.extraPackages`を使い、
opencode実行時のwrapper内でのみkonokaのbin/が見えるように限定します。
`home.packages`と違いユーザ全体のPATHは汚しません。

bulletで`./install.sh`による適用が成功し、
Claude Codeの`/plugin`と`/reload-plugins`で全11個のkonokaプラグインが、
`/nix/store`のパスから読み込まれることを確認済みです。
nix-fast-buildの統合チェックも通っています。