### PR TITLE
feat(opencode): GitHub Copilotのデフォルトモデルを設定

### DIFF
--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -28,7 +28,8 @@
     settings = {
       # パッケージはNixで管理しているため自己アップデートは無効にします。
       autoupdate = false;
-      # デフォルトモデルは現在あえて宣言しません。
+      model = "github-copilot/gpt-5.6-terra";
+      small_model = "github-copilot/gpt-5-mini";
     };
   };
 }


### PR DESCRIPTION
OpenCodeでGitHub Copilotを使う際の初期モデルをGPT-5.6 Terraに固定します。
タイトル生成などの軽量な内部タスクには、
コストを抑えるためGPT-5 miniを使います。
