### PR TITLE
feat(opencode): Claude Code互換のキーバインドを設定

### DIFF
--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -31,5 +31,22 @@
       model = "github-copilot/gpt-5.6-terra";
       small_model = "github-copilot/gpt-5-mini";
     };
+    # `home/linked/.claude/keybindings.json`と共通の操作へ寄せます。
+    tui.keybinds = {
+      editor_open = "ctrl+l";
+      messages_undo = "ctrl+/";
+      session_interrupt = "ctrl+g";
+      input_submit = "meta+return";
+      input_newline = "return";
+      history_previous = "up,ctrl+t";
+      history_next = "down,ctrl+n";
+      dialog.select.prev = "up,ctrl+t";
+      dialog.select.next = "down,ctrl+n";
+      dialog.select.submit = "meta+return";
+      prompt.autocomplete.prev = "up,ctrl+t";
+      prompt.autocomplete.next = "down,ctrl+n";
+      prompt.autocomplete.hide = "ctrl+g";
+      prompt.autocomplete.select = "meta+return";
+    };
   };
 }

--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -48,13 +48,13 @@
       input_newline = "return";
       history_previous = "up,ctrl+t";
       history_next = "down,ctrl+n";
-      dialog.select.prev = "up,ctrl+t";
-      dialog.select.next = "down,ctrl+n";
-      dialog.select.submit = "meta+return";
-      prompt.autocomplete.prev = "up,ctrl+t";
-      prompt.autocomplete.next = "down,ctrl+n";
-      prompt.autocomplete.hide = "ctrl+g";
-      prompt.autocomplete.select = "meta+return";
+      "dialog.select.prev" = "up,ctrl+t";
+      "dialog.select.next" = "down,ctrl+n";
+      "dialog.select.submit" = "meta+return";
+      "prompt.autocomplete.prev" = "up,ctrl+t";
+      "prompt.autocomplete.next" = "down,ctrl+n";
+      "prompt.autocomplete.hide" = "ctrl+g";
+      "prompt.autocomplete.select" = "meta+return";
     };
   };
 }


### PR DESCRIPTION
Claude CodeとOpenCodeを切り替える際の操作の違和感を減らします。
既存の`keybindings.json`に合わせ、
入力、選択、送信の操作を統一します。