### PR TITLE
feat(opencode): Claude Codeと同じ外部ディレクトリを許可

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -3,25 +3,12 @@
   pkgs,
   pkgs-unstable,
   config,
+  codingAgentWorkDirFullPath,
   konoka,
-  osConfig ? null,
   ...
 }:
 let
   ccstatusline = pkgs.callPackage ../../pkgs/ccstatusline.nix { };
-
-  # コーディングエージェントの作業ディレクトリ。
-  # konokaプラグインは`${XDG_RUNTIME_DIR:-/tmp}/coding-agent-work/`を使用します。
-  # NixOS環境では`osConfig`からUIDを取得して、
-  # `/run/user/<uid>/coding-agent-work/`を構築します。
-  # 非NixOS環境(Termux等)では`XDG_RUNTIME_DIR`が設定されない場合があるため、
-  # `/tmp`にフォールバックします。
-  codingAgentWorkDirFullPath =
-    let
-      uid = if osConfig != null then osConfig.users.users.${config.home.username}.uid else null;
-      base = if uid != null then "/run/user/${toString uid}" else "/tmp";
-    in
-    "${base}/coding-agent-work/";
 in
 {
   programs.claude-code = {

--- a/home/core/coding-agent-work-dir.nix
+++ b/home/core/coding-agent-work-dir.nix
@@ -1,0 +1,18 @@
+{
+  username,
+  osConfig ? null,
+  ...
+}:
+let
+  # konokaプラグインは`${XDG_RUNTIME_DIR:-/tmp}/coding-agent-work/`を使用します。
+  # NixOS環境では`osConfig`からUIDを取得し、非NixOS環境では`/tmp`へフォールバックします。
+  codingAgentWorkDirFullPath =
+    let
+      uid = if osConfig != null then osConfig.users.users.${username}.uid else null;
+      base = if uid != null then "/run/user/${toString uid}" else "/tmp";
+    in
+    "${base}/coding-agent-work/";
+in
+{
+  _module.args = { inherit codingAgentWorkDirFullPath; };
+}

--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -1,6 +1,7 @@
 {
   pkgs-unstable,
   config,
+  codingAgentWorkDirFullPath,
   konoka,
   ...
 }:
@@ -30,6 +31,12 @@
       autoupdate = false;
       model = "github-copilot/gpt-5.6-terra";
       small_model = "github-copilot/gpt-5-mini";
+      permission.external_directory = {
+        # Claude Codeと同じ追加ディレクトリを許可します。
+        "${codingAgentWorkDirFullPath}**" = "allow";
+        "/nix/store/**" = "allow";
+        "~/dotfiles/**" = "allow";
+      };
     };
   };
 }


### PR DESCRIPTION
OpenCodeでもコーディングエージェント用の作業ディレクトリ、
`/nix/store`、
dotfilesを確認・編集できるようにします。
作業ディレクトリのパス解決は専用モジュールに集約し、
Claude CodeとOpenCodeで同じ場所を参照します。
