### PR TITLE
feat(gaming): ゲーム中は3D V-Cache側CCDを優先するように

### DIFF
--- a/nixos/gaming/gamemode.nix
+++ b/nixos/gaming/gamemode.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  pkgs,
+  username,
+  ...
+}:
+let
+  # 9950X3Dのような片側CCDにだけ3D V-Cacheを搭載するCPUでは、
+  # カーネルのamd_x3d_vcacheドライバが提供する`amd_x3d_mode`によって、
+  # amd-pstateのコア優先度ランキングを切り替えられる。
+  #
+  # - `frequency`: 高クロック側CCDを優先(デフォルト)
+  # - `cache`: 3D V-Cache側CCDを優先
+  #
+  # ゲーム中はキャッシュ容量が効くワークロードが多いので、
+  # customフックでゲーム開始時に`cache`へ切り替えて、
+  # スケジューラがV-Cache側CCDへスレッドを配置するようにする。
+  # 終了時はデフォルトの`frequency`へ戻す。
+  #
+  # ワイルドカード部分はACPIデバイス名(bulletでは`AMDI0101:00`)を吸収する。
+  # X3D非搭載CPUのホストではglobがマッチせず何もしない。
+  modeFileGlob = "/sys/bus/platform/drivers/amd_x3d_vcache/*/amd_x3d_mode";
+
+  x3d-mode = pkgs.writeShellApplication {
+    name = "x3d-mode";
+    text = ''
+      mode="$1"
+      for f in ${modeFileGlob}; do
+        [ -e "$f" ] || continue
+        echo "$mode" > "$f"
+      done
+    '';
+  };
+in
+{
+  # LutrisがProton(umu)経由で起動するゲームでもgamemodeが効くように、
+  # `libgamemodeauto.so`のRUNPATHを修正する。
+  nixpkgs.overlays = [ (import ../../lib/gamemode-lib-rpath-overlay.nix) ];
+
+  programs.gamemode = {
+    enable = true;
+    settings.custom = {
+      start = "${lib.getExe x3d-mode} cache";
+      end = "${lib.getExe x3d-mode} frequency";
+    };
+  };
+
+  # gamemodedはCPUガバナー変更などの特権操作をpkexecで行う。
+  # gamemodeが同梱するpolkitルールは`gamemode`グループのユーザにだけ認証なしで許可するので、
+  # ユーザをグループに追加する。
+  users.users.${username}.extraGroups = [ "gamemode" ];
+
+  # `amd_x3d_mode`はデフォルトでroot専用書き込みなので、
+  # gamemodedを動かす一般ユーザが属するgamemodeグループへ書き込みを許可する。
+  # `%S`はsysfsのマウントポイント、
+  # `%p`はデバイスパスに展開される。
+  services.udev.extraRules = ''
+    ACTION=="add|bind", SUBSYSTEM=="platform", DRIVER=="amd_x3d_vcache", RUN+="${pkgs.coreutils}/bin/chgrp gamemode %S%p/amd_x3d_mode", RUN+="${pkgs.coreutils}/bin/chmod 0664 %S%p/amd_x3d_mode"
+  '';
+}

--- a/nixos/gaming/lutris.nix
+++ b/nixos/gaming/lutris.nix
@@ -1,9 +1,5 @@
 { pkgs, ... }:
 {
-  # LutrisがProton(umu)経由で起動するゲームでもgamemodeが効くように、
-  # `libgamemodeauto.so`のRUNPATHを修正する。
-  nixpkgs.overlays = [ (import ../../lib/gamemode-lib-rpath-overlay.nix) ];
-
   environment.systemPackages = with pkgs; [
     # Steam外部も含めたアプリをSteamのProtonを使って管理・起動するためのツール。
     # FHS環境にgamemodeのライブラリを追加して、

--- a/nixos/gaming/steam.nix
+++ b/nixos/gaming/steam.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }:
+{ pkgs, ... }:
 {
   programs = {
     steam = {
@@ -17,14 +17,8 @@
       # Protonプレフィックスへwinetricksを適用するトラブルシューティングツール。
       protontricks.enable = true;
     };
-    gamemode.enable = true;
     # `gamescopeSession`が有効化するが、
     # 単体ゲームのネスト起動にも使うので明示。
     gamescope.enable = true;
   };
-
-  # gamemodedはCPUガバナー変更などの特権操作をpkexecで行う。
-  # gamemodeが同梱するpolkitルールは`gamemode`グループのユーザにだけ認証なしで許可するので、
-  # ユーザをグループに追加する。
-  users.users.${username}.extraGroups = [ "gamemode" ];
 }


### PR DESCRIPTION
9950X3Dのような片側CCDにだけ3D V-Cacheを搭載するCPUでは、
デフォルトのamd-pstateのコア優先度ランキングが高クロック側CCDを優先するため、
キャッシュ容量が効くゲームのスレッドがV-Cache側CCDに配置されませんでした。

カーネルのamd_x3d_vcacheドライバが提供する`amd_x3d_mode`を、
gamemodeのcustomフックでゲーム開始時に`cache`へ、
終了時にデフォルトの`frequency`へ切り替えることで、
ゲーム中だけスケジューラがV-Cache側CCDへスレッドを配置するようにします。

`amd_x3d_mode`はデフォルトでroot専用書き込みなので、
udevルールでgamemodeグループへ書き込みを許可して、
一般ユーザとして動くgamemodedのフックから書けるようにします。

X3D非搭載CPUのホストではudevルールがドライバ名にマッチせず、
フックのglobも不一致で何もしないため、
同じgamingモジュールをimportしているcreepでも無害です。

あわせてgamemode関連の設定が複数ファイルに分散してきたため、
steam.nixの`programs.gamemode.enable`とgamemodeグループ所属、
lutris.nixの`libgamemodeauto.so`のRUNPATH修正overlayを、
新設のgamemode.nixへ集約します。

bulletで適用して`gamemoderun`の実行中だけ、
`amd_x3d_mode`が`frequency`から`cache`へ切り替わることを確認済みです。

Claude-Session: https://claude.ai/code/session_01Atsfv89FiF2dizyBDvdoAV
