### PR TITLE
feat: Claude CodeとOpenCodeでも通常のターミナルと同じキーでスクロール

### DIFF
--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -55,6 +55,19 @@
       "prompt.autocomplete.next" = "down,ctrl+n";
       "prompt.autocomplete.hide" = "ctrl+g";
       "prompt.autocomplete.select" = "meta+return";
+      # tmuxのスクロールキーと同じ操作でメッセージをスクロールできるようにします。
+      # tmuxはalternate screen上のペインではこれらのキーをアプリに透過してくるので、
+      # OpenCode側で同じ挙動を割り当てて通常のターミナルとスクロール操作を揃えます。
+      messages_line_up = "shift+up";
+      messages_line_down = "shift+down";
+      messages_page_up = "pageup,shift+left";
+      messages_page_down = "pagedown,shift+right";
+      # shift+矢印のデフォルトは入力欄のテキスト選択ですが、
+      # スクロールキーとして使うため無効化します。
+      input_select_up = "none";
+      input_select_down = "none";
+      input_select_left = "none";
+      input_select_right = "none";
     };
   };
 }

--- a/home/core/tmux.nix
+++ b/home/core/tmux.nix
@@ -85,17 +85,27 @@
         bind -n C-M-s swap-window -t +1 \; select-window -t +1
         bind -n C-M-h swap-window -t -1 \; select-window -t -1
 
+        # スクロールキーはalternate screen上のフルスクリーンTUI(Claude CodeやOpenCodeなど)では、
+        # tmuxのcopy-modeに履歴が無くスクロールできないため、
+        # キーをそのままアプリに透過して、アプリ側のスクロール機能に任せます。
+        # Claude Codeはclaude-code.nixのtui = "fullscreen"設定によりalternate screenで動作し、
+        # keybindings.jsonのScrollコンテキストで同じキーにスクロールを割り当てています。
+        # OpenCodeも同様にopencode.nixのtui.keybindsで割り当てています。
+        # 通常画面(シェルなど)では従来通りcopy-modeでスクロールします。
+        # copy-modeの-eは最下部まで戻った時に自動でcopy-modeを抜けるオプションで、
+        # 普通のターミナルのスクロールバックと同じ感覚になります。
+
         # shift+up/down = 1行スクロール
-        bind -n S-Up copy-mode \; send-keys -X scroll-up
-        bind -n S-Down copy-mode \; send-keys -X scroll-down
+        bind -n S-Up if -F "#{alternate_on}" { send-keys S-Up } { copy-mode -e ; send-keys -X scroll-up }
+        bind -n S-Down if -F "#{alternate_on}" { send-keys S-Down } { copy-mode -e ; send-keys -X scroll-down }
 
         # shift+left/right = ページスクロール
-        bind -n S-Left copy-mode \; send-keys -X page-up
-        bind -n S-Right copy-mode \; send-keys -X page-down
+        bind -n S-Left if -F "#{alternate_on}" { send-keys S-Left } { copy-mode -e ; send-keys -X page-up }
+        bind -n S-Right if -F "#{alternate_on}" { send-keys S-Right } { copy-mode -e ; send-keys -X page-down }
 
         # PageUp/PageDown = ページスクロール
-        bind -n PageUp copy-mode \; send-keys -X page-up
-        bind -n PageDown copy-mode \; send-keys -X page-down
+        bind -n PageUp if -F "#{alternate_on}" { send-keys PageUp } { copy-mode -e ; send-keys -X page-up }
+        bind -n PageDown if -F "#{alternate_on}" { send-keys PageDown } { copy-mode -e ; send-keys -X page-down }
 
         # クイックウィンドウ切り替え(Alt+数字)
         bind -n M-1 select-window -t 1

--- a/home/linked/.claude/keybindings.json
+++ b/home/linked/.claude/keybindings.json
@@ -38,6 +38,17 @@
       }
     },
     {
+      "context": "Scroll",
+      "bindings": {
+        "shift+up": "scroll:lineUp",
+        "shift+down": "scroll:lineDown",
+        "shift+left": "scroll:fullPageUp",
+        "shift+right": "scroll:fullPageDown",
+        "pageup": "scroll:fullPageUp",
+        "pagedown": "scroll:fullPageDown"
+      }
+    },
+    {
       "context": "HistorySearch",
       "bindings": {
         "ctrl+g": "historySearch:accept",


### PR DESCRIPTION
tmuxのスクロールキー(shift+矢印とPageUp/PageDown)は、
無条件にcopy-modeへ入る実装だったため、
alternate screenで動作するフルスクリーンTUIでは、
copy-modeに履歴が無くスクロールできませんでした。
Claude Codeは`tui = "fullscreen"`設定によりalternate screenで動作し、
OpenCodeのTUIもデフォルトでalternate screenを使います。

tmuxのスクロールキーを`#{alternate_on}`で条件分岐させ、
alternate screen上ではキーをそのままアプリに透過し、
Claude Codeは`keybindings.json`の`Scroll`コンテキスト、
OpenCodeは`tui.keybinds`で同じキーにスクロールを割り当てることで、
どの画面でも同一のキー操作でスクロールできるようにします。

通常画面でのcopy-modeには`-e`を付けて、
最下部まで戻った時に自動でcopy-modeを抜けるようにし、
普通のターミナルのスクロールバックと同じ感覚にします。

OpenCodeのshift+矢印のデフォルトは入力欄のテキスト選択(`input_select_*`)、
Claude Codeの`Scroll`コンテキストのshift+矢印のデフォルトは選択範囲の拡張ですが、
どちらもスクロールキーとして使うため上書き・無効化します。

テスト用tmuxサーバで、
alternate screenのアプリ(less)ではキーが透過され、
通常のシェルではcopy-modeに入ることを確認済みです。
OpenCode 1.18.3のソースで`messages_line_up`などのアクションが存在することも確認済みです。
nix-fast-buildの統合チェックも通っています。

https://claude.ai/code/session_01XQDGcuzq6DWgVk6cDZ5zau