### PR TITLE
refactor(tailscale-serve): `--bg`をやめてフォアグラウンドで常駐させる

### DIFF
--- a/nixos/host/bullet/comfyui/tailscale-serve.nix
+++ b/nixos/host/bullet/comfyui/tailscale-serve.nix
@@ -6,6 +6,13 @@
 # 何のサービスか分かりやすいように、
 # また将来他のサービスも公開できるように、
 # ルートではなく`/comfy-ui`パスにマウントする。
+#
+# `--bg`は使わずフォアグラウンドで常駐させる。
+# フォアグラウンドのServe設定はCLIプロセスのセッションに紐付き、
+# プロセスが死ぬとtailscaled側が設定を自動で消すため、
+# Serve設定のライフサイクルがユニットのライフサイクルと完全に一致する。
+# `--bg`と違いoffによる明示的な登録解除も、
+# モジュール削除後にtailscaledへ設定が残留する心配も不要になる。
 { config, ... }:
 let
   tailscale = config.services.tailscale.package;
@@ -13,7 +20,7 @@ let
 in
 {
   systemd.services.tailscale-serve = {
-    description = "Configure Tailscale Serve";
+    description = "Tailscale Serve";
     requires = [
       "tailscaled.service"
     ];
@@ -28,11 +35,10 @@ in
     ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${tailscale}/bin/tailscale serve --bg --https=443 --set-path=/comfy-ui http://127.0.0.1:${toString port}";
-      ExecStop = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfy-ui off";
-      RemainAfterExit = true;
-      Restart = "on-failure";
+      ExecStart = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfy-ui http://127.0.0.1:${toString port}";
+      # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
+      # 終了コードによらず常に再起動して復帰させる。
+      Restart = "always";
       RestartSec = "10s";
     };
   };

--- a/nixos/host/seminar/tailscale-serve.nix
+++ b/nixos/host/seminar/tailscale-serve.nix
@@ -6,8 +6,15 @@ in
   # Tailscale Serveの設定。
   # Serveはtailnet内のみに公開する。
   # Caddy :8081がパス毎にtailnet専用サービスをルーティングする。
+  #
+  # `--bg`は使わずフォアグラウンドで常駐させる。
+  # フォアグラウンドのServe設定はCLIプロセスのセッションに紐付き、
+  # プロセスが死ぬとtailscaled側が設定を自動で消すため、
+  # Serve設定のライフサイクルがユニットのライフサイクルと完全に一致する。
+  # `--bg`と違いoffによる明示的な登録解除も、
+  # モジュール削除後にtailscaledへ設定が残留する心配も不要になる。
   systemd.services.tailscale-serve = {
-    description = "Configure Tailscale Serve";
+    description = "Tailscale Serve";
     requires = [
       "tailscaled.service"
     ];
@@ -22,11 +29,10 @@ in
     ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
-      Type = "oneshot";
-      ExecStart = "${tailscale}/bin/tailscale serve --bg --https=8443 http://127.0.0.1:8081";
-      ExecStop = "${tailscale}/bin/tailscale serve --https=8443 off";
-      RemainAfterExit = true;
-      Restart = "on-failure";
+      ExecStart = "${tailscale}/bin/tailscale serve --https=8443 http://127.0.0.1:8081";
+      # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
+      # 終了コードによらず常に再起動して復帰させる。
+      Restart = "always";
       RestartSec = "10s";
     };
   };


### PR DESCRIPTION
`--bg`のServe設定はtailscaledの状態として永続化されるため、
停止時に`off`で明示的に登録解除する必要があり、
開始と停止でフラグを対称に保つ注意が要るうえ、
モジュールを削除しても設定がtailscaledに残留する問題がありました。

フォアグラウンドのServe設定はCLIプロセスのセッションに紐付き、
プロセスが死ぬと(クラッシュやSIGKILLでも)tailscaled側が設定を自動で消すため、
`Type = "simple"`の常駐サービスにすることで、
Serve設定のライフサイクルがユニットのライフサイクルと完全に一致します。
`ExecStop`と`RemainAfterExit`は不要になり削除します。

tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
`Restart`は`on-failure`から`always`に変更して終了コードによらず復帰させます。

同じパターンを使っているbulletのComfyUI用とseminarの両方を書き換えます。

bulletとseminarの両方に適用して以下を確認済みです。

- フォアグラウンドのプロセスが常駐してServe経由で200が返る
- bulletで`systemctl stop tailscale-serve`するとServeへの接続が即座に不能になり、
  startで復活する
- seminarに残留していた旧ホスト名`seminar-1`の`--bg`設定を`tailscale serve reset`で掃除し、
  resetでフォアグラウンドセッションが切れても`Restart = "always"`で自動復帰する

なおフォアグラウンドのServe設定は`tailscale serve status`には表示されないため、
状態確認は`systemctl status tailscale-serve`か実際の疎通で行います。

https://claude.ai/code/session_01EU9E5w7jgkib9ChSnkzBrn