### PR TITLE
feat: アイドル時のCPUとGPUの消費電力と発熱を抑える

### DIFF
--- a/home/native-linux/grobi.nix
+++ b/home/native-linux/grobi.nix
@@ -23,7 +23,7 @@ let
   # 宣言的に定義されたサービスが設定値を持っているため、
   # 値を二重管理せずにそれらのサービスを再起動して元の設定に復元する。
   restoreIdle = [
-    (systemctl + " --user restart dpms-power.service screensaver-timeout.service")
+    (systemctl + " --user restart dpms-timeout.service screensaver-timeout.service")
   ];
 in
 {

--- a/nixos/desktop/dpms.nix
+++ b/nixos/desktop/dpms.nix
@@ -33,7 +33,7 @@
           '';
         }
       );
-      Restart = "always";
+      Restart = "on-failure";
       RestartSec = "10s";
     };
     wantedBy = [ "graphical-session.target" ];

--- a/nixos/desktop/dpms.nix
+++ b/nixos/desktop/dpms.nix
@@ -1,27 +1,40 @@
-{ pkgs, lib, ... }:
+# デスクトップの画面消灯とロック猶予のタイムアウト設定。
+# GPUの例えばRTX 5090は、
+# 画面点灯中はマルチモニタ制約でメモリクロックを下げられず約48W消費しますが、
+# 消灯中はP8ステートに落ちて約21Wになるため、
+# 発熱対策として離席時は画面を消灯させます。
+# OLEDモニターの焼き付き防止の意味もあります。
+{ lib, pkgs, ... }:
 {
-  # OLEDモニターにも対応したDPMS設定。
-  # 作業の邪魔にならない程度に管理。
-  systemd.user.services.dpms-oled = {
-    description = "Configure DPMS for OLED monitors";
+  systemd.user.services.dpms-timeout = {
+    description = "Configure screen saver and DPMS timeout";
     serviceConfig = {
       Type = "oneshot";
       ExecStart = lib.getExe (
         pkgs.writeShellApplication {
-          name = "dpms-oled";
+          name = "dpms-timeout";
           runtimeInputs = with pkgs; [ xset ];
           text = ''
-            # スクリーンセーバーの方は無効化
-            xset s off
+            # スクリーンセーバーのタイムアウトを設定。
+            # 30分の無操作で消灯してxss-lockのnotifierが起動され、
+            # サイクル時間の8時間が経過するとlockerが起動されます。
+            # つまり消灯から8時間以内の復帰ならロックされていません。
+            # 動画を見ていても大抵は30分に収まります。
+            # 自宅のデスクトップなのでロックまでの猶予は長めで実質無制限にしています。
+            # 仕組みの詳細は`native-linux/screen-lock.nix`を参照。
+            xset s 1800 28800
             # DPMSを有効化
             xset +dpms
-            # DPMS設定 (スタンバイ:6時間, サスペンド:7時間, オフ:8時間)
-            xset dpms 21600 25200 28800
+            # スクリーンセーバー発動の直後にDPMSでモニタの電源を切ります。
+            # (スタンバイ:30.5分, サスペンド:30.75分, オフ:31分)
+            # スクリーンセーバーのタイムアウトより後にすることで、
+            # ロックの起点が常にnotifier経由になるようにします。
+            xset dpms 1830 1845 1860
           '';
         }
       );
-      Restart = "on-failure";
-      RestartSec = "5s";
+      Restart = "always";
+      RestartSec = "10s";
     };
     wantedBy = [ "graphical-session.target" ];
   };

--- a/nixos/desktop/power-management.nix
+++ b/nixos/desktop/power-management.nix
@@ -1,0 +1,25 @@
+# デスクトップの性能をあまり犠牲にしないでアイドル時の消費電力と発熱を抑えます。
+_: {
+  powerManagement = {
+    # デフォルトで`enable`ですが、
+    # わかりやすさのために明示的に有効にします。
+    enable = true;
+    # amd-pstate-eppドライバではgovernorは`performance`と`powersave`の2択で、
+    # カーネルデフォルトは`performance`です。
+    # `performance`だとEPP(Energy Performance Preference)も`performance`に固定され、
+    # アイドル時でも積極的にブーストして無駄に発熱します。
+    # クロック制御はCPUが自律的に行うため、
+    # 負荷時のブーストが制限されるわけではありません。
+    cpuFreqGovernor = "powersave";
+  };
+
+  # EPPの設定はpower-profiles-daemonに任せます。
+  # デフォルトの`balanced`プロファイルがamd-pstateでは、
+  # governorを`powersave`、EPPを`balance_performance`に設定します。
+  # governorを`powersave`にしただけではEPPは`performance`のまま残るので、
+  # EPPを設定する仕組みが別途必要です。
+  # bulletでの実測ではEPPを`balance_performance`にすることで、
+  # アイドル時のパッケージ電力が約39Wから約33Wに下がり、
+  # シングルスレッド負荷時は変わらず約5.7GHzまでブーストしました。
+  services.power-profiles-daemon.enable = true;
+}

--- a/nixos/laptop/dpms.nix
+++ b/nixos/laptop/dpms.nix
@@ -1,15 +1,20 @@
 { pkgs, ... }:
 let
-  acTimeout = 30 * 60; # AC電源時: 30分
-  battTimeout = 15 * 60; # バッテリー時: 15分
+  # AC電源時: 30.5分。
+  # スクリーンセーバーのタイムアウト(screen-lock-time.nixで30分)より後にすることで、
+  # ロックの起点が常にxss-lockのnotifier経由になり猶予時間が機能します。
+  acTimeout = 30 * 60 + 30;
+  # バッテリー時: 15分。
+  # 省電力を優先してスクリーンセーバーのタイムアウトより先に消灯させます。
+  battTimeout = 15 * 60;
 in
 {
-  systemd.user.services.dpms-power = {
-    description = "Adjust DPMS timeout based on AC/battery state";
+  systemd.user.services.dpms-timeout = {
+    description = "Configure screen saver and DPMS timeout";
     serviceConfig = {
       ExecStart = pkgs.lib.getExe (
         pkgs.writeShellApplication {
-          name = "dpms-power";
+          name = "dpms-timeout";
           runtimeInputs = with pkgs; [
             gnugrep
             upower

--- a/nixos/laptop/screen-lock-time.nix
+++ b/nixos/laptop/screen-lock-time.nix
@@ -1,16 +1,19 @@
 { pkgs, lib, ... }:
 {
   systemd = {
-    # 画面ロックまでの時間を30分に設定。
+    # 画面消灯までの時間を30分に設定。
     # xss-lockはXのスクリーンセーバータイムアウトをトリガーにするため、
     # xsetでタイムアウトを設定します。
-    # デスクトップPCではdpms.nixで`xset s off`していますが、
-    # ラップトップでは適度なタイムアウトを設定します。
+    # 消灯でnotifierが起動され、
+    # サイクル時間の30秒が経過するとロックされます。
+    # ラップトップは外に持ち出すためセキュリティを重視して、
+    # デスクトップと違い猶予は短めにしています。
+    # 仕組みの詳細はnative-linuxのscreen-lock.nixを参照。
     user.services.screensaver-timeout = {
       description = "Set X screensaver timeout";
       serviceConfig = {
         Type = "oneshot";
-        ExecStart = "${pkgs.xset}/bin/xset s 1800 1800";
+        ExecStart = "${pkgs.xset}/bin/xset s 1800 30";
         Restart = "on-failure";
         RestartSec = "5s";
       };

--- a/nixos/native-linux/screen-lock.nix
+++ b/nixos/native-linux/screen-lock.nix
@@ -18,6 +18,92 @@ let
     # 回数制限のある指紋認証を要求するため仮に盗難されてもリスクはほぼありません。
     alice = "+nkdBXuOuCKqJ41VEal3/kJaET23fIQzBEky8PgTKEaGfAAu7lmpvjey1Fai4cSNHZvnx7GPOWZJryfvMXZoFQ==,B7lUv5xvIO6UUhd3OMzBhlNaGCKwfHBb/aXBzxf1E1PvOI09uYq+Ot+seZhMwCUti3NDS3Ina06thkmE4NRPPw==,es256,+presence";
   };
+
+  # 復帰からモニタのEDID読み取りが安定するまでの待ち時間(秒)。
+  # 消灯からの復帰直後はEDID読み取りが一時的に不安定で、
+  # grobiが「monitor has changed」として出力を無効化・再構成し、
+  # XMonadのrescreenでワークスペースとウィンドウの配置が崩れることが、
+  # bulletのDP-0(Acer VG270K)で実測により確認されています。
+  # 実測では復帰の数秒後に一時イベントが発生したため、
+  # 余裕を持たせた値にしています。
+  grobiRestartDelay = "20";
+
+  # 猶予時間内の復帰でロックされていなければgrobiを再開します。
+  # 猶予超過でロックに進んだ場合はロッカー側が解除後に再開するため、
+  # ここでは再開しません。
+  grobiStartIfUnlocked = pkgs.writeShellApplication {
+    name = "grobi-start-if-unlocked";
+    runtimeInputs = with pkgs; [
+      procps
+      systemd
+    ];
+    text = ''
+      if ! pgrep -x xsecurelock > /dev/null; then
+        systemctl --user start grobi.service
+      fi
+    '';
+  };
+
+  # 無操作による消灯時にxss-lockから起動されるnotifier。
+  # 消灯中と復帰直後のRandRイベントでレイアウトが崩れないようにgrobiを止めます。
+  # 自身が殺される時に、
+  # 遅延起動のtransientユニットでgrobiの再開を予約します。
+  # xss-lockに殺されてもgrobiの再開が実行されるように、
+  # このプロセスの子ではなくsystemdのユニットとして予約します。
+  screenBlankNotifier = pkgs.writeShellApplication {
+    name = "screen-blank-notifier";
+    runtimeInputs = with pkgs; [
+      coreutils
+      systemd
+    ];
+    text = ''
+      systemctl --user stop grobi.service
+      sleep_pid=""
+      on_term() {
+        if [ -n "$sleep_pid" ]; then
+          kill "$sleep_pid" 2> /dev/null || true
+        fi
+        systemd-run --user --collect --on-active=${grobiRestartDelay} \
+          ${lib.getExe grobiStartIfUnlocked}
+        exit 0
+      }
+      trap on_term TERM INT
+      # SIGTERMを受け取るまで待機し続けます。
+      while :; do
+        sleep 3600 &
+        sleep_pid=$!
+        wait "$sleep_pid" || true
+      done
+    '';
+  };
+
+  # xsecurelockのラッパー。
+  # 手動ロック(loginctl lock-session)やサスペンドでは、
+  # notifierを経由せずlockerが直接起動されるため、
+  # ここでもgrobiを停止します。
+  xsecurelockGrobiPause = pkgs.writeShellApplication {
+    name = "xsecurelock-grobi-pause";
+    runtimeInputs = with pkgs; [
+      systemd
+      xsecurelock
+    ];
+    text = ''
+      systemctl --user stop grobi.service
+      locker_pid=""
+      on_term() {
+        if [ -n "$locker_pid" ]; then
+          kill "$locker_pid" 2> /dev/null || true
+        fi
+      }
+      trap on_term TERM INT
+      xsecurelock &
+      locker_pid=$!
+      wait "$locker_pid" || true
+      # 解除後にモニタのEDIDが安定してからgrobiを再開します。
+      systemd-run --user --collect --on-active=${grobiRestartDelay} \
+        systemctl --user start grobi.service
+    '';
+  };
 in
 {
   security.pam = {
@@ -40,9 +126,19 @@ in
   };
 
   # xss-lock: systemdのlock-session/suspend等のイベントでロッカーを自動起動。
+  # notifierとlockerの2段階の仕組みで画面ロックに猶予時間を設けています。
+  # - 無操作で`xset s TIMEOUT CYCLE`のTIMEOUTに達するとnotifierが起動され、
+  #   活動再開かlockerの起動時にSIGTERMで殺されます。
+  # - lockerはさらにCYCLE秒が経過してから起動されます。
+  # つまりCYCLEが猶予時間になり、
+  # その間に復帰すればnotifierが殺されるだけで認証は発生しません。
+  # タイムアウトと猶予時間の値は環境ごとに設定します。
+  # - デスクトップ: `nixos/desktop/dpms.nix`
+  # - ラップトップ: `nixos/laptop/screen-lock-time.nix`
   programs.xss-lock = {
     enable = true;
+    extraOptions = [ "--notifier=${lib.getExe screenBlankNotifier}" ];
     # i3lockなどに比べてクラッシュ耐性などが多少堅牢らしいのでxsecurelockを指定。
-    lockerCommand = "${pkgs.xsecurelock}/bin/xsecurelock";
+    lockerCommand = lib.getExe xsecurelockGrobiPause;
   };
 }

--- a/nixos/native-linux/screen-lock.nix
+++ b/nixos/native-linux/screen-lock.nix
@@ -57,13 +57,17 @@ let
       systemd
     ];
     text = ''
-      systemctl --user stop grobi.service
+      # grobiの停止に失敗しても本来の役目には支障がないので、
+      # エラーログを残した上で続行します。
+      systemctl --user stop grobi.service ||
+        echo "screen-blank-notifier: failed to stop grobi.service (exit=$?)" >&2
       sleep_pid=""
       on_term() {
         if [ -n "$sleep_pid" ]; then
           kill "$sleep_pid" 2> /dev/null || true
         fi
         systemd-run --user --collect --on-active=${grobiRestartDelay} \
+          --timer-property=AccuracySec=1s \
           ${lib.getExe grobiStartIfUnlocked}
         exit 0
       }
@@ -88,7 +92,13 @@ let
       xsecurelock
     ];
     text = ''
-      systemctl --user stop grobi.service
+      # `writeShellApplication`はerrexitを注入するため、
+      # ここでgrobiの停止が失敗するとxsecurelockの起動前にラッパーが終了し、
+      # 画面がロックされないまま放置されるfail-openになってしまいます。
+      # ロックの起動を最優先するため、
+      # 停止の失敗はエラーログを残した上で続行します。
+      systemctl --user stop grobi.service ||
+        echo "xsecurelock-grobi-pause: failed to stop grobi.service (exit=$?)" >&2
       locker_pid=""
       on_term() {
         if [ -n "$locker_pid" ]; then
@@ -101,6 +111,7 @@ let
       wait "$locker_pid" || true
       # 解除後にモニタのEDIDが安定してからgrobiを再開します。
       systemd-run --user --collect --on-active=${grobiRestartDelay} \
+        --timer-property=AccuracySec=1s \
         systemctl --user start grobi.service
     '';
   };

--- a/nixos/server/power-management.nix
+++ b/nixos/server/power-management.nix
@@ -19,4 +19,15 @@ _: {
       enable = true;
     };
   };
+
+  # governorが`powersave`でもEPPはファームウェアの初期値のまま残り、
+  # seminarでは`performance`になっていて、
+  # アイドル時でもコアが最大クロック近くまでブーストしていました。
+  # desktopと同様にEPPの設定はpower-profiles-daemonに任せて、
+  # デフォルトの`balanced`プロファイルでEPPを`balance_performance`にします。
+  services.power-profiles-daemon.enable = true;
+  # upstreamのユニットは`WantedBy=graphical.target`ですが、
+  # サーバはヘッドレスで`multi-user.target`までしか到達しないため、
+  # そのままでは自動起動しません。
+  systemd.services.power-profiles-daemon.wantedBy = [ "multi-user.target" ];
 }


### PR DESCRIPTION
最近暑いので、
アイドル状態の時にCPUやGPUがなるべく発熱しないようにします。
通常動作時の性能にはほぼ影響を与えません。

CPUはamd-pstate-eppのEPP(Energy Performance Preference)が、
デスクトップでもサーバでも`performance`固定になっていて、
アイドル時でも積極的にブーストして無駄に発熱していました。
governorを`powersave`にした上でEPPの設定はpower-profiles-daemonに任せることで、
アイドル時は電圧とクロックを抑えつつ、
負荷時はこれまで通り最大までブーストするようにします。
bulletの実測ではアイドル時のパッケージ電力が約39Wから約33Wに下がり、
シングルスレッド負荷時は変わらず約5.7GHzまでブーストしました。

GPU(RTX 5090)はマルチモニタ制約により、
画面点灯中はメモリクロックを下げられず約48Wを消費し続けますが、
消灯すればP8ステートで約21Wまで下がることが実測で分かったため、
6時間だった画面消灯までの時間を30分に短縮します。

消灯を短縮すると、
復帰の度にロック解除の認証が必要になる煩わしさと、
復帰時にウィンドウ配置がモニタ間で崩れる問題が顕在化するため、
あわせて対処します。

- xss-lockのnotifierとlockerの2段階の仕組みでロックに猶予時間を設けて、
  デスクトップは8時間、
  ラップトップは30秒の猶予内に復帰すれば認証を不要にします
- ウィンドウ配置の崩れの原因は復帰直後のモニタのEDID読み取り不安定と、
  それに反応するgrobiの再構成だと実測で特定したため、
  消灯中と復帰直後はgrobiを一時停止します

それぞれの検証内容は各コミットメッセージを参照してください。

Claude-Session: https://claude.ai/code/session_01SVawTrrtEq3PfCSttr3PRN