### PR TITLE
refactor(comfyui): 公開パスを公式表記に合わせて`/comfyui`に変更

### DIFF
--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -73,7 +73,7 @@ in
             --replace-fail \
             'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", CSV_META_FILE_NAME))' \
             'os.path.join("${autocompletePlusDataDir}", CSV_META_FILE_NAME)'
-          # Tailscale Serveで`/comfy-ui`サブパスに公開しているため、
+          # Tailscale Serveで`/comfyui`サブパスに公開しているため、
           # ルート絶対パスの参照はサブパス配下で404になる。
           # 特に`/scripts/`の絶対importはモジュール読み込み自体を失敗させ、
           # 拡張機能が丸ごと無効になるので相対パスへ書き換える。

--- a/nixos/host/bullet/comfyui/tailscale-serve.nix
+++ b/nixos/host/bullet/comfyui/tailscale-serve.nix
@@ -5,7 +5,7 @@
 # tailnet経由の初回アクセスでもソケットアクティベーションによるオンデマンド起動が機能する。
 # 何のサービスか分かりやすいように、
 # また将来他のサービスも公開できるように、
-# ルートではなく`/comfy-ui`パスにマウントする。
+# ルートではなく`/comfyui`パスにマウントする。
 #
 # `--bg`は使わずフォアグラウンドで常駐させる。
 # フォアグラウンドのServe設定はCLIプロセスのセッションに紐付き、
@@ -35,7 +35,7 @@ in
     ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
-      ExecStart = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfy-ui http://127.0.0.1:${toString port}";
+      ExecStart = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfyui http://127.0.0.1:${toString port}";
       # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
       # 終了コードによらず常に再起動して復帰させる。
       Restart = "always";


### PR DESCRIPTION
Tailscale Serveの公開パスとその言及コメントで、
「ComfyUI」を「Comfy」と「UI」に分解した`comfy-ui`という表記を使っていました。
しかし公式はリポジトリ名の`comfyanonymous/ComfyUI`や、
pipパッケージの`comfyui-frontend-package`のように、
一貫して1つの単語として扱い小文字化しても区切りません。
公式表記に合わせて`/comfyui`に正規化します。

公開URLが変わるため、
旧パスをブックマークしている端末は更新が必要です。

bullet設定の評価で`ExecStart`に新しいパスが反映されることを確認済みです。

Claude-Session: https://claude.ai/code/session_01BboKz4CKCahvbvAwaAy1Wp
