### PR TITLE
feat: beesによるbtrfsの重複排除を全ホストで有効にする

### DIFF
--- a/nixos/host/bullet/bees.nix
+++ b/nixos/host/bullet/bees.nix
@@ -1,0 +1,23 @@
+{
+  # btrfsの重複排除デーモン。
+  # 上流のsystemdユニットがNice=19とIOSchedulingClass=idleを設定しているため、
+  # CPUとI/Oの優先度は元々アイドル相当。
+  services.beesd.filesystems.root = {
+    spec = "/";
+    # 検出粒度よりメモリ消費を優先して1GBに抑える。
+    # 2TB SSD全域に対しては約32KB粒度で、
+    # それ未満の細かい重複は見逃す。
+    hashTableSizeMB = 1024;
+    extraOptions = [
+      # 他プロセスが動き出したら縮退。
+      "--loadavg-target"
+      "4.0"
+      # シンプルなスロットリングも併用。
+      "--thread-count"
+      "4"
+      # btrfsカーネル側の遅延ワークキューの飽和を防ぐ。
+      "--throttle-factor"
+      "2.0"
+    ];
+  };
+}

--- a/nixos/host/creep/bees.nix
+++ b/nixos/host/creep/bees.nix
@@ -1,0 +1,25 @@
+{
+  # btrfsの重複排除デーモン。
+  # 上流のsystemdユニットがNice=19とIOSchedulingClass=idleを設定しているため、
+  # CPUとI/Oの優先度は元々アイドル相当。
+  services.beesd.filesystems.root = {
+    spec = "/";
+    # 検出粒度よりメモリ消費を優先して1GBに抑える。
+    # 約692GiBのSSD全域に対しては約11KB粒度で、
+    # それ未満の細かい重複は見逃す。
+    hashTableSizeMB = 1024;
+    extraOptions = [
+      # 他プロセスが動き出したら縮退。
+      # ラップトップなので最も保守的に、
+      # 何か作業を始めてloadavgが1を超えたら即座に全スレッドを停止させる。
+      "--loadavg-target"
+      "1.0"
+      # シンプルなスロットリングも併用。
+      "--thread-count"
+      "1"
+      # btrfsカーネル側の遅延ワークキューの飽和を防ぐ。
+      "--throttle-factor"
+      "2.0"
+    ];
+  };
+}

--- a/nixos/host/seminar/bees.nix
+++ b/nixos/host/seminar/bees.nix
@@ -1,0 +1,48 @@
+{
+  # btrfsの重複排除デーモン。
+  # 上流のsystemdユニットがNice=19とIOSchedulingClass=idleを設定しているため、
+  # CPUとI/Oの優先度は元々アイドル相当。
+  #
+  # 同一btrfsファイルシステムに複数インスタンスを向けてはいけないが、
+  # rootとnoaは完全に独立したファイルシステムなので問題ない。
+  services.beesd.filesystems = {
+    root = {
+      spec = "/";
+      # 検出粒度よりメモリ消費を優先して1GBに抑える。
+      # 2TB SSD全域に対しては約32KB粒度で、
+      # それ未満の細かい重複は見逃す。
+      hashTableSizeMB = 1024;
+      extraOptions = [
+        # 他プロセスが動き出したら縮退。
+        "--loadavg-target"
+        "3.0"
+        # シンプルなスロットリングも併用。
+        "--thread-count"
+        "3"
+        # btrfsカーネル側の遅延ワークキューの飽和を防ぐ。
+        "--throttle-factor"
+        "1.0"
+      ];
+    };
+    noa = {
+      spec = "/mnt/noa";
+      # 検出粒度よりメモリ消費を優先して1GBに抑える。
+      # 現在の使用量約2.9TiBに対しては約46KB粒度で、
+      # 現在の最大容量12.7TiB全域に対しては約200KB粒度と粗いが、
+      # HDDでは細かい重複まで共有するほど空き領域の断片化が進むため、
+      # 粗い粒度は断片化抑制の面ではむしろ好都合。
+      hashTableSizeMB = 1024;
+      extraOptions = [
+        # 他プロセスが動き出したら縮退。
+        "--loadavg-target"
+        "3.0"
+        # シンプルなスロットリングも併用。
+        "--thread-count"
+        "3"
+        # btrfsカーネル側の遅延ワークキューの飽和を防ぐ。
+        "--throttle-factor"
+        "1.0"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
bullet・creep・seminarの各btrfsファイルシステムで、
常駐デーモン型の重複排除ツールbeesを`services.beesd`モジュールで有効にします。
バッチ型のduperemove等と比較して、
スナップショットを含めた全体を1回だけスキャンする設計と、
NixOSモジュールが既に存在する宣言的な管理のしやすさからbeesを選びました。

アイドル時に片手間で動く方針で調整しています。
上流のsystemdユニットがNice=19とIOSchedulingClass=idleを設定しているため、
CPUとI/Oの優先度は元々アイドル相当です。
その上でniceが効かない領域を2つのオプションで塞ぎます。

- `--loadavg-target`: 他プロセスの負荷で目標値を超えたらスレッドを0まで縮退させる。
  据え置きは多め、
  ラップトップは作業開始で即停止する1.0にします
- `--throttle-factor`: dedupe要求を受けたbtrfs側のカーネルワーカーは、
  beesのnice値と無関係に走るため、
  遅延ワークキューの飽和を投入レートの制御で防ぎます

ハッシュテーブルは指定サイズ全体がmlockされて常時RAMに張り付くため、
検出粒度よりメモリ消費を優先して全ホスト1GBに統一します。
これは上流とNixOSモジュール共通のデフォルト値でもあります。
細かい重複を見逃す代わりに、
VMイメージやビルド成果物のような大きめの連続した重複は検出できます。

HDDのseminarの`/mnt/noa`はdedupeによる空き領域の断片化で、
性能が劣化する報告(Zygo/bees#298)がある構成ですが、
粗い検出粒度は断片化を抑える方向に働くことと、
容量が逼迫したらRAIDにディスクを追加する運用方針のため許容します。

bulletで適用して`beesd@root.service`が起動し、
`.beeshome`サブボリュームの自動作成と初回スキャンの開始を確認済みです。
creepとseminarへの適用はまだ行っていません。

Claude-Session: https://claude.ai/code/session_01Tnno5L7eRXUMxHqo1FEUHT