### PR TITLE
feat(comfyui): 動画ワークフローに終了ポーズの任意指定(FLF2V)を追加

### DIFF
--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -40,6 +40,13 @@ in
       "ComfyUI-Translate-Text" = pkgs.writeTextDir "__init__.py" (
         builtins.readFile ./custom-node/translate-text/__init__.py
       );
+      # 画像を選ばないことも許可する自作LoadImage。
+      # (none)のままなら出力がNoneになり、optional入力が未接続扱いになる。
+      # WanFirstLastFrameToVideoのend_imageなど任意入力の有効・無効を、
+      # バイパス操作なしで画像指定の有無だけで切り替えるために使う。
+      "ComfyUI-Load-Image-Optional" = pkgs.writeTextDir "__init__.py" (
+        builtins.readFile ./custom-node/load-image-optional/__init__.py
+      );
       # danbooruタグのオートコンプリート。
       # 日本語からの検索とpost count表示に対応していて、
       # メジャーなタグかどうかを確認しながら入力できる。

--- a/nixos/host/bullet/comfyui/custom-node/load-image-optional/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/load-image-optional/__init__.py
@@ -1,0 +1,54 @@
+# 画像を選ばないことも許可するLoadImage。
+# 選択肢の先頭に(none)を追加した以外は本家LoadImageと同じ。
+# (none)のままなら出力はNoneになり、
+# 接続先のoptional入力へは未接続と同じ扱いで渡る。
+#
+# WanFirstLastFrameToVideoのend_imageのような任意入力に対して、
+# ノードのバイパス操作なしで、
+# 「画像が指定してあれば有効、なければ無効」を実現するためのもの。
+from typing import Any
+
+import torch
+
+import nodes
+
+NONE_CHOICE = "(none)"
+
+
+class LoadImageOptional(nodes.LoadImage):
+    @classmethod
+    def INPUT_TYPES(cls) -> dict[str, Any]:
+        types = super().INPUT_TYPES()
+        files, config = types["required"]["image"]
+        types["required"]["image"] = ([NONE_CHOICE] + files, config)
+        return types
+
+    FUNCTION: str = "load_image_optional"
+
+    def load_image_optional(
+        self, image: str
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if image == NONE_CHOICE:
+            return (None, None)
+        return self.load_image(image)
+
+    @classmethod
+    def IS_CHANGED(cls, image: str) -> str:
+        if image == NONE_CHOICE:
+            return NONE_CHOICE
+        return super().IS_CHANGED(image)
+
+    @classmethod
+    def VALIDATE_INPUTS(cls, image: str) -> bool | str:
+        if image == NONE_CHOICE:
+            return True
+        return super().VALIDATE_INPUTS(image)
+
+
+NODE_CLASS_MAPPINGS: dict[str, type[LoadImageOptional]] = {
+    "LoadImageOptional": LoadImageOptional,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS: dict[str, str] = {
+    "LoadImageOptional": "Load Image (Optional)",
+}

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -12,6 +12,21 @@
 # 弱点は繋ぎ目で動きの勢いが一瞬失われることと、
 # 区間を重ねるごとに色味や質感が少しずつ劣化していくこと。
 #
+# 任意で区間の終了ポーズも画像で指定できる(FLF2V方式)。
+# 成り行き生成では5秒以内に動作が完結せず中途半端なポーズで終わって、
+# 次の継ぎ足しが破綻しやすい。
+# 「終了ポーズの画像」ノードで画像を選ぶと、
+# WanFirstLastFrameToVideoが末尾フレームを指定画像へ固定するため、
+# 動作が区間内で必ず完結し、
+# キーフレームを先に用意しておけば長尺の動きを計画的に設計できる。
+# 終了ポーズの画像は元動画の最終フレームを元に、
+# anime-editやqwen-editなどで先に作っておく。
+# ノード内部で生成解像度へbilinear+中央クロップされるため、
+# 元動画と同じアスペクト比の画像を用意するのが安全。
+# (none)のままなら自作のLoadImageOptionalがNoneを出力して、
+# end_imageは未指定扱いになり、
+# 従来どおり開始フレームのみの成り行き生成になる。
+#
 # モデル構成とサンプリング設定はanime-videoと同じ。
 # Wan 2.2 14B I2VのLightning LoRA有効構成で、
 # 4ステップ・CFG 1の高速生成にしている。
@@ -49,8 +64,8 @@ in
         type = "UNETLoader";
         title = "high noiseモデル";
         pos = [
-          (-40)
-          60
+          1340
+          40
         ];
         size = [
           385
@@ -68,8 +83,8 @@ in
         type = "UNETLoader";
         title = "low noiseモデル";
         pos = [
-          (-40)
-          200
+          1340
+          500
         ];
         size = [
           385
@@ -86,8 +101,8 @@ in
         id = 3;
         type = "CLIPLoader";
         pos = [
-          (-40)
-          340
+          860
+          40
         ];
         size = [
           385
@@ -110,8 +125,8 @@ in
         id = 4;
         type = "VAELoader";
         pos = [
-          (-40)
-          500
+          860
+          980
         ];
         size = [
           385
@@ -132,7 +147,7 @@ in
         title = "延長する動画";
         pos = [
           (-40)
-          620
+          320
         ];
         size = [
           340
@@ -142,12 +157,37 @@ in
         outputs = [ (mkOutput "VIDEO" "VIDEO" [ 11 ]) ];
         widgets = [ "example.webm" ];
       })
+      # 区間の終了時点のポーズを指定する任意入力。
+      # 自作のLoadImageOptionalで、(none)のままなら未指定扱いになる。
+      # 元動画と同じキャラ・同じ画風・同じアスペクト比の画像を使う。
+      (mkNode {
+        id = 27;
+        type = "LoadImageOptional";
+        title = "終了ポーズの画像(任意)";
+        pos = [
+          (-40)
+          710
+        ];
+        size = [
+          340
+          314
+        ];
+        order = 25;
+        outputs = [
+          (mkOutput "IMAGE" "IMAGE" [ 34 ])
+          (mkOutput "MASK" "MASK" [ ])
+        ];
+        widgets = [
+          "(none)"
+          "image"
+        ];
+      })
       (mkNode {
         id = 23;
         type = "GetVideoComponents";
         pos = [
-          (-40)
-          1000
+          480
+          520
         ];
         size = [
           240
@@ -171,8 +211,8 @@ in
         type = "ImageFromBatch";
         title = "最終フレームを取り出す";
         pos = [
-          (-40)
-          1180
+          480
+          700
         ];
         size = [
           315
@@ -194,8 +234,8 @@ in
         type = "ImageScaleToTotalPixels";
         title = "生成解像度へスケール";
         pos = [
-          (-40)
-          1340
+          480
+          880
         ];
         size = [
           315
@@ -220,8 +260,8 @@ in
         id = 22;
         type = "GetImageSize";
         pos = [
-          460
-          1040
+          480
+          1090
         ];
         size = [
           240
@@ -243,7 +283,7 @@ in
         title = "続きの動きの指示(日本語でも英語でも可)";
         pos = [
           (-40)
-          (-220)
+          40
         ];
         size = [
           420
@@ -259,8 +299,8 @@ in
         type = "StringConcatenate";
         title = "アニメスタイル指定の前置";
         pos = [
-          460
-          (-220)
+          480
+          40
         ];
         size = [
           340
@@ -296,8 +336,8 @@ in
         type = "PreviewAny";
         title = "最終プロンプト";
         pos = [
-          860
-          (-220)
+          480
+          240
         ];
         size = [
           340
@@ -311,8 +351,8 @@ in
         type = "CLIPTextEncode";
         title = "ポジティブ(スタイル+動きの指示)";
         pos = [
-          460
-          340
+          860
+          220
         ];
         size = [
           420
@@ -340,8 +380,8 @@ in
         type = "CLIPTextEncode";
         title = "ネガティブ(CFG 1では無効)";
         pos = [
-          460
-          560
+          860
+          450
         ];
         size = [
           420
@@ -352,27 +392,33 @@ in
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" [ 23 ]) ];
         widgets = [ negativePrompt ];
       })
-      # 元動画の最終フレームから初期latentを作る。
+      # 元動画の最終フレームを開始フレームにして初期latentを作る。
+      # end_imageは任意入力で、終了ポーズ画像が指定されている時だけ、
+      # 拡散過程で末尾フレームが境界条件として強制され、
+      # 動作が区間内で終了ポーズへ収束する。
+      # 未指定時(None)はWanImageToVideoと等価な開始フレームのみの条件付けになる。
       # 解像度はソケット経由で自動で入るので手動調整は不要。
       # 1回の延長は学習範囲内の81フレーム(約5秒)固定。
       (mkNode {
         id = 12;
-        type = "WanImageToVideo";
+        type = "WanFirstLastFrameToVideo";
         pos = [
-          460
-          780
+          860
+          680
         ];
         size = [
           315
-          210
+          230
         ];
         order = 14;
         inputs = [
           (mkInput "positive" "CONDITIONING" 22)
           (mkInput "negative" "CONDITIONING" 23)
           (mkInput "vae" "VAE" 5)
-          (mkInput "clip_vision_output" "CLIP_VISION_OUTPUT" null)
+          (mkInput "clip_vision_start_image" "CLIP_VISION_OUTPUT" null)
+          (mkInput "clip_vision_end_image" "CLIP_VISION_OUTPUT" null)
           (mkInput "start_image" "IMAGE" 15)
+          (mkInput "end_image" "IMAGE" 34)
           (
             mkInput "width" "INT" 17
             // {
@@ -413,8 +459,8 @@ in
         type = "LoraLoaderModelOnly";
         title = "Lightning LoRA(high)";
         pos = [
-          960
-          40
+          1340
+          200
         ];
         size = [
           315
@@ -433,8 +479,8 @@ in
         type = "ModelSamplingSD3";
         title = "shift(high)";
         pos = [
-          960
-          180
+          1340
+          340
         ];
         size = [
           315
@@ -450,8 +496,8 @@ in
         type = "LoraLoaderModelOnly";
         title = "Lightning LoRA(low)";
         pos = [
-          960
-          320
+          1340
+          660
         ];
         size = [
           315
@@ -470,8 +516,8 @@ in
         type = "ModelSamplingSD3";
         title = "shift(low)";
         pos = [
-          960
-          460
+          1340
+          800
         ];
         size = [
           315
@@ -488,7 +534,7 @@ in
         type = "KSamplerAdvanced";
         title = "サンプリング前半(high noise)";
         pos = [
-          1380
+          1780
           40
         ];
         size = [
@@ -523,8 +569,8 @@ in
         type = "KSamplerAdvanced";
         title = "サンプリング後半(low noise)";
         pos = [
-          1380
-          440
+          1780
+          460
         ];
         size = [
           315
@@ -555,8 +601,8 @@ in
         id = 15;
         type = "VAEDecode";
         pos = [
-          1780
-          440
+          2160
+          40
         ];
         size = [
           210
@@ -577,8 +623,8 @@ in
         type = "ImageFromBatch";
         title = "新区間の先頭フレームを除去";
         pos = [
-          1780
-          560
+          2160
+          160
         ];
         size = [
           315
@@ -599,8 +645,8 @@ in
         type = "ImageBatch";
         title = "元動画と連結";
         pos = [
-          1780
-          720
+          2160
+          340
         ];
         size = [
           240
@@ -618,8 +664,8 @@ in
         id = 17;
         type = "SaveWEBM";
         pos = [
-          1780
-          440
+          2160
+          490
         ];
         size = [
           420
@@ -753,7 +799,7 @@ in
         21
         0
         12
-        4
+        5
         "IMAGE"
       ]
       [
@@ -769,7 +815,7 @@ in
         22
         0
         12
-        5
+        7
         "INT"
       ]
       [
@@ -777,7 +823,7 @@ in
         22
         1
         12
-        6
+        8
         "INT"
       ]
       [
@@ -898,6 +944,14 @@ in
         0
         17
         0
+        "IMAGE"
+      ]
+      [
+        34
+        27
+        0
+        12
+        6
         "IMAGE"
       ]
     ];

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -27,6 +27,22 @@
 # コアのMath Expressionノードが窓の数からフレーム数を計算して、
 # WanImageToVideoのlengthへソケットで渡す。
 #
+# 任意で動画の終了ポーズも画像で指定できる(FLF2V方式)。
+# 成り行き生成では動作が中途半端なポーズで終わりやすく、
+# anime-video-extendでの継ぎ足しの破綻に繋がる。
+# 「終了ポーズの画像」ノードで画像を選ぶと、
+# WanFirstLastFrameToVideoが末尾フレームを指定画像へ固定するため、
+# 動作が動画内で必ず完結する。
+# 終了ポーズの画像は開始画像を元にanime-editやqwen-editなどで先に作っておく。
+# ノード内部で生成解像度へbilinear+中央クロップされるため、
+# 開始画像と同じアスペクト比の画像を用意するのが安全。
+# 複数窓の長尺生成でも末尾の条件は最終フレームを含む窓にだけ効くが、
+# 終了ポーズへ向かうのは最後の窓の中だけなので、
+# 長い動作を終了ポーズで縛りたい時は区間を分けてanime-video-extendで繋ぐ方が確実。
+# (none)のままなら自作のLoadImageOptionalがNoneを出力して、
+# end_imageは未指定扱いになり、
+# 従来どおり開始フレームのみの成り行き生成になる。
+#
 # 動きの指示は日本語で書けば自作カスタムノードで英語へ翻訳される。
 # カメラワーク(近づく、回り込むなど)と動作を具体的に書くと動きが出やすい。
 # 出力は公式SaveWEBMノードによるSVT-AV1のWebM。
@@ -54,8 +70,8 @@ in
         type = "UNETLoader";
         title = "high noiseモデル";
         pos = [
-          (-40)
-          60
+          1340
+          40
         ];
         size = [
           385
@@ -73,8 +89,8 @@ in
         type = "UNETLoader";
         title = "low noiseモデル";
         pos = [
-          (-40)
-          200
+          1340
+          740
         ];
         size = [
           385
@@ -91,8 +107,8 @@ in
         id = 3;
         type = "CLIPLoader";
         pos = [
-          (-40)
-          340
+          860
+          40
         ];
         size = [
           385
@@ -115,8 +131,8 @@ in
         id = 4;
         type = "VAELoader";
         pos = [
-          (-40)
-          500
+          860
+          980
         ];
         size = [
           385
@@ -137,7 +153,7 @@ in
         title = "動かす画像";
         pos = [
           (-40)
-          620
+          320
         ];
         size = [
           340
@@ -153,6 +169,31 @@ in
           "image"
         ];
       })
+      # 動画の終了時点のポーズを指定する任意入力。
+      # 自作のLoadImageOptionalで、(none)のままなら未指定扱いになる。
+      # 開始画像と同じキャラ・同じ画風・同じアスペクト比の画像を使う。
+      (mkNode {
+        id = 30;
+        type = "LoadImageOptional";
+        title = "終了ポーズの画像(任意)";
+        pos = [
+          (-40)
+          710
+        ];
+        size = [
+          340
+          314
+        ];
+        order = 26;
+        outputs = [
+          (mkOutput "IMAGE" "IMAGE" [ 37 ])
+          (mkOutput "MASK" "MASK" [ ])
+        ];
+        widgets = [
+          "(none)"
+          "image"
+        ];
+      })
       # アスペクト比を保って0.9メガピクセルへスケールしつつ、
       # 幅と高さをWanの要求する16の倍数へ丸める。
       # 生成を速くしたい時はmegapixelsを0.5などへ下げる。
@@ -161,8 +202,8 @@ in
         type = "ImageScaleToTotalPixels";
         title = "生成解像度へスケール";
         pos = [
-          (-40)
-          1020
+          480
+          520
         ];
         size = [
           315
@@ -187,8 +228,8 @@ in
         id = 22;
         type = "GetImageSize";
         pos = [
-          460
-          1040
+          480
+          730
         ];
         size = [
           240
@@ -210,7 +251,7 @@ in
         title = "動画の長さ: 1窓約5秒、1窓ごとに+約3.5秒";
         pos = [
           (-40)
-          1220
+          1100
         ];
         size = [
           460
@@ -233,8 +274,8 @@ in
         type = "ComfyMathExpression";
         title = "フレーム数を計算";
         pos = [
-          580
-          1220
+          480
+          1100
         ];
         size = [
           315
@@ -267,8 +308,8 @@ in
         type = "ComfyMathExpression";
         title = "フレーム数を秒数へ換算";
         pos = [
-          940
-          1220
+          480
+          1260
         ];
         size = [
           315
@@ -300,8 +341,8 @@ in
         type = "PreviewAny";
         title = "実際の動画の長さ(秒)";
         pos = [
-          1300
-          1220
+          840
+          1260
         ];
         size = [
           240
@@ -318,7 +359,7 @@ in
         title = "動きの指示(日本語でも英語でも可)";
         pos = [
           (-40)
-          (-220)
+          40
         ];
         size = [
           420
@@ -334,8 +375,8 @@ in
         type = "StringConcatenate";
         title = "アニメスタイル指定の前置";
         pos = [
-          460
-          (-220)
+          480
+          40
         ];
         size = [
           340
@@ -371,8 +412,8 @@ in
         type = "PreviewAny";
         title = "最終プロンプト";
         pos = [
-          860
-          (-220)
+          480
+          240
         ];
         size = [
           340
@@ -386,8 +427,8 @@ in
         type = "CLIPTextEncode";
         title = "ポジティブ(スタイル+動きの指示)";
         pos = [
-          460
-          340
+          860
+          220
         ];
         size = [
           420
@@ -415,8 +456,8 @@ in
         type = "CLIPTextEncode";
         title = "ネガティブ(CFG 1では無効)";
         pos = [
-          460
-          560
+          860
+          450
         ];
         size = [
           420
@@ -427,26 +468,31 @@ in
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" [ 13 ]) ];
         widgets = [ negativePrompt ];
       })
-      # スケール済み画像から初期latentを作る。
+      # スケール済み画像を開始フレームにして初期latentを作る。
+      # end_imageは任意入力で、終了ポーズ画像が指定されている時だけ、
+      # 拡散過程で末尾フレームが境界条件として強制される。
+      # 未指定時(None)はWanImageToVideoと等価な開始フレームのみの条件付けになる。
       # 解像度はソケット経由で自動で入るので手動調整は不要。
       (mkNode {
         id = 12;
-        type = "WanImageToVideo";
+        type = "WanFirstLastFrameToVideo";
         pos = [
-          460
-          780
+          860
+          680
         ];
         size = [
           315
-          210
+          230
         ];
         order = 12;
         inputs = [
           (mkInput "positive" "CONDITIONING" 12)
           (mkInput "negative" "CONDITIONING" 13)
           (mkInput "vae" "VAE" 5)
-          (mkInput "clip_vision_output" "CLIP_VISION_OUTPUT" null)
+          (mkInput "clip_vision_start_image" "CLIP_VISION_OUTPUT" null)
+          (mkInput "clip_vision_end_image" "CLIP_VISION_OUTPUT" null)
           (mkInput "start_image" "IMAGE" 26)
+          (mkInput "end_image" "IMAGE" 37)
           (
             mkInput "width" "INT" 28
             // {
@@ -495,8 +541,8 @@ in
         type = "LoraLoaderModelOnly";
         title = "Lightning LoRA(high)";
         pos = [
-          960
-          40
+          1340
+          200
         ];
         size = [
           315
@@ -515,8 +561,8 @@ in
         type = "LoraLoaderModelOnly";
         title = "Lightning LoRA(low)";
         pos = [
-          960
-          620
+          1340
+          880
         ];
         size = [
           315
@@ -535,8 +581,8 @@ in
         type = "ModelSamplingSD3";
         title = "shift(high)";
         pos = [
-          960
-          180
+          1340
+          340
         ];
         size = [
           315
@@ -552,8 +598,8 @@ in
         type = "ModelSamplingSD3";
         title = "shift(low)";
         pos = [
-          960
-          760
+          1340
+          1020
         ];
         size = [
           315
@@ -577,8 +623,8 @@ in
         type = "WanContextWindowsManual";
         title = "コンテキスト窓(high)";
         pos = [
-          960
-          320
+          1340
+          460
         ];
         size = [
           330
@@ -604,8 +650,8 @@ in
         type = "WanContextWindowsManual";
         title = "コンテキスト窓(low)";
         pos = [
-          960
-          900
+          1340
+          1140
         ];
         size = [
           330
@@ -632,7 +678,7 @@ in
         type = "KSamplerAdvanced";
         title = "サンプリング前半(high noise)";
         pos = [
-          1380
+          1780
           40
         ];
         size = [
@@ -667,8 +713,8 @@ in
         type = "KSamplerAdvanced";
         title = "サンプリング後半(low noise)";
         pos = [
-          1380
-          620
+          1780
+          460
         ];
         size = [
           315
@@ -699,8 +745,8 @@ in
         id = 15;
         type = "VAEDecode";
         pos = [
-          1780
-          620
+          2160
+          40
         ];
         size = [
           210
@@ -718,8 +764,8 @@ in
         id = 17;
         type = "SaveWEBM";
         pos = [
-          1780
-          620
+          2160
+          180
         ];
         size = [
           420
@@ -933,7 +979,7 @@ in
         21
         0
         12
-        4
+        5
         "IMAGE"
       ]
       [
@@ -949,7 +995,7 @@ in
         22
         0
         12
-        5
+        7
         "INT"
       ]
       [
@@ -957,7 +1003,7 @@ in
         22
         1
         12
-        6
+        8
         "INT"
       ]
       [
@@ -965,7 +1011,7 @@ in
         24
         1
         12
-        7
+        9
         "INT"
       ]
       [
@@ -1007,6 +1053,14 @@ in
         14
         0
         "MODEL"
+      ]
+      [
+        37
+        30
+        0
+        12
+        6
+        "IMAGE"
       ]
     ];
   };

--- a/nixos/host/bullet/comfyui/workflow/lib/overlap.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/overlap.nix
@@ -1,0 +1,44 @@
+# ワークフローのノード矩形の重なり検出。
+#
+# ComfyUIのノードの`pos`はタイトルバー左上の座標で、
+# `size`は本体のみの寸法なので、
+# 表示上の矩形はタイトルバーの高さを足したものになる。
+# ぴったり接していても視覚的に窮屈なので、
+# 余白が`margin`未満のペアも重なり扱いにする。
+{ lib }:
+rec {
+  # LiteGraphのNODE_TITLE_HEIGHT。
+  titleHeight = 30;
+  # ノード間に最低限確保する余白。
+  margin = 10;
+
+  # ノードのリストから重なっているペア{a, b}のリストを返す。
+  # aとbは{id, label, x0, y0, x1, y1}の矩形情報。
+  overlappingNodePairs =
+    nodes:
+    let
+      rect = node: rec {
+        inherit (node) id;
+        label = node.title or node.type;
+        x0 = builtins.elemAt node.pos 0;
+        y0 = builtins.elemAt node.pos 1;
+        x1 = x0 + builtins.elemAt node.size 0;
+        y1 = y0 + builtins.elemAt node.size 1 + titleHeight;
+      };
+      intersects =
+        a: b: a.x0 < b.x1 + margin && b.x0 < a.x1 + margin && a.y0 < b.y1 + margin && b.y0 < a.y1 + margin;
+      rects = map rect nodes;
+      n = builtins.length rects;
+    in
+    lib.concatMap (
+      i:
+      lib.concatMap (
+        j:
+        let
+          a = builtins.elemAt rects i;
+          b = builtins.elemAt rects j;
+        in
+        lib.optional (intersects a b) { inherit a b; }
+      ) (lib.range (i + 1) (n - 1))
+    ) (lib.range 0 (n - 1));
+}

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -1,0 +1,22 @@
+# 宣言された全ワークフローのレイアウトを評価時に検証する。
+#
+# ノードの重なりはUIで開くまで気付きにくく、
+# ノードを追加するたびに手動検証が漏れて何度も再発したため、
+# NixOSのassertionsで機械的に検出する。
+# `local.comfyui.workflows`を横断して検証するので、
+# ワークフローを追加するだけで自動的に検証対象になる。
+{ config, lib, ... }:
+let
+  overlap = import ./lib/overlap.nix { inherit lib; };
+  describe =
+    pair: "  ${toString pair.a.id}(${pair.a.label}) と ${toString pair.b.id}(${pair.b.label})";
+in
+{
+  config.assertions = lib.mapAttrsToList (name: workflow: {
+    assertion = overlap.overlappingNodePairs workflow.nodes == [ ];
+    message = ''
+      ComfyUIワークフロー${name}で以下のノードが重なっています(余白${toString overlap.margin}px未満を含む):
+      ${lib.concatMapStringsSep "\n" describe (overlap.overlappingNodePairs workflow.nodes)}
+    '';
+  }) config.local.comfyui.workflows;
+}


### PR DESCRIPTION
Wan 2.2 I2Vの成り行き生成では81フレーム(約5秒)以内に動作が完結せず、
中途半端なポーズで終わった動画を継ぎ足すと次区間の破綻に繋がっていました。
区間の終了ポーズを画像で指定して動作を区間内で完結させられるようにします。

anime-videoとanime-video-extendの生成ノードを、
`WanImageToVideo`からコアの`WanFirstLastFrameToVideo`へ置き換えます。
`end_image`を指定すると拡散過程で末尾フレームが境界条件として強制されるため、
動作が区間内で必ず完結し、
anime-editやqwen-editでキーフレームを先に用意すれば長尺の動きを計画的に設計できます。
このノードはWan 2.2のbase I2Vモデルでそのまま使えるため、
モデルの追加ダウンロードは不要です。

終了ポーズの指定は任意です。
自作カスタムノード`LoadImageOptional`を追加して、
画像を選べば有効、`(none)`のままなら従来どおりの成り行き生成になります。
本家`LoadImage`を継承して選択肢の先頭に`(none)`を追加したもので、
`(none)`選択時は出力がNoneになりoptional入力は未接続と同じ扱いになります。
ノードのバイパス(Ctrl+B)での切り替えは、
xremap環境でCtrl+Bがバックスペースに化けて操作しにくいため採用しませんでした。

anime-videoの複数窓の長尺生成では、
concat条件が窓ごとに時間方向でスライスされるため、
終了ポーズの条件は最終フレームを含む窓にだけ効くことを実装から確認しています。
ただし終了ポーズへ向かう動きが起きるのは最後の窓の中だけなので、
長い動作全体を縛りたい場合は区間を分けてextendで繋ぐ方が確実です。

あわせてノードの重なり検証をNixOSのassertionsとして恒久化します。
重なりはUIで開くまで気付きにくくノード追加のたびに再発していたため、
これまで使い捨てのjqスクリプトで行っていた検証を、
`local.comfyui.workflows`の全ワークフローを横断するモジュールにしました。
タイトルバー高さ込みの矩形で余白10px未満も検出し、
重なりがあると`./install.sh`やnix-fast-buildの段階で、
ワークフロー名とノードのペアがIDとタイトル付きで報告されて失敗します。
ノード追加で重なりが生じていたレイアウト自体も、
入力を左端・出力を右端に置く6列構成へ両ワークフローとも組み直しました。

bulletで適用して以下を確認済みです。

- 生成JSONのノードとリンクの整合性のスクリプト検証
- `/object_info`で`LoadImageOptional`が登録され選択肢の先頭に`(none)`が入ること
- 全8ワークフローでassertが通ることと、
  ダミーノードや一時的に重ねた実ノードで異常系が検出されること

なおカスタムノードの追加は稼働中のコンテナには反映されず、
`container@comfyui.service`の再起動が必要でした。

https://claude.ai/code/session_01BHinZcmxWCsM8p58PHAvc9