### PR TITLE
perf(comfyui): RTX 5090向けに生成速度と品質を改善する

### DIFF
--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -74,7 +74,18 @@ in
         };
       };
     config =
-      { lib, ... }:
+      {
+        lib,
+        pkgs,
+        config,
+        ...
+      }:
+      let
+        torch = lib.findFirst (
+          pkg: lib.getName pkg == "torch"
+        ) null config.services.comfyui.package.heavyDeps;
+        cudaNvcc = torch.cudaPackages.cuda_nvcc;
+      in
       {
         imports = [ inputs.utensils-comfyui-nix.nixosModules.default ];
         system.stateVersion = "26.05";
@@ -95,11 +106,17 @@ in
           inherit dataDir;
           # コンテナ内のfirewallを開ける。到達できるのはvethを持つホストのみ。
           openFirewall = true;
-          # xformers 0.0.30のflash-attentionカーネルはBlackwell(sm_120)のカーネルイメージを含まず、
-          # Qwen系モデルのサンプリング開始時に、
-          # `CUDA error: no kernel image is available for execution on the device`
-          # でクラッシュするためPyTorch組み込みのSDPAを使う。
-          extraArgs = [ "--use-pytorch-cross-attention" ];
+          # xformers 0.0.30はBlackwell(sm_120)に対応していないため使わない。
+          # RTX 5090に対応したSageAttentionで、動画生成の大半を占めるattentionを高速化する。
+          extraArgs = [ "--use-sage-attention" ];
+        };
+        # Tritonは未指定時にNixOSには存在しない`/sbin/ldconfig`でlibcudaを探す。
+        systemd.services.comfyui.environment = {
+          CC = lib.getExe pkgs.stdenv.cc;
+          TRITON_CUDACRT_PATH = "${torch.cudaPackages.cuda_cudart}/include";
+          TRITON_LIBCUDA_PATH = "/run/opengl-driver/lib";
+          TRITON_LIBDEVICE_PATH = "${cudaNvcc}/nvvm/libdevice/libdevice.10.bc";
+          TRITON_PTXAS_PATH = "${cudaNvcc}/bin/ptxas";
         };
       };
   };

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -106,9 +106,17 @@ in
           inherit dataDir;
           # コンテナ内のfirewallを開ける。到達できるのはvethを持つホストのみ。
           openFirewall = true;
-          # xformers 0.0.30はBlackwell(sm_120)に対応していないため使わない。
-          # RTX 5090に対応したSageAttentionで、動画生成の大半を占めるattentionを高速化する。
-          extraArgs = [ "--use-sage-attention" ];
+          extraArgs = [
+            # WanのRoPEやFP8量子化処理をeager実装からTritonカーネルへ切り替える。
+            "--enable-triton-backend"
+            # FP16の行列積で低精度の累積を許可して、LoRAやFP16 fallbackを高速化する。
+            # 丸め誤差が増えるため生成結果は変化する可能性がある。
+            "--fast"
+            "fp16_accumulation"
+            # xformers 0.0.30はBlackwell(sm_120)に対応していないため使わない。
+            # SageAttentionで動画生成の大半を占めるattentionを近似計算して高速化する。
+            "--use-sage-attention"
+          ];
         };
         # Tritonは未指定時にNixOSには存在しない`/sbin/ldconfig`でlibcudaを探す。
         systemd.services.comfyui.environment = {

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -84,7 +84,7 @@ in
         comfyuiPython = config.services.comfyui.package.pythonRuntime.python;
         torch = lib.findFirst (
           pkg: lib.getName pkg == "torch"
-        ) null config.services.comfyui.package.heavyDeps;
+        ) (throw "torch not found in comfyui heavyDeps") config.services.comfyui.package.heavyDeps;
         cudaNvcc = torch.cudaPackages.cuda_nvcc;
         sageattention = comfyuiPython.pkgs.callPackage ../../../../pkgs/sageattention.nix {
           inherit torch;

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -88,6 +88,7 @@ in
         cudaNvcc = torch.cudaPackages.cuda_nvcc;
         sageattention = comfyuiPython.pkgs.callPackage ../../../../pkgs/sageattention.nix {
           inherit torch;
+          # torchの全CUDA世代ではなく、RTX 5090向けのカーネルだけをビルドする。
           cudaCapabilities = [ "12.0" ];
         };
       in

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -81,10 +81,15 @@ in
         ...
       }:
       let
+        comfyuiPython = config.services.comfyui.package.pythonRuntime.python;
         torch = lib.findFirst (
           pkg: lib.getName pkg == "torch"
         ) null config.services.comfyui.package.heavyDeps;
         cudaNvcc = torch.cudaPackages.cuda_nvcc;
+        sageattention = comfyuiPython.pkgs.callPackage ../../../../pkgs/sageattention.nix {
+          inherit torch;
+          cudaCapabilities = [ "12.0" ];
+        };
       in
       {
         imports = [ inputs.utensils-comfyui-nix.nixosModules.default ];
@@ -121,6 +126,7 @@ in
         # Tritonは未指定時にNixOSには存在しない`/sbin/ldconfig`でlibcudaを探す。
         systemd.services.comfyui.environment = {
           CC = lib.getExe pkgs.stdenv.cc;
+          PYTHONPATH = lib.makeSearchPath comfyuiPython.sitePackages [ sageattention ];
           TRITON_CUDACRT_PATH = "${torch.cudaPackages.cuda_cudart}/include";
           TRITON_LIBCUDA_PATH = "/run/opengl-driver/lib";
           TRITON_LIBDEVICE_PATH = "${cudaNvcc}/nvvm/libdevice/libdevice.10.bc";

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -84,21 +84,23 @@ let
       };
     };
     text_encoders = {
-      # Qwen-Image系が使うテキストエンコーダ。画像も読むVLM。
-      "qwen_2.5_vl_7b_fp8_scaled.safetensors" = fetchHuggingface {
+      # Qwen-Image-Editで編集指示と入力画像を解析するVLM。
+      # 画像理解と複雑な指示の精度を優先してBF16版を使う。
+      "qwen_2.5_vl_7b.safetensors" = fetchHuggingface {
         owner = "Comfy-Org";
         repo = "Qwen-Image_ComfyUI";
         rev = "46839d338df81ce625d5fae27d7e370314c0fbc9";
-        file = "split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors";
-        hash = "sha256-y1Y22FKg6mqQdasb70lsDbeu8TwCNQVx44iuqVnFwLQ=";
+        file = "split_files/text_encoders/qwen_2.5_vl_7b.safetensors";
+        hash = "sha256-z6/XOUWbyGJXOXJZ9hKpruiOW5joW1wNDRcX6JizRjo=";
       };
       # Wan系が使うテキストエンコーダ。
-      "umt5_xxl_fp8_e4m3fn_scaled.safetensors" = fetchHuggingface {
+      # 複雑な動作やカメラ指示の追従精度を優先してFP16版を使う。
+      "umt5_xxl_fp16.safetensors" = fetchHuggingface {
         owner = "Comfy-Org";
         repo = "Wan_2.2_ComfyUI_Repackaged";
         rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
-        file = "split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors";
-        hash = "sha256-wzVdMBkfHwZrJtk/ugF66YCdzmxifdpfambqplEgT2g=";
+        file = "split_files/text_encoders/umt5_xxl_fp16.safetensors";
+        hash = "sha256-e4hQ8ZYeHPinfMpMlko1jTA/SQgzxsCH0M/0svmdsq8=";
       };
     };
     vae = {

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -52,14 +52,6 @@ let
         file = "animagine-xl-4.0.safetensors";
         hash = "sha256-HVtD/3W2q1mFAtTHedL7+j3OylHGDDtglkCmB3IzORY=";
       };
-      # Illustrious系の公式ベースモデル。素の状態やマージ元として。
-      "Illustrious-XL-v2.0.safetensors" = fetchHuggingface {
-        owner = "OnomaAIResearch";
-        repo = "Illustrious-XL-v2.0";
-        rev = "69459c1fe6f46db41ab31e6114f05acc0e06bcaa";
-        file = "Illustrious-XL-v2.0.safetensors";
-        hash = "sha256-wqGj6qE9TBB9x+AMP+gwyrQnqgJjYnQOoJR0WzQiozE=";
-      };
     };
     # UNETLoaderが読むcheckpoint非統合の拡散モデル。
     diffusion_models = {

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -44,15 +44,6 @@ let
         file = "waiIllustriousSDXL_v170.safetensors";
         hash = "sha256-8Rawx4/0QUZ7DNyPGTbh7RjqMemZfHsTKxuNtTPwvQQ=";
       };
-      # Illustrious-XLにdanbooru/e621約1300万枚を追加学習したモデル。
-      # 画質とタグ網羅性に強い。非商用ライセンス。
-      "NoobAI-XL-v1.1.safetensors" = fetchHuggingface {
-        owner = "Laxhar";
-        repo = "noobai-XL-1.1";
-        rev = "814a274af2b8097c0828819d561ec74c7d0c6cea";
-        file = "NoobAI-XL-v1.1.safetensors";
-        hash = "sha256-ZoHo5LE0yB8WUzrO2w1AbX5eNm4WJLQQUXjGTQCwXVE=";
-      };
       # SDXLをアニメ画像で再学習したモデル。タグ設計が分かりやすい。
       "animagine-xl-4.0.safetensors" = fetchHuggingface {
         owner = "cagliostrolab";

--- a/nixos/host/bullet/comfyui/model.nix
+++ b/nixos/host/bullet/comfyui/model.nix
@@ -81,22 +81,23 @@ let
         file = "split_files/diffusion_models/qwen_image_edit_2511_fp8mixed.safetensors";
         hash = "sha256-yf3BWORtO2HvdfIa6GbKL+gIv0pTZDEg0cHofBkoCk4=";
       };
-      # Wan 2.2 image-to-videoの14B MoE構成のexpertモデル2つ。
+      # Wan 2.2 I2V 14B MoEを4ステップ用に蒸留したfull expertモデル2つ。
+      # LoRA近似ではなく蒸留済みの全重みを使い、
       # サンプリング前半をhigh noise、後半をlow noiseが担当する。
       # Apache 2.0ライセンス。
-      "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors" = fetchHuggingface {
-        owner = "Comfy-Org";
-        repo = "Wan_2.2_ComfyUI_Repackaged";
-        rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
-        file = "split_files/diffusion_models/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors";
-        hash = "sha256-YSLnnVXg8jVpjRHWV/OxlsUnPIMNoAsrATxaBI1eakI=";
+      "wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors" = fetchHuggingface {
+        owner = "lightx2v";
+        repo = "Wan2.2-Distill-Models";
+        rev = "715f592b12e99e398923d255ee6a4dae85543cee";
+        file = "wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors";
+        hash = "sha256-OdOvdORuWemJ21zDb0AeZm8653x2SOtV06/5/uR3Fvo=";
       };
-      "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors" = fetchHuggingface {
-        owner = "Comfy-Org";
-        repo = "Wan_2.2_ComfyUI_Repackaged";
-        rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
-        file = "split_files/diffusion_models/wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors";
-        hash = "sha256-VHGkV7asQEICpfvmwRWVo9VkH8dmsA84dj9yMD//wh4=";
+      "wan2.2_i2v_A14b_low_noise_lightx2v_4step.safetensors" = fetchHuggingface {
+        owner = "lightx2v";
+        repo = "Wan2.2-Distill-Models";
+        rev = "715f592b12e99e398923d255ee6a4dae85543cee";
+        file = "wan2.2_i2v_A14b_low_noise_lightx2v_4step.safetensors";
+        hash = "sha256-o7hoCv/iqy4hISEKg/+n01H3faGBkeV7s1nXg5vrqKI=";
       };
     };
     text_encoders = {
@@ -133,25 +134,6 @@ let
         rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
         file = "split_files/vae/wan_2.1_vae.safetensors";
         hash = "sha256-L8OdMTWaSwpk9Vh22P9/qNeAlWriyxNGOwIj4VFIl2s=";
-      };
-    };
-    loras = {
-      # Wan 2.2 I2V用のlightx2v蒸留LoRA。
-      # 4ステップ・CFG 1での高速生成を可能にする。
-      # high/low noiseの各expertモデルに対応する方を適用する。
-      "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors" = fetchHuggingface {
-        owner = "Comfy-Org";
-        repo = "Wan_2.2_ComfyUI_Repackaged";
-        rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
-        file = "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors";
-        hash = "sha256-0XbICNb8RhmZto4yHvy3UBsguMN5dSPtDfFPfR3v8R4=";
-      };
-      "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors" = fetchHuggingface {
-        owner = "Comfy-Org";
-        repo = "Wan_2.2_ComfyUI_Repackaged";
-        rev = "fb1388adc906ab39ffc26ee40e96b22886b56bc4";
-        file = "split_files/loras/wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors";
-        hash = "sha256-Ak8h3glbyPrZgJ3tPp5JouFw3PJwddqBRbp9YNiqt/k=";
       };
     };
     controlnet = {

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -28,7 +28,7 @@
 # 従来どおり開始フレームのみの成り行き生成になる。
 #
 # モデル構成とサンプリング設定はanime-videoと同じ。
-# Wan 2.2 14B I2VのLightning LoRA有効構成で、
+# Wan 2.2 14B I2Vのlightx2v 4-step distilled full model構成で、
 # 4ステップ・CFG 1の高速生成にしている。
 # 1回の延長は学習範囲内の81フレーム固定なのでコンテキスト窓は使わない。
 #
@@ -74,7 +74,7 @@ in
         order = 0;
         outputs = [ (mkOutput "MODEL" "MODEL" [ 1 ]) ];
         widgets = [
-          "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors"
+          "wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors"
           "default" # weight_dtype
         ];
       })
@@ -93,7 +93,7 @@ in
         order = 1;
         outputs = [ (mkOutput "MODEL" "MODEL" [ 2 ]) ];
         widgets = [
-          "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors"
+          "wan2.2_i2v_A14b_low_noise_lightx2v_4step.safetensors"
           "default" # weight_dtype
         ];
       })
@@ -455,26 +455,6 @@ in
         ];
       })
       (mkNode {
-        id = 5;
-        type = "LoraLoaderModelOnly";
-        title = "Lightning LoRA(high)";
-        pos = [
-          1340
-          200
-        ];
-        size = [
-          315
-          82
-        ];
-        order = 15;
-        inputs = [ (mkInput "model" "MODEL" 1) ];
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 7 ]) ];
-        widgets = [
-          "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
-          1 # strength_model
-        ];
-      })
-      (mkNode {
         id = 7;
         type = "ModelSamplingSD3";
         title = "shift(high)";
@@ -487,29 +467,9 @@ in
           58
         ];
         order = 16;
-        inputs = [ (mkInput "model" "MODEL" 7) ];
+        inputs = [ (mkInput "model" "MODEL" 1) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 9 ]) ];
         widgets = [ 5 ]; # shift
-      })
-      (mkNode {
-        id = 6;
-        type = "LoraLoaderModelOnly";
-        title = "Lightning LoRA(low)";
-        pos = [
-          1340
-          660
-        ];
-        size = [
-          315
-          82
-        ];
-        order = 17;
-        inputs = [ (mkInput "model" "MODEL" 2) ];
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 8 ]) ];
-        widgets = [
-          "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
-          1 # strength_model
-        ];
       })
       (mkNode {
         id = 8;
@@ -524,7 +484,7 @@ in
           58
         ];
         order = 18;
-        inputs = [ (mkInput "model" "MODEL" 8) ];
+        inputs = [ (mkInput "model" "MODEL" 2) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 10 ]) ];
         widgets = [ 5 ]; # shift
       })
@@ -686,7 +646,7 @@ in
         1
         1
         0
-        5
+        7
         0
         "MODEL"
       ]
@@ -694,7 +654,7 @@ in
         2
         2
         0
-        6
+        8
         0
         "MODEL"
       ]
@@ -729,22 +689,6 @@ in
         15
         1
         "VAE"
-      ]
-      [
-        7
-        5
-        0
-        7
-        0
-        "MODEL"
-      ]
-      [
-        8
-        6
-        0
-        8
-        0
-        "MODEL"
       ]
       [
         9

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -116,7 +116,7 @@ in
           ])
         ];
         widgets = [
-          "umt5_xxl_fp8_e4m3fn_scaled.safetensors"
+          "umt5_xxl_fp16.safetensors"
           "wan" # type
           "default" # device
         ];

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -1,9 +1,9 @@
 # アニメ調イラスト1枚をWan 2.2 14B I2Vで動画にするワークフロー。
 #
-# 公式テンプレートvideo_wan2_2_14B_i2vのLightning LoRA有効構成を、
+# 公式テンプレートvideo_wan2_2_14B_i2vと同じ4ステップ構成を、
 # サブグラフや切り替えスイッチを除いてフラットに展開したもの。
 # high noise→low noiseの2つのexpertモデルをKSamplerAdvanced 2段で使い分ける。
-# lightx2v 4steps LoRAで4ステップ・CFG 1の高速生成にしている。
+# lightx2vの4-step distilled full modelで4ステップ・CFG 1の高速生成にしている。
 #
 # Wan 2.2は実写方向へのバイアスが強く、
 # アニメ絵を入力すると実写風に崩れたり動かなかったりしやすい。
@@ -14,9 +14,6 @@
 # 生成解像度は入力画像から自動で決まる。
 # アスペクト比を保ったまま総ピクセル量0.9メガピクセル(720p相当)へスケールして、
 # 16の倍数へ丸めた実寸をWanImageToVideoへ渡す。
-#
-# 品質重視にする場合はLightning LoRAの2ノードをバイパスして、
-# 両方のKSamplerAdvancedをsteps 20(切り替え点10)、cfg 3.5にする。
 #
 # 動画の長さは「窓の数」で指定する。
 # Wanは81フレーム(16fpsで約5秒)前後の長さで学習されていて、
@@ -80,7 +77,7 @@ in
         order = 0;
         outputs = [ (mkOutput "MODEL" "MODEL" [ 1 ]) ];
         widgets = [
-          "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors"
+          "wan2.2_i2v_A14b_high_noise_lightx2v_4step.safetensors"
           "default" # weight_dtype
         ];
       })
@@ -99,7 +96,7 @@ in
         order = 1;
         outputs = [ (mkOutput "MODEL" "MODEL" [ 2 ]) ];
         widgets = [
-          "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors"
+          "wan2.2_i2v_A14b_low_noise_lightx2v_4step.safetensors"
           "default" # weight_dtype
         ];
       })
@@ -537,46 +534,6 @@ in
         ];
       })
       (mkNode {
-        id = 5;
-        type = "LoraLoaderModelOnly";
-        title = "Lightning LoRA(high)";
-        pos = [
-          1340
-          200
-        ];
-        size = [
-          315
-          82
-        ];
-        order = 13;
-        inputs = [ (mkInput "model" "MODEL" 1) ];
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 7 ]) ];
-        widgets = [
-          "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
-          1 # strength_model
-        ];
-      })
-      (mkNode {
-        id = 6;
-        type = "LoraLoaderModelOnly";
-        title = "Lightning LoRA(low)";
-        pos = [
-          1340
-          880
-        ];
-        size = [
-          315
-          82
-        ];
-        order = 14;
-        inputs = [ (mkInput "model" "MODEL" 2) ];
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 8 ]) ];
-        widgets = [
-          "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
-          1 # strength_model
-        ];
-      })
-      (mkNode {
         id = 7;
         type = "ModelSamplingSD3";
         title = "shift(high)";
@@ -589,7 +546,7 @@ in
           58
         ];
         order = 15;
-        inputs = [ (mkInput "model" "MODEL" 7) ];
+        inputs = [ (mkInput "model" "MODEL" 1) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 9 ]) ];
         widgets = [ 5 ]; # shift
       })
@@ -606,7 +563,7 @@ in
           58
         ];
         order = 16;
-        inputs = [ (mkInput "model" "MODEL" 8) ];
+        inputs = [ (mkInput "model" "MODEL" 2) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 10 ]) ];
         widgets = [ 5 ]; # shift
       })
@@ -786,7 +743,7 @@ in
         1
         1
         0
-        5
+        7
         0
         "MODEL"
       ]
@@ -794,7 +751,7 @@ in
         2
         2
         0
-        6
+        8
         0
         "MODEL"
       ]
@@ -829,22 +786,6 @@ in
         15
         1
         "VAE"
-      ]
-      [
-        7
-        5
-        0
-        7
-        0
-        "MODEL"
-      ]
-      [
-        8
-        6
-        0
-        8
-        0
-        "MODEL"
       ]
       [
         9

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -119,7 +119,7 @@ in
           ])
         ];
         widgets = [
-          "umt5_xxl_fp8_e4m3fn_scaled.safetensors"
+          "umt5_xxl_fp16.safetensors"
           "wan" # type
           "default" # device
         ];

--- a/nixos/host/bullet/comfyui/workflow/lib/link-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/link-test.nix
@@ -1,0 +1,36 @@
+{ lib }:
+let
+  link = import ./link.nix { inherit lib; };
+  validWorkflow = {
+    nodes = [
+      {
+        id = 1;
+        inputs = [ ];
+        outputs = [ { links = [ 1 ]; } ];
+      }
+      {
+        id = 2;
+        inputs = [ { link = 1; } ];
+        outputs = [ ];
+      }
+    ];
+    links = [
+      [
+        1
+        1
+        0
+        2
+        0
+        "TEST"
+      ]
+    ];
+  };
+  brokenWorkflow = validWorkflow // {
+    nodes = map (
+      node: if node.id == 2 then node // { inputs = [ { link = 2; } ]; } else node
+    ) validWorkflow.nodes;
+  };
+in
+assert lib.assertMsg (link.invalidReferences validWorkflow == [ ]) "正常なワークフローを拒否しました";
+assert lib.assertMsg (link.invalidReferences brokenWorkflow != [ ]) "壊れたワークフローを検出できませんでした";
+true

--- a/nixos/host/bullet/comfyui/workflow/lib/link-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/link-test.nix
@@ -6,11 +6,21 @@ let
       {
         id = 1;
         inputs = [ ];
-        outputs = [ { links = [ 1 ]; } ];
+        outputs = [
+          {
+            type = "TEST";
+            links = [ 1 ];
+          }
+        ];
       }
       {
         id = 2;
-        inputs = [ { link = 1; } ];
+        inputs = [
+          {
+            type = "TEST";
+            link = 1;
+          }
+        ];
         outputs = [ ];
       }
     ];
@@ -27,10 +37,48 @@ let
   };
   brokenWorkflow = validWorkflow // {
     nodes = map (
-      node: if node.id == 2 then node // { inputs = [ { link = 2; } ]; } else node
+      node:
+      if node.id == 2 then
+        node
+        // {
+          inputs = [
+            {
+              type = "TEST";
+              link = 2;
+            }
+          ];
+        }
+      else
+        node
     ) validWorkflow.nodes;
+  };
+  invalidSlotWorkflow = validWorkflow // {
+    links = [
+      [
+        1
+        1
+        1
+        2
+        0
+        "TEST"
+      ]
+    ];
+  };
+  invalidTypeWorkflow = validWorkflow // {
+    links = [
+      [
+        1
+        1
+        0
+        2
+        0
+        "OTHER"
+      ]
+    ];
   };
 in
 assert lib.assertMsg (link.invalidReferences validWorkflow == [ ]) "正常なワークフローを拒否しました";
 assert lib.assertMsg (link.invalidReferences brokenWorkflow != [ ]) "壊れたワークフローを検出できませんでした";
+assert lib.assertMsg (link.invalidReferences invalidSlotWorkflow != [ ]) "範囲外のスロットを検出できませんでした";
+assert lib.assertMsg (link.invalidReferences invalidTypeWorkflow != [ ]) "一致しないリンク型を検出できませんでした";
 true

--- a/nixos/host/bullet/comfyui/workflow/lib/link.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/link.nix
@@ -8,6 +8,9 @@
       getSlot =
         slots: index:
         if 0 <= index && index < builtins.length slots then builtins.elemAt slots index else null;
+      acceptsType =
+        slotType: linkType:
+        slotType == "*" || linkType == "*" || builtins.elem linkType (lib.splitString "," slotType);
       nodeReferenceErrors = lib.concatMap (
         node:
         lib.concatLists (
@@ -45,6 +48,7 @@
           sourceSlot = builtins.elemAt link 2;
           targetNodeId = builtins.elemAt link 3;
           targetSlot = builtins.elemAt link 4;
+          linkType = builtins.elemAt link 5;
           sourceNode = findNode sourceNodeId;
           targetNode = findNode targetNodeId;
           sourceOutput = if sourceNode == null then null else getSlot sourceNode.outputs sourceSlot;
@@ -56,6 +60,12 @@
         ++ lib.optional (
           targetInput == null || targetInput.link != linkId
         ) "  リンク${toString linkId}の接続先ノード${toString targetNodeId}の入力${toString targetSlot}がリンクを参照していません"
+        ++ lib.optional (
+          sourceOutput != null && !(acceptsType sourceOutput.type linkType)
+        ) "  リンク${toString linkId}の型${linkType}が接続元の出力型${sourceOutput.type}と一致しません"
+        ++ lib.optional (
+          targetInput != null && !(acceptsType targetInput.type linkType)
+        ) "  リンク${toString linkId}の型${linkType}が接続先の入力型${targetInput.type}と一致しません"
       ) workflow.links;
     in
     nodeReferenceErrors ++ linkEndpointErrors;

--- a/nixos/host/bullet/comfyui/workflow/lib/link.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/link.nix
@@ -1,0 +1,62 @@
+{ lib }:
+{
+  invalidReferences =
+    workflow:
+    let
+      findNode = id: lib.findFirst (node: node.id == id) null workflow.nodes;
+      findLink = id: lib.findFirst (link: builtins.elemAt link 0 == id) null workflow.links;
+      getSlot =
+        slots: index:
+        if 0 <= index && index < builtins.length slots then builtins.elemAt slots index else null;
+      nodeReferenceErrors = lib.concatMap (
+        node:
+        lib.concatLists (
+          lib.imap0 (
+            inputSlot: input:
+            let
+              link = if input.link == null then null else findLink input.link;
+            in
+            lib.optional (
+              input.link != null
+              && (link == null || builtins.elemAt link 3 != node.id || builtins.elemAt link 4 != inputSlot)
+            ) "  ノード${toString node.id}の入力${toString inputSlot}が不整合なリンク${toString input.link}を参照しています"
+          ) node.inputs
+        )
+        ++ lib.concatLists (
+          lib.imap0 (
+            outputSlot: output:
+            lib.concatMap (
+              linkId:
+              let
+                link = findLink linkId;
+              in
+              lib.optional (
+                link == null || builtins.elemAt link 1 != node.id || builtins.elemAt link 2 != outputSlot
+              ) "  ノード${toString node.id}の出力${toString outputSlot}が不整合なリンク${toString linkId}を参照しています"
+            ) output.links
+          ) node.outputs
+        )
+      ) workflow.nodes;
+      linkEndpointErrors = lib.concatMap (
+        link:
+        let
+          linkId = builtins.elemAt link 0;
+          sourceNodeId = builtins.elemAt link 1;
+          sourceSlot = builtins.elemAt link 2;
+          targetNodeId = builtins.elemAt link 3;
+          targetSlot = builtins.elemAt link 4;
+          sourceNode = findNode sourceNodeId;
+          targetNode = findNode targetNodeId;
+          sourceOutput = if sourceNode == null then null else getSlot sourceNode.outputs sourceSlot;
+          targetInput = if targetNode == null then null else getSlot targetNode.inputs targetSlot;
+        in
+        lib.optional (
+          sourceOutput == null || !(builtins.elem linkId sourceOutput.links)
+        ) "  リンク${toString linkId}の接続元ノード${toString sourceNodeId}の出力${toString sourceSlot}がリンクを参照していません"
+        ++ lib.optional (
+          targetInput == null || targetInput.link != linkId
+        ) "  リンク${toString linkId}の接続先ノード${toString targetNodeId}の入力${toString targetSlot}がリンクを参照していません"
+      ) workflow.links;
+    in
+    nodeReferenceErrors ++ linkEndpointErrors;
+}

--- a/nixos/host/bullet/comfyui/workflow/lib/overlap-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/overlap-test.nix
@@ -1,0 +1,46 @@
+{ lib }:
+let
+  overlap = import ./overlap.nix { inherit lib; };
+  validNodes = [
+    {
+      id = 1;
+      type = "TestNode";
+      pos = [
+        0
+        0
+      ];
+      size = [
+        100
+        100
+      ];
+    }
+    {
+      id = 2;
+      type = "TestNode";
+      pos = [
+        200
+        0
+      ];
+      size = [
+        100
+        100
+      ];
+    }
+  ];
+  overlappingNodes = map (
+    node:
+    if node.id == 2 then
+      node
+      // {
+        pos = [
+          50
+          0
+        ];
+      }
+    else
+      node
+  ) validNodes;
+in
+assert lib.assertMsg (overlap.overlappingNodePairs validNodes == [ ]) "重なっていないノードを拒否しました";
+assert lib.assertMsg (overlap.overlappingNodePairs overlappingNodes != [ ]) "重なったノードを検出できませんでした";
+true

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -65,7 +65,7 @@ in
           ])
         ];
         widgets = [
-          "qwen_2.5_vl_7b_fp8_scaled.safetensors"
+          "qwen_2.5_vl_7b.safetensors"
           "qwen_image" # type
           "default" # device
         ];

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -7,75 +7,21 @@
 # ワークフローを追加するだけで自動的に検証対象になる。
 { config, lib, ... }:
 let
+  link = import ./lib/link.nix { inherit lib; };
+  linkTest = import ./lib/link-test.nix { inherit lib; };
   overlap = import ./lib/overlap.nix { inherit lib; };
+  overlapTest = import ./lib/overlap-test.nix { inherit lib; };
   describeOverlap =
     pair: "  ${toString pair.a.id}(${pair.a.label}) と ${toString pair.b.id}(${pair.b.label})";
-  invalidLinkReferences =
-    workflow:
-    let
-      findNode = id: lib.findFirst (node: node.id == id) null workflow.nodes;
-      findLink = id: lib.findFirst (link: builtins.elemAt link 0 == id) null workflow.links;
-      getSlot =
-        slots: index:
-        if 0 <= index && index < builtins.length slots then builtins.elemAt slots index else null;
-      nodeReferenceErrors = lib.concatMap (
-        node:
-        lib.concatLists (
-          lib.imap0 (
-            inputSlot: input:
-            let
-              link = if input.link == null then null else findLink input.link;
-            in
-            lib.optional (
-              input.link != null
-              && (link == null || builtins.elemAt link 3 != node.id || builtins.elemAt link 4 != inputSlot)
-            ) "  ノード${toString node.id}の入力${toString inputSlot}が不整合なリンク${toString input.link}を参照しています"
-          ) node.inputs
-        )
-        ++ lib.concatLists (
-          lib.imap0 (
-            outputSlot: output:
-            lib.concatMap (
-              linkId:
-              let
-                link = findLink linkId;
-              in
-              lib.optional (
-                link == null || builtins.elemAt link 1 != node.id || builtins.elemAt link 2 != outputSlot
-              ) "  ノード${toString node.id}の出力${toString outputSlot}が不整合なリンク${toString linkId}を参照しています"
-            ) output.links
-          ) node.outputs
-        )
-      ) workflow.nodes;
-      linkEndpointErrors = lib.concatMap (
-        link:
-        let
-          linkId = builtins.elemAt link 0;
-          sourceNodeId = builtins.elemAt link 1;
-          sourceSlot = builtins.elemAt link 2;
-          targetNodeId = builtins.elemAt link 3;
-          targetSlot = builtins.elemAt link 4;
-          sourceNode = findNode sourceNodeId;
-          targetNode = findNode targetNodeId;
-          sourceOutput = if sourceNode == null then null else getSlot sourceNode.outputs sourceSlot;
-          targetInput = if targetNode == null then null else getSlot targetNode.inputs targetSlot;
-        in
-        lib.optional (
-          sourceOutput == null || !(builtins.elem linkId sourceOutput.links)
-        ) "  リンク${toString linkId}の接続元ノード${toString sourceNodeId}の出力${toString sourceSlot}がリンクを参照していません"
-        ++ lib.optional (
-          targetInput == null || targetInput.link != linkId
-        ) "  リンク${toString linkId}の接続先ノード${toString targetNodeId}の入力${toString targetSlot}がリンクを参照していません"
-      ) workflow.links;
-    in
-    nodeReferenceErrors ++ linkEndpointErrors;
 in
+assert linkTest;
+assert overlapTest;
 {
   config.assertions = lib.concatLists (
     lib.mapAttrsToList (
       name: workflow:
       let
-        linkErrors = invalidLinkReferences workflow;
+        linkErrors = link.invalidReferences workflow;
         overlappingNodePairs = overlap.overlappingNodePairs workflow.nodes;
       in
       [

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -10,36 +10,90 @@ let
   overlap = import ./lib/overlap.nix { inherit lib; };
   describeOverlap =
     pair: "  ${toString pair.a.id}(${pair.a.label}) と ${toString pair.b.id}(${pair.b.label})";
-  invalidNodeLinks =
+  invalidLinkReferences =
     workflow:
     let
-      nodeIds = map (node: node.id) workflow.nodes;
+      findNode = id: lib.findFirst (node: node.id == id) null workflow.nodes;
+      findLink = id: lib.findFirst (link: builtins.elemAt link 0 == id) null workflow.links;
+      getSlot =
+        slots: index:
+        if 0 <= index && index < builtins.length slots then builtins.elemAt slots index else null;
+      nodeReferenceErrors = lib.concatMap (
+        node:
+        lib.concatLists (
+          lib.imap0 (
+            inputSlot: input:
+            let
+              link = if input.link == null then null else findLink input.link;
+            in
+            lib.optional (
+              input.link != null
+              && (link == null || builtins.elemAt link 3 != node.id || builtins.elemAt link 4 != inputSlot)
+            ) "  ノード${toString node.id}の入力${toString inputSlot}が不整合なリンク${toString input.link}を参照しています"
+          ) node.inputs
+        )
+        ++ lib.concatLists (
+          lib.imap0 (
+            outputSlot: output:
+            lib.concatMap (
+              linkId:
+              let
+                link = findLink linkId;
+              in
+              lib.optional (
+                link == null || builtins.elemAt link 1 != node.id || builtins.elemAt link 2 != outputSlot
+              ) "  ノード${toString node.id}の出力${toString outputSlot}が不整合なリンク${toString linkId}を参照しています"
+            ) output.links
+          ) node.outputs
+        )
+      ) workflow.nodes;
+      linkEndpointErrors = lib.concatMap (
+        link:
+        let
+          linkId = builtins.elemAt link 0;
+          sourceNodeId = builtins.elemAt link 1;
+          sourceSlot = builtins.elemAt link 2;
+          targetNodeId = builtins.elemAt link 3;
+          targetSlot = builtins.elemAt link 4;
+          sourceNode = findNode sourceNodeId;
+          targetNode = findNode targetNodeId;
+          sourceOutput = if sourceNode == null then null else getSlot sourceNode.outputs sourceSlot;
+          targetInput = if targetNode == null then null else getSlot targetNode.inputs targetSlot;
+        in
+        lib.optional (
+          sourceOutput == null || !(builtins.elem linkId sourceOutput.links)
+        ) "  リンク${toString linkId}の接続元ノード${toString sourceNodeId}の出力${toString sourceSlot}がリンクを参照していません"
+        ++ lib.optional (
+          targetInput == null || targetInput.link != linkId
+        ) "  リンク${toString linkId}の接続先ノード${toString targetNodeId}の入力${toString targetSlot}がリンクを参照していません"
+      ) workflow.links;
     in
-    builtins.filter (
-      link:
-      !(builtins.elem (builtins.elemAt link 1) nodeIds && builtins.elem (builtins.elemAt link 3) nodeIds)
-    ) workflow.links;
-  describeInvalidNodeLink =
-    link:
-    "  リンク${toString (builtins.elemAt link 0)}: ノード${toString (builtins.elemAt link 1)} → ノード${toString (builtins.elemAt link 3)}";
+    nodeReferenceErrors ++ linkEndpointErrors;
 in
 {
   config.assertions = lib.concatLists (
-    lib.mapAttrsToList (name: workflow: [
-      {
-        assertion = invalidNodeLinks workflow == [ ];
-        message = ''
-          ComfyUIワークフロー${name}で以下のリンクが存在しないノードを参照しています:
-          ${lib.concatMapStringsSep "\n" describeInvalidNodeLink (invalidNodeLinks workflow)}
-        '';
-      }
-      {
-        assertion = overlap.overlappingNodePairs workflow.nodes == [ ];
-        message = ''
-          ComfyUIワークフロー${name}で以下のノードが重なっています(余白${toString overlap.margin}px未満を含む):
-          ${lib.concatMapStringsSep "\n" describeOverlap (overlap.overlappingNodePairs workflow.nodes)}
-        '';
-      }
-    ]) config.local.comfyui.workflows
+    lib.mapAttrsToList (
+      name: workflow:
+      let
+        linkErrors = invalidLinkReferences workflow;
+        overlappingNodePairs = overlap.overlappingNodePairs workflow.nodes;
+      in
+      [
+        {
+          assertion = linkErrors == [ ];
+          message = ''
+            ComfyUIワークフロー${name}で以下のリンク参照が不整合です:
+            ${lib.concatStringsSep "\n" linkErrors}
+          '';
+        }
+        {
+          assertion = overlappingNodePairs == [ ];
+          message = ''
+            ComfyUIワークフロー${name}で以下のノードが重なっています(余白${toString overlap.margin}px未満を含む):
+            ${lib.concatMapStringsSep "\n" describeOverlap overlappingNodePairs}
+          '';
+        }
+      ]
+    ) config.local.comfyui.workflows
   );
 }

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -1,6 +1,6 @@
-# 宣言された全ワークフローのレイアウトを評価時に検証する。
+# 宣言された全ワークフローの構造とレイアウトを評価時に検証する。
 #
-# ノードの重なりはUIで開くまで気付きにくく、
+# 存在しないノードへのリンクやノードの重なりはUIで開くまで気付きにくく、
 # ノードを追加するたびに手動検証が漏れて何度も再発したため、
 # NixOSのassertionsで機械的に検出する。
 # `local.comfyui.workflows`を横断して検証するので、
@@ -8,15 +8,38 @@
 { config, lib, ... }:
 let
   overlap = import ./lib/overlap.nix { inherit lib; };
-  describe =
+  describeOverlap =
     pair: "  ${toString pair.a.id}(${pair.a.label}) と ${toString pair.b.id}(${pair.b.label})";
+  invalidNodeLinks =
+    workflow:
+    let
+      nodeIds = map (node: node.id) workflow.nodes;
+    in
+    builtins.filter (
+      link:
+      !(builtins.elem (builtins.elemAt link 1) nodeIds && builtins.elem (builtins.elemAt link 3) nodeIds)
+    ) workflow.links;
+  describeInvalidNodeLink =
+    link:
+    "  リンク${toString (builtins.elemAt link 0)}: ノード${toString (builtins.elemAt link 1)} → ノード${toString (builtins.elemAt link 3)}";
 in
 {
-  config.assertions = lib.mapAttrsToList (name: workflow: {
-    assertion = overlap.overlappingNodePairs workflow.nodes == [ ];
-    message = ''
-      ComfyUIワークフロー${name}で以下のノードが重なっています(余白${toString overlap.margin}px未満を含む):
-      ${lib.concatMapStringsSep "\n" describe (overlap.overlappingNodePairs workflow.nodes)}
-    '';
-  }) config.local.comfyui.workflows;
+  config.assertions = lib.concatLists (
+    lib.mapAttrsToList (name: workflow: [
+      {
+        assertion = invalidNodeLinks workflow == [ ];
+        message = ''
+          ComfyUIワークフロー${name}で以下のリンクが存在しないノードを参照しています:
+          ${lib.concatMapStringsSep "\n" describeInvalidNodeLink (invalidNodeLinks workflow)}
+        '';
+      }
+      {
+        assertion = overlap.overlappingNodePairs workflow.nodes == [ ];
+        message = ''
+          ComfyUIワークフロー${name}で以下のノードが重なっています(余白${toString overlap.margin}px未満を含む):
+          ${lib.concatMapStringsSep "\n" describeOverlap (overlap.overlappingNodePairs workflow.nodes)}
+        '';
+      }
+    ]) config.local.comfyui.workflows
+  );
 }

--- a/pkgs/sageattention.nix
+++ b/pkgs/sageattention.nix
@@ -41,6 +41,11 @@ buildPythonPackage rec {
     ninja
   ];
 
+  # ninjaをnativeBuildInputsに追加すると、
+  # setup hookがPythonのpypaBuildPhaseをninjaBuildPhaseへ置き換え、
+  # build.ninjaがまだないソース直下でninjaを実行してしまう。
+  # この置換だけを防ぎ、
+  # pypaBuildPhase内のPyTorch BuildExtensionからninjaを使う。
   dontUseNinjaBuild = true;
 
   dependencies = [
@@ -60,6 +65,7 @@ buildPythonPackage rec {
 
   preBuild = ''
     export CPATH="${cudaPackages.cuda_cudart}/include:${cudaPackages.cuda_cccl}/include:${lib.getDev cudaPackages.libcublas}/include:${lib.getDev cudaPackages.libcusolver}/include:${lib.getDev cudaPackages.libcusparse}/include''${CPATH:+:$CPATH}"
+    export MAX_JOBS="$NIX_BUILD_CORES"
   '';
 
   pythonImportsCheck = [ "sageattention" ];

--- a/pkgs/sageattention.nix
+++ b/pkgs/sageattention.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  torch,
+  triton,
+  ninja,
+  stdenv,
+  cudaPackages ? torch.cudaPackages,
+  cudaCapabilities ? torch.cudaCapabilities,
+}:
+let
+  cudaNvcc = cudaPackages.cuda_nvcc;
+in
+buildPythonPackage rec {
+  pname = "sageattention";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "thu-ml";
+    repo = "SageAttention";
+    tag = "v${version}";
+    hash = "sha256-luHu7BkOLRg1LfwNvj3ieeaRSYHNYciMK56MCzkUQd4=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_cccl
+    cudaPackages.libcublas
+    cudaPackages.libcusolver
+    cudaPackages.libcusparse
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [
+    cudaNvcc
+    ninja
+  ];
+
+  dontUseNinjaBuild = true;
+
+  dependencies = [
+    torch
+    triton
+  ];
+
+  CUDA_HOME = cudaNvcc;
+  TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'setuptools>=62,<75' 'setuptools>=62' \
+      --replace-fail 'wheel>=0.38,<0.44' 'wheel>=0.38' \
+      --replace-fail 'packaging>=21,<24' 'packaging>=21'
+  '';
+
+  preBuild = ''
+    export CPATH="${cudaPackages.cuda_cudart}/include:${cudaPackages.cuda_cccl}/include:${lib.getDev cudaPackages.libcublas}/include:${lib.getDev cudaPackages.libcusolver}/include:${lib.getDev cudaPackages.libcusparse}/include''${CPATH:+:$CPATH}"
+  '';
+
+  pythonImportsCheck = [ "sageattention" ];
+
+  meta = {
+    description = "Accurate and efficient plug-and-play low-bit attention";
+    homepage = "https://github.com/thu-ml/SageAttention";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
ComfyUIの生成時間を短縮しつつ、
品質不良による再生成も減らして目的の出力を得るまでの総時間を改善します。

RTX 5090向けにSageAttention 2.2.0をsm_120専用でビルドし、
PyTorch SDPAから切り替えます。
SageAttentionが依存するTritonのCUDA toolchainをNixOS上で宣言的に構成し、
comfy-kitchenのTriton backendとFP16低精度累積も有効にします。

Wan 2.2 I2VはFP8 base modelと初代4-step LoRAの組み合わせから、
LightX2V公式の4-step distilled full BF16 modelへ切り替えます。
LoRAの低ランク近似や適用漏れを避け、
ghostingや入力忠実度低下による再生成を減らします。
4 stepsとCFG 1とshift 5のサンプリング設定は維持します。

短時間で完了するtext encoderは量子化効率より精度を優先します。
WanのUMT5-XXLをFP16へ変更し、
Qwen-Image-EditのQwen2.5-VLをBF16へ変更します。
これにより複雑な動作・カメラ指示・編集指示・入力画像理解の精度向上を狙います。

あわせて用途上の利点がないIllustrious公式base modelと、
商用範囲が曖昧な非商用ライセンスのNoobAIをモデル一覧から削除します。

bulletへ適用して以下を確認済みです。

- SageAttention 2.2.0のsm_120 CUDAカーネル生成とRTX 5090上での実行
- Triton backendとFP16 accumulationの有効化
- high/low distilled full modelのBF16 tensorとワークフロー接続
- UMT5-XXL FP16とQwen2.5-VL BF16の実ファイルdtype
- 全ワークフローのノード・リンク整合性とレイアウトassertion
- nix-fast-buildによる統合チェック