### PR TITLE
feat: Git LFSのロック機能をユーザグローバルでは無効化する

### DIFF
--- a/home/core/git.nix
+++ b/home/core/git.nix
@@ -51,6 +51,12 @@ in
           useHttpPath = false;
           username = "ncaq";
         };
+        # Git LFSのロック機能は基本的に使わないので、
+        # ユーザグローバルではpushのたびの検証と通知を無効化します。
+        lfs = {
+          "https://github.com/".locksverify = false;
+          "https://forgejo.ncaq.net/".locksverify = false;
+        };
       };
       ignores = [
         "**/.claude/scheduled_tasks.lock"


### PR DESCRIPTION
使わない機能が毎回広告されて鬱陶しいため。
リポジトリレベルではURLがもっと長くなるはずなので、
個別に有効化する邪魔はしない。
