### PR TITLE
fix: GTKのdesktop portalを有効化する

### DIFF
--- a/nixos/native-linux/desktop-portal.nix
+++ b/nixos/native-linux/desktop-portal.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  xdg.portal = {
+    enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    config.common.default = [ "gtk" ];
+  };
+}


### PR DESCRIPTION
XMonad環境ではdesktop portalが自動構成されないため、
Firefoxのファイル選択がGTK fallbackへ入りクラッシュしていました。
GTK backendを共通のportal実装として設定します。
