### PR TITLE
fix(seminar): sops生成後にコンテナを起動する

### DIFF
--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -117,6 +117,10 @@ in
   };
 
   systemd = {
+    services."container@garage" = {
+      requires = [ "sops-install-secrets.service" ];
+      after = [ "sops-install-secrets.service" ];
+    };
     tmpfiles.rules = [
       "d /var/lib/garage      0750 garage garage -"
       "d /var/lib/garage/meta 0750 garage garage -"

--- a/nixos/host/seminar/github-runner/github-runner-x64.nix
+++ b/nixos/host/seminar/github-runner/github-runner-x64.nix
@@ -178,6 +178,8 @@ in
         addr = addrOf name;
       in
       lib.nameValuePair "container@${name}" {
+        requires = [ "sops-install-secrets.service" ];
+        after = [ "sops-install-secrets.service" ];
         # NixOSコンテナモジュールが生成するpostStartは`ip addr add`/`ip route add`を使うため、
         # systemd-networkdが先に設定済みの場合にEEXISTエラーで失敗します。
         # 冪等にするために`2>/dev/null || true`を付けます。

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -112,11 +112,13 @@ in
         "caddy.service"
         "garage-setup-niks3-private.service"
         "postgresql-ready.service"
+        "sops-install-secrets.service"
       ];
       after = [
         "caddy.service"
         "garage-setup-niks3-private.service"
         "postgresql-ready.service"
+        "sops-install-secrets.service"
       ];
     };
     garage-setup-niks3-private = import ../../../lib/garage-setup.nix {

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -125,11 +125,13 @@ in
         "caddy.service"
         "garage-setup-niks3-public.service"
         "postgresql-ready.service"
+        "sops-install-secrets.service"
       ];
       after = [
         "caddy.service"
         "garage-setup-niks3-public.service"
         "postgresql-ready.service"
+        "sops-install-secrets.service"
       ];
     };
     garage-setup-niks3-public = import ../../../lib/garage-setup.nix {


### PR DESCRIPTION
シークレットをbind mountするコンテナに、
`sops-install-secrets.service`への順序依存と必須依存を追加します。

`RequiresMountsFor`では`/run`のmountしか待ちません。
sopsのレンダリング完了前にコンテナが起動して失敗していたためです。