### PR TITLE
fix(comfyui): 非推奨の画像バッチノードを置き換えます

### DIFF
--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -615,10 +615,9 @@ in
         ];
       })
       # 元動画のフレーム列の後ろへ新区間を連結する。
-      # ImageBatchはdeprecated扱いだがコアに連結の代替ノードがない。
       (mkNode {
         id = 26;
-        type = "ImageBatch";
+        type = "BatchImagesNode";
         title = "元動画と連結";
         pos = [
           2160
@@ -630,8 +629,8 @@ in
         ];
         order = 23;
         inputs = [
-          (mkInput "image1" "IMAGE" 13)
-          (mkInput "image2" "IMAGE" 32)
+          (mkInput "images.image0" "IMAGE" 13)
+          (mkInput "images.image1" "IMAGE" 32)
         ];
         outputs = [ (mkOutput "IMAGE" "IMAGE" [ 33 ]) ];
       })


### PR DESCRIPTION
`ImageBatch`が非推奨になったため、
公式後継の`BatchImagesNode`へ変更します。
Autogrow形式に合わせて画像入力名も更新します。
