### PR TITLE
feat: systemdサービスとコンテナの隔離を強化します

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,8 @@
 
       # ディレクトリ内の全`.nix`ファイルをimportするヘルパー関数。
       importDirModules = import ./lib/import-dir-modules.nix { inherit lib; };
+      # systemdサービス共通のハードニング設定。
+      hardening = import ./lib/systemd-hardening.nix;
       # nixpkgsの共通設定。
       nixpkgsConfig = import ./lib/nixpkgs-config.nix { inherit lib; };
       # 全環境で共通のoverlays。
@@ -193,6 +195,7 @@
           importPkgsStable
           importPkgsUnstable
           importDirModules
+          hardening
           inputs
           ;
       };

--- a/lib/garage-setup.nix
+++ b/lib/garage-setup.nix
@@ -11,44 +11,25 @@
   config,
   name,
 }:
+let
+  hardening = import ./systemd-hardening.nix;
+in
 {
   description = "Setup Garage bucket and key for ${name}";
   requires = [ "container@garage.service" ];
   after = [ "container@garage.service" ];
   wantedBy = [ "multi-user.target" ];
-  serviceConfig = {
+  serviceConfig = hardening.network // {
     Type = "oneshot";
     RemainAfterExit = true;
     RuntimeDirectory = "garage-setup/${name}";
     RuntimeDirectoryMode = "0700";
-    # Hardening
+    # 生成したキーファイルをクライアントユーザへchownするために必要なcapabilityだけ許可する。
     CapabilityBoundingSet = [
       "CAP_CHOWN"
       "CAP_DAC_READ_SEARCH"
       "CAP_FOWNER"
     ];
-    LockPersonality = true;
-    MemoryDenyWriteExecute = true;
-    NoNewPrivileges = true;
-    PrivateDevices = true;
-    PrivateTmp = true;
-    ProtectClock = true;
-    ProtectControlGroups = true;
-    ProtectHome = true;
-    ProtectHostname = true;
-    ProtectKernelLogs = true;
-    ProtectKernelModules = true;
-    ProtectKernelTunables = true;
-    ProtectSystem = "strict";
-    RestrictAddressFamilies = [
-      "AF_INET"
-      "AF_INET6"
-      "AF_UNIX"
-    ];
-    RestrictNamespaces = true;
-    RestrictRealtime = true;
-    RestrictSUIDSGID = true;
-    SystemCallArchitectures = "native";
     SystemCallFilter = [
       "@system-service"
       "~@privileged"

--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -3,6 +3,7 @@
   importPkgsStable,
   importPkgsUnstable,
   importDirModules,
+  hardening,
   inputs,
 }:
 {
@@ -13,6 +14,7 @@ let
   specialArgs = {
     inherit
       importDirModules
+      hardening
       inputs
 
       hostName

--- a/lib/seminar-cifs.nix
+++ b/lib/seminar-cifs.nix
@@ -6,23 +6,8 @@
   片方だけ更新される事故を防ぐ。
 */
 { pkgs }:
-{
-  # マウントの見せ方(uid/dir_modeなど)に依存しない基本のマウントオプション。
-  baseMountOptions = credentialsPath: [
-    # 認証
-    "credentials=${credentialsPath}"
-    # セキュリティ
-    "nodev"
-    "noexec"
-    "nosuid"
-    # パフォーマンス
-    "noatime"
-    # SMBダイアレクトを明示的に指定。
-    # 未指定だとkernelが`No dialect specified on mount`の警告を出す。
-    # `vers=3`はSMB3.0以上を意味し、ネゴシエーションで3.x系の最新版が選択される。
-    # SMB1/SMB2系を排除しつつ、将来のマイナーバージョン更新にも自動追従する。
-    "vers=3"
-  ];
+let
+  hardening = import ./systemd-hardening.nix;
   # seminarのSMBポートへ実際にTCP接続できるまで待つスクリプト。
   # `network-online.target`や`tailscale-online.service`はどちらも
   # 「seminarに到達できる」ことまでは保証しないため、
@@ -39,4 +24,67 @@
       done
     '';
   };
+in
+{
+  inherit waitForSeminar;
+  # マウントの見せ方(uid/dir_modeなど)に依存しない基本のマウントオプション。
+  baseMountOptions = credentialsPath: [
+    # 認証
+    "credentials=${credentialsPath}"
+    # セキュリティ
+    "nodev"
+    "noexec"
+    "nosuid"
+    # パフォーマンス
+    "noatime"
+    # SMBダイアレクトを明示的に指定。
+    # 未指定だとkernelが`No dialect specified on mount`の警告を出す。
+    # `vers=3`はSMB3.0以上を意味し、ネゴシエーションで3.x系の最新版が選択される。
+    # SMB1/SMB2系を排除しつつ、将来のマイナーバージョン更新にも自動追従する。
+    "vers=3"
+  ];
+  # マウント失敗時にOnFailureから起動するリトライサービスを生成する。
+  # seminarへの到達性が回復するまで待ってから対象のmountユニットを再起動する。
+  # `name`はスクリプトのderivation名に使うので英数字とハイフンだけにする
+  # (mountユニット名はパスのエスケープでバックスラッシュを含むことがあるため分ける)。
+  mkRetryService =
+    {
+      name,
+      description,
+      mountUnit,
+    }:
+    {
+      inherit description;
+      unitConfig = {
+        # mount側のStartLimitだけに停止保証を頼らない。
+        # mountがstart-limit-hitで拒否された場合にOnFailureが再発火するかは、
+        # systemdのバージョンで挙動が異なるため(systemd/systemd#33710)、
+        # 再発火する環境でもこのサービス自身の起動制限でループを確実に打ち切る。
+        StartLimitIntervalSec = 600;
+        StartLimitBurst = 5;
+      };
+      # 到達性確認のTCP接続(AF_INET/AF_INET6)と、
+      # systemctlのプライベートソケット(AF_UNIX)だけあれば動く。
+      # 書き込み先はないのでProtectSystem=strictのままで良い。
+      serviceConfig = hardening.network // {
+        Type = "oneshot";
+        TimeoutStartSec = 600;
+        ExecStart = pkgs.lib.getExe (
+          pkgs.writeShellApplication {
+            name = "retry-${name}";
+            runtimeInputs = with pkgs; [
+              coreutils
+              systemd
+              waitForSeminar
+            ];
+            # 失敗直後の即時再試行は同じ理由で失敗しやすいので少し置く。
+            text = ''
+              sleep 10
+              wait-for-seminar
+              systemctl restart "${mountUnit}"
+            '';
+          }
+        );
+      };
+    };
 }

--- a/lib/seminar-cifs.nix
+++ b/lib/seminar-cifs.nix
@@ -1,0 +1,42 @@
+/**
+  seminarのchihiro共有をCIFSマウントするための共通定義。
+
+  `nixos/native-linux/cifs.nix`(/mnt/chihiroの常用マウント)と、
+  `nixos/host/bullet/comfyui/dir.nix`(ComfyUIコンテナ専用マウント)で共用して、
+  片方だけ更新される事故を防ぐ。
+*/
+{ pkgs }:
+{
+  # マウントの見せ方(uid/dir_modeなど)に依存しない基本のマウントオプション。
+  baseMountOptions = credentialsPath: [
+    # 認証
+    "credentials=${credentialsPath}"
+    # セキュリティ
+    "nodev"
+    "noexec"
+    "nosuid"
+    # パフォーマンス
+    "noatime"
+    # SMBダイアレクトを明示的に指定。
+    # 未指定だとkernelが`No dialect specified on mount`の警告を出す。
+    # `vers=3`はSMB3.0以上を意味し、ネゴシエーションで3.x系の最新版が選択される。
+    # SMB1/SMB2系を排除しつつ、将来のマイナーバージョン更新にも自動追従する。
+    "vers=3"
+  ];
+  # seminarのSMBポートへ実際にTCP接続できるまで待つスクリプト。
+  # `network-online.target`や`tailscale-online.service`はどちらも
+  # 「seminarに到達できる」ことまでは保証しないため、
+  # マウント前に実到達性を確認する必要がある。
+  waitForSeminar = pkgs.writeShellApplication {
+    name = "wait-for-seminar";
+    runtimeInputs = with pkgs; [
+      bash
+      coreutils
+    ];
+    text = ''
+      until timeout 5 bash -c ': < /dev/tcp/seminar/445'; do
+        sleep 2
+      done
+    '';
+  };
+}

--- a/lib/systemd-hardening.nix
+++ b/lib/systemd-hardening.nix
@@ -1,0 +1,68 @@
+/**
+  systemdサービスへ共通で適用するハードニング設定。
+
+  各サービスの`serviceConfig`へ`//`で先頭側にマージして、
+  サービス固有の設定と差分だけを上書き側に書く。
+
+  ```nix
+  serviceConfig = hardening.network // {
+    ExecStart = "...";
+    ReadWritePaths = [ "/var/lib/foo" ];
+  };
+  ```
+
+  設定を外す必要がある場合は`builtins.removeAttrs`で属性ごと外し、
+  理由をコメントに残す。
+
+  NixOSモジュールへは`flake.nix`の`specialArgs`経由で、
+  `hardening`として配布される。
+*/
+let
+  base = {
+    # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+    # 空文字列でbounding setを空集合にリセットする。
+    # capabilityが必要なサービスは必要なものだけのリストで上書きする。
+    CapabilityBoundingSet = "";
+    LockPersonality = true;
+    MemoryDenyWriteExecute = true;
+    NoNewPrivileges = true;
+    PrivateDevices = true;
+    PrivateTmp = true;
+    ProtectClock = true;
+    ProtectControlGroups = true;
+    ProtectHome = true;
+    ProtectHostname = true;
+    ProtectKernelLogs = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectSystem = "strict";
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [ "@system-service" ];
+  };
+in
+{
+  # ソケットを一切使わないサービス向け。
+  # あらゆるアドレスファミリを禁止して、
+  # ネットワーク名前空間ごと隔離する。
+  isolated = base // {
+    PrivateNetwork = true;
+    RestrictAddressFamilies = "none";
+  };
+  # UNIXソケットだけで通信するサービス向け。
+  # ネットワーク名前空間ごと隔離する。
+  unixSocket = base // {
+    PrivateNetwork = true;
+    RestrictAddressFamilies = [ "AF_UNIX" ];
+  };
+  # ネットワーク通信を行うサービス向け。
+  network = base // {
+    RestrictAddressFamilies = [
+      "AF_INET"
+      "AF_INET6"
+      "AF_UNIX"
+    ];
+  };
+}

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -22,6 +22,7 @@
 {
   pkgs,
   username,
+  hardening,
   ...
 }:
 let
@@ -134,7 +135,10 @@ in
         umask 077
         ${pkgs.gnupg}/bin/gpg --batch --no-autostart --quiet --import ${keyConfig.publicKeyFile}
       '';
-      serviceConfig = {
+      # 秘密鍵を扱うプロセスなので、
+      # 不要な場所を見せず不要な特権と通信経路を断ちます。
+      # gpg-agentのソケットはUNIXドメインのみでネットワーク通信は不要です。
+      serviceConfig = hardening.unixSocket // {
         User = "gpg-vault";
         Group = "gpg-vault";
         # gpg-agentはソケットを作り終えてからforkするため、
@@ -153,25 +157,6 @@ in
         RuntimeDirectoryMode = "0750";
         StateDirectory = "gpg-vault";
         StateDirectoryMode = "0700";
-        # ハードニング。
-        # 秘密鍵を扱うプロセスなので、
-        # 不要な場所を見せず不要な特権と通信経路を断ちます。
-        # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-        # 空文字列でbounding setを空集合にリセットする。
-        CapabilityBoundingSet = "";
-        LockPersonality = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectSystem = "strict";
-        # gpg-agentのソケットはUNIXドメインのみでネットワーク通信は不要です。
-        RestrictAddressFamilies = [ "AF_UNIX" ];
-        RestrictNamespaces = true;
-        SystemCallFilter = [ "@system-service" ];
       };
     };
 

--- a/nixos/core/gpg-vault.nix
+++ b/nixos/core/gpg-vault.nix
@@ -156,7 +156,9 @@ in
         # ハードニング。
         # 秘密鍵を扱うプロセスなので、
         # 不要な場所を見せず不要な特権と通信経路を断ちます。
-        CapabilityBoundingSet = [ ];
+        # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+        # 空文字列でbounding setを空集合にリセットする。
+        CapabilityBoundingSet = "";
         LockPersonality = true;
         NoNewPrivileges = true;
         PrivateDevices = true;

--- a/nixos/core/tailscale.nix
+++ b/nixos/core/tailscale.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  hardening,
   ...
 }:
 {
@@ -19,38 +20,11 @@
       "network-online.target"
       "tailscaled.service"
     ];
-    serviceConfig = {
+    # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続するだけなので、
+    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
+    serviceConfig = hardening.network // {
       Type = "oneshot";
       RemainAfterExit = true;
-      # Hardening
-      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続するだけなので、
-      # capabilityも書き込み可能なファイルシステムも不要。
-      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-      # 空文字列でbounding setを空集合にリセットする。
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      MemoryDenyWriteExecute = true;
-      NoNewPrivileges = true;
-      PrivateDevices = true;
-      PrivateTmp = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHome = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      ProtectSystem = "strict";
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
-      RestrictNamespaces = true;
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-      SystemCallFilter = [ "@system-service" ];
       ExecStart = lib.getExe (
         pkgs.writeShellApplication {
           name = "wait-for-tailscale";

--- a/nixos/core/tailscale.nix
+++ b/nixos/core/tailscale.nix
@@ -21,8 +21,10 @@
       "tailscaled.service"
     ];
     # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続するだけなので、
-    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
-    serviceConfig = hardening.network // {
+    # UNIXソケットのみ許可のハードニングまで絞れる。
+    # seminar上で同等のサンドボックスを再現して`tailscale status --json`が
+    # 動作することを確認済み。
+    serviceConfig = hardening.unixSocket // {
       Type = "oneshot";
       RemainAfterExit = true;
       ExecStart = lib.getExe (

--- a/nixos/core/tailscale.nix
+++ b/nixos/core/tailscale.nix
@@ -22,6 +22,35 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
+      # Hardening
+      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続するだけなので、
+      # capabilityも書き込み可能なファイルシステムも不要。
+      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+      # 空文字列でbounding setを空集合にリセットする。
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
       ExecStart = lib.getExe (
         pkgs.writeShellApplication {
           name = "wait-for-tailscale";

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -16,6 +16,8 @@ let
   # コンテナ内のcomfyuiユーザのID。
   # ephemeralコンテナでは動的割り当ての記録が起動ごとに消えるため、
   # bind mountした`/var/lib/comfyui`の所有権がずれないように固定する。
+  # idmap付きbind mountは数値IDをホストとコンテナで同一視するため、
+  # `privateUsers = "pick"`でもこの固定が引き続き必要。
   # nixpkgsが静的IDに予約している400未満と、
   # 動的割り当てが使う999からの降順領域を避けた任意の値。
   comfyuiUid = 500;
@@ -48,13 +50,18 @@ in
     autoStart = false;
     ephemeral = true;
     privateNetwork = true;
-    privateUsers = "identity";
+    # 毎起動ランダムな高位UID範囲へマップして、
+    # コンテナを脱出されてもホスト上では無権限のUIDになるようにする。
+    # identityと違いコンテナ内rootがホストのUID 0を持たなくなる。
+    privateUsers = "pick";
     inherit hostAddress localAddress;
     # CUDAを使うためにNVIDIAデバイスをコンテナへ渡す。
     allowedDevices = map (node: {
       inherit node;
       modifier = "rw";
     }) nvidiaDevices;
+    # NVIDIAデバイスノードは0666、ドライバライブラリはworld-readableなので、
+    # UIDがマップされないpickでもotherパーミッションでアクセスできる。
     bindMounts =
       lib.genAttrs nvidiaDevices (device: {
         hostPath = device;
@@ -67,12 +74,12 @@ in
           hostPath = "/run/opengl-driver";
           isReadOnly = true;
         };
-        # モデルやカスタムノードなどのデータはホスト側に永続化する。
-        ${dataDir} = {
-          hostPath = dataDir;
-          isReadOnly = false;
-        };
       };
+    # モデルやカスタムノードなどのデータはホスト側に永続化する。
+    # pickでは素のbind mountだと所有者が無効なUIDに見えて書き込めないため、
+    # idmapオプションで数値IDをホストとコンテナで同一視させる。
+    # `bindMounts`はマウントオプションを渡せないのでextraFlagsで指定する。
+    extraFlags = [ "--bind=${dataDir}:${dataDir}:idmap" ];
     config =
       {
         lib,

--- a/nixos/host/bullet/comfyui/dir.nix
+++ b/nixos/host/bullet/comfyui/dir.nix
@@ -21,7 +21,13 @@
 # ホスト側のセキュリティは緩まない。
 # サーバ側の認証と所有権はマウント資格情報(ncaq)で決まるので、
 # どのUIDで書いてもseminar上ではncaqのファイルになる。
-{ lib, config, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  utils,
+  ...
+}:
 let
   # コンテナ内から見える出力ディレクトリ。
   # ncaqがseminar上で見るパスと揃えて分かりやすくする。
@@ -30,6 +36,11 @@ let
   # 親ディレクトリを0700にしてホストの一般ユーザから隠す。
   hostMountParent = "/run/comfyui-cifs";
   hostMountPoint = "${hostMountParent}/output";
+  mountUnit = "${utils.escapeSystemdPath hostMountPoint}.mount";
+  inherit (import ../../../../lib/seminar-cifs.nix { inherit pkgs; })
+    baseMountOptions
+    waitForSeminar
+    ;
 in
 {
   containers.comfyui = {
@@ -59,40 +70,86 @@ in
           "seminar-online.service"
           "sops-install-secrets.service"
         ];
-        # wantedByは設定しない。
-        # `container@comfyui`のRequiresMountsForが必要時にpullする。
-        # コンテナが停止して誰も必要としなくなったら自動でアンマウントする。
-        unitConfig.StopWhenUnneeded = true;
+        unitConfig = {
+          # wantedByは設定しない。
+          # `container@comfyui`のRequiresMountsForが必要時にpullする。
+          # コンテナが停止して誰も必要としなくなったら自動でアンマウントする。
+          StopWhenUnneeded = true;
+          # `nofail`は意図的に付けない。
+          # wantedByを持たずブート時に引き込まれないため、
+          # remote-fs.target経由でブートをブロックする経路がそもそもなく、
+          # 失敗はコンテナの起動失敗として顕在化させて気付けるようにしたい。
+          # マウント失敗時はリトライ用サービスに委ねる。
+          # mountユニット自体はRestart=を持てないため、
+          # 到達性を待ってから再マウントする別サービスで補う。
+          OnFailure = [ "comfyui-cifs-retry.service" ];
+          # リトライが恒久的な失敗(認証エラーなど)で無限ループしないよう起動回数を制限する。
+          StartLimitIntervalSec = 600;
+          StartLimitBurst = 5;
+        };
         what = "//seminar/chihiro/comfyui-output";
         where = hostMountPoint;
         type = "cifs";
-        options = lib.concatStringsSep "," [
-          # 認証。`nixos/native-linux/cifs.nix`と同じ資格情報を使う。
-          "credentials=${config.sops.templates."cifs-credentials".path}"
-          # コンテナのUIDはpickで毎起動変わるため、
-          # 誰でも書けるモードにしてUID非依存で書き込めるようにする。
-          # このマウントは0700の親ディレクトリで隠されているので、
-          # ホストの一般ユーザからはアクセスできない。
-          "dir_mode=0777"
-          "file_mode=0666"
-          # セキュリティ
-          "nodev"
-          "noexec"
-          "nosuid"
-          # パフォーマンス
-          "noatime"
-          # SMBダイアレクトはcifs.nixと同じ理由でSMB3.0以上を明示する。
-          "vers=3"
-        ];
+        # 認証・セキュリティ・ダイアレクトの共通部分は`lib/seminar-cifs.nix`で管理する。
+        # 資格情報は`nixos/native-linux/cifs.nix`と同じものを使う。
+        options = lib.concatStringsSep "," (
+          baseMountOptions config.sops.templates."cifs-credentials".path
+          ++ [
+            # コンテナのUIDはpickで毎起動変わるため、
+            # 誰でも書けるモードにしてUID非依存で書き込めるようにする。
+            # このマウントは0700の親ディレクトリで隠されているので、
+            # ホストの一般ユーザからはアクセスできない。
+            "dir_mode=0777"
+            "file_mode=0666"
+          ]
+        );
         mountConfig = {
           TimeoutSec = 30;
         };
       }
     ];
-    # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
-    # 明示的に指定してコンテナ起動時にCIFSマウントを引き込む。
-    # マウント失敗時はコンテナも起動しない。
-    services."container@comfyui".unitConfig.RequiresMountsFor = [ hostMountPoint ];
+    services = {
+      # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
+      # 明示的に指定してコンテナ起動時にCIFSマウントを引き込む。
+      # マウント失敗時はコンテナも起動しない。
+      "container@comfyui".unitConfig.RequiresMountsFor = [ hostMountPoint ];
+      # マウント失敗時にOnFailureから起動されるリトライサービス。
+      # seminarへの到達性が回復するまで待ってから再マウントする。
+      # 再マウント直後に誰も必要としていなければStopWhenUnneededですぐ外れるが、
+      # 到達性の回復を待つ経路を作ることで、
+      # seminarの一時的なダウン後に自動復旧できるようにする。
+      comfyui-cifs-retry = {
+        description = "Retry mounting ComfyUI CIFS output after failure";
+        unitConfig = {
+          # mount側のStartLimitだけに停止保証を頼らない。
+          # mountがstart-limit-hitで拒否された場合にOnFailureが再発火するかは、
+          # systemdのバージョンで挙動が異なるため(systemd/systemd#33710)、
+          # 再発火する環境でもこのサービス自身の起動制限でループを確実に打ち切る。
+          StartLimitIntervalSec = 600;
+          StartLimitBurst = 5;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          TimeoutStartSec = 600;
+          ExecStart = lib.getExe (
+            pkgs.writeShellApplication {
+              name = "retry-comfyui-cifs";
+              runtimeInputs = with pkgs; [
+                coreutils
+                systemd
+                waitForSeminar
+              ];
+              # 失敗直後の即時再試行は同じ理由で失敗しやすいので少し置く。
+              text = ''
+                sleep 10
+                wait-for-seminar
+                systemctl restart "${mountUnit}"
+              '';
+            }
+          );
+        };
+      };
+    };
     tmpfiles.rules = [
       "d ${hostMountParent} 0700 root root - -"
       "d ${hostMountPoint} 0700 root root - -"

--- a/nixos/host/bullet/comfyui/dir.nix
+++ b/nixos/host/bullet/comfyui/dir.nix
@@ -1,29 +1,39 @@
 # ComfyUIの出力画像をseminarのchihiro共有へ直接保存するための設定。
 #
 # コンテナはファイルシステム隔離されているので、
-# ホストの`/mnt/chihiro`をbind mountで見せた上で、
+# CIFSマウントをbind mountで見せた上で、
 # ComfyUIの`--output-directory`で出力先を切り替える。
 #
-# `/mnt/chihiro`のCIFSマウントはuid=1000(ncaq),gid=100(users)の見せ方なので、
-# コンテナ内のcomfyui(uid=500)はグループ経由で書き込む。
-# グループ書き込みを許可する`dir_mode=0775,file_mode=0664`は、
-# `nixos/native-linux/cifs.nix`のマウントオプション側で設定している。
-_:
+# `/mnt/chihiro`本体のマウントはuid=1000(ncaq),gid=100(users)の見せ方だが、
+# `privateUsers = "pick"`のコンテナからはUIDがマップされず書き込めない。
+# CIFSはidmapped mountに対応していないため(kernel 6.18時点でEINVAL)、
+# idmapオプションのbind mountによる解決もできない。
+# そこでコンテナ専用に同じ共有のcomfyui-outputサブディレクトリを、
+# 誰でも書けるモードで別マウントする。
+#
+# コンテナ内部でのマウント定義にはできない。
+# カーネルはcifsに`FS_USERNS_MOUNT`フラグを付けていないため、
+# ユーザ名前空間内からのcifsマウントはEPERMで拒否される(実機確認済み)。
+# 代わりにマウントユニットをコンテナのライフサイクルに連動させる:
+# `RequiresMountsFor`でコンテナ起動時にだけマウントされ、
+# `StopWhenUnneeded`でコンテナ停止時に自動でアンマウントされる。
+# 0700のrootディレクトリ配下に置いてホストの一般ユーザからは隠すため、
+# ホスト側のセキュリティは緩まない。
+# サーバ側の認証と所有権はマウント資格情報(ncaq)で決まるので、
+# どのUIDで書いてもseminar上ではncaqのファイルになる。
+{ lib, config, ... }:
 let
+  # コンテナ内から見える出力ディレクトリ。
+  # ncaqがseminar上で見るパスと揃えて分かりやすくする。
   outputDir = "/mnt/chihiro/comfyui-output";
+  # コンテナ専用CIFSマウントのホスト側パス。
+  # 親ディレクトリを0700にしてホストの一般ユーザから隠す。
+  hostMountParent = "/run/comfyui-cifs";
+  hostMountPoint = "${hostMountParent}/output";
 in
 {
   containers.comfyui = {
-    # NixOSコンテナモジュールがhostPathに`RequiresMountsFor`を自動付与するため、
-    # コンテナ起動時に`mnt-chihiro.mount`が引き込まれ、
-    # マウント失敗時はコンテナも起動しない。
-    bindMounts.${outputDir} = {
-      hostPath = outputDir;
-      isReadOnly = false;
-    };
     config = {
-      # CIFSマウントのgid=100(users)でグループ書き込みするために所属させる。
-      users.users.comfyui.extraGroups = [ "users" ];
       services.comfyui.extraArgs = [
         "--output-directory"
         outputDir
@@ -32,5 +42,60 @@ in
       # `ReadWritePaths`にdataDirしか含めないため出力先を追加する。
       systemd.services.comfyui.serviceConfig.ReadWritePaths = [ outputDir ];
     };
+    # 誰でも書けるモードのマウントなのでidmapは不要。
+    extraFlags = [ "--bind=${hostMountPoint}:${outputDir}" ];
+  };
+  systemd = {
+    mounts = [
+      {
+        # 資格情報が展開されてからマウントする。
+        # コンテナはソケットアクティベーションでブート後に起動するため、
+        # 通常はどちらも満たされている。
+        wants = [
+          "seminar-online.service"
+          "sops-install-secrets.service"
+        ];
+        after = [
+          "seminar-online.service"
+          "sops-install-secrets.service"
+        ];
+        # wantedByは設定しない。
+        # `container@comfyui`のRequiresMountsForが必要時にpullする。
+        # コンテナが停止して誰も必要としなくなったら自動でアンマウントする。
+        unitConfig.StopWhenUnneeded = true;
+        what = "//seminar/chihiro/comfyui-output";
+        where = hostMountPoint;
+        type = "cifs";
+        options = lib.concatStringsSep "," [
+          # 認証。`nixos/native-linux/cifs.nix`と同じ資格情報を使う。
+          "credentials=${config.sops.templates."cifs-credentials".path}"
+          # コンテナのUIDはpickで毎起動変わるため、
+          # 誰でも書けるモードにしてUID非依存で書き込めるようにする。
+          # このマウントは0700の親ディレクトリで隠されているので、
+          # ホストの一般ユーザからはアクセスできない。
+          "dir_mode=0777"
+          "file_mode=0666"
+          # セキュリティ
+          "nodev"
+          "noexec"
+          "nosuid"
+          # パフォーマンス
+          "noatime"
+          # SMBダイアレクトはcifs.nixと同じ理由でSMB3.0以上を明示する。
+          "vers=3"
+        ];
+        mountConfig = {
+          TimeoutSec = 30;
+        };
+      }
+    ];
+    # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
+    # 明示的に指定してコンテナ起動時にCIFSマウントを引き込む。
+    # マウント失敗時はコンテナも起動しない。
+    services."container@comfyui".unitConfig.RequiresMountsFor = [ hostMountPoint ];
+    tmpfiles.rules = [
+      "d ${hostMountParent} 0700 root root - -"
+      "d ${hostMountPoint} 0700 root root - -"
+    ];
   };
 }

--- a/nixos/host/bullet/comfyui/dir.nix
+++ b/nixos/host/bullet/comfyui/dir.nix
@@ -39,7 +39,7 @@ let
   mountUnit = "${utils.escapeSystemdPath hostMountPoint}.mount";
   inherit (import ../../../../lib/seminar-cifs.nix { inherit pkgs; })
     baseMountOptions
-    waitForSeminar
+    mkRetryService
     ;
 in
 {
@@ -118,36 +118,10 @@ in
       # 再マウント直後に誰も必要としていなければStopWhenUnneededですぐ外れるが、
       # 到達性の回復を待つ経路を作ることで、
       # seminarの一時的なダウン後に自動復旧できるようにする。
-      comfyui-cifs-retry = {
+      comfyui-cifs-retry = mkRetryService {
+        name = "comfyui-cifs";
         description = "Retry mounting ComfyUI CIFS output after failure";
-        unitConfig = {
-          # mount側のStartLimitだけに停止保証を頼らない。
-          # mountがstart-limit-hitで拒否された場合にOnFailureが再発火するかは、
-          # systemdのバージョンで挙動が異なるため(systemd/systemd#33710)、
-          # 再発火する環境でもこのサービス自身の起動制限でループを確実に打ち切る。
-          StartLimitIntervalSec = 600;
-          StartLimitBurst = 5;
-        };
-        serviceConfig = {
-          Type = "oneshot";
-          TimeoutStartSec = 600;
-          ExecStart = lib.getExe (
-            pkgs.writeShellApplication {
-              name = "retry-comfyui-cifs";
-              runtimeInputs = with pkgs; [
-                coreutils
-                systemd
-                waitForSeminar
-              ];
-              # 失敗直後の即時再試行は同じ理由で失敗しやすいので少し置く。
-              text = ''
-                sleep 10
-                wait-for-seminar
-                systemctl restart "${mountUnit}"
-              '';
-            }
-          );
-        };
+        inherit mountUnit;
       };
     };
     tmpfiles.rules = [

--- a/nixos/host/bullet/comfyui/socket-activation.nix
+++ b/nixos/host/bullet/comfyui/socket-activation.nix
@@ -26,7 +26,35 @@ in
           # `lib.getExe'`は使えない。
           ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${localAddress}:${toString port}";
           DynamicUser = true;
+          # Hardening
+          # 受け取ったソケットとコンテナへのTCP接続を仲介するだけなので、
+          # capabilityもファイルシステムへのアクセスも不要。
+          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+          # 空文字列でbounding setを空集合にリセットする。
+          CapabilityBoundingSet = "";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
           PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" ];
         };
       };
       "container@comfyui" = {

--- a/nixos/host/bullet/comfyui/socket-activation.nix
+++ b/nixos/host/bullet/comfyui/socket-activation.nix
@@ -8,6 +8,7 @@
   lib,
   pkgs,
   config,
+  hardening,
   ...
 }:
 let
@@ -21,40 +22,13 @@ in
         description = "systemd-socket-proxyd for on-demand ComfyUI activation";
         requires = [ "container@comfyui.service" ];
         after = [ "container@comfyui.service" ];
-        serviceConfig = {
+        # 受け取ったソケットとコンテナへのTCP接続を仲介するだけなので、
+        # capabilityもファイルシステムへのアクセスも不要でハードニングをそのまま適用できる。
+        serviceConfig = hardening.network // {
           # systemd-socket-proxydは`bin/`ではなく`lib/systemd/`に配置されるため、
           # `lib.getExe'`は使えない。
           ExecStart = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd ${localAddress}:${toString port}";
           DynamicUser = true;
-          # Hardening
-          # 受け取ったソケットとコンテナへのTCP接続を仲介するだけなので、
-          # capabilityもファイルシステムへのアクセスも不要。
-          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-          # 空文字列でbounding setを空集合にリセットする。
-          CapabilityBoundingSet = "";
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          NoNewPrivileges = true;
-          PrivateDevices = true;
-          PrivateTmp = true;
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectHome = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          ProtectSystem = "strict";
-          RestrictAddressFamilies = [
-            "AF_INET"
-            "AF_INET6"
-            "AF_UNIX"
-          ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [ "@system-service" ];
         };
       };
       "container@comfyui" = {

--- a/nixos/host/bullet/comfyui/tailscale-serve.nix
+++ b/nixos/host/bullet/comfyui/tailscale-serve.nix
@@ -40,6 +40,36 @@ in
       # 終了コードによらず常に再起動して復帰させる。
       Restart = "always";
       RestartSec = "10s";
+      # Hardening
+      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
+      # 実際のプロキシ転送はtailscaled側が行うため、
+      # capabilityも書き込み可能なファイルシステムも不要。
+      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+      # 空文字列でbounding setを空集合にリセットする。
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
     };
   };
 }

--- a/nixos/host/bullet/comfyui/tailscale-serve.nix
+++ b/nixos/host/bullet/comfyui/tailscale-serve.nix
@@ -36,8 +36,10 @@ in
     wantedBy = [ "multi-user.target" ];
     # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
     # 実際のプロキシ転送はtailscaled側が行うため、
-    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
-    serviceConfig = hardening.network // {
+    # UNIXソケットのみ許可のハードニングまで絞れる。
+    # seminar上で同等のサンドボックスを再現して、
+    # フォアグラウンドのserveセッションが登録・維持できることを確認済み。
+    serviceConfig = hardening.unixSocket // {
       ExecStart = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfyui http://127.0.0.1:${toString port}";
       # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
       # 終了コードによらず常に再起動して復帰させる。

--- a/nixos/host/bullet/comfyui/tailscale-serve.nix
+++ b/nixos/host/bullet/comfyui/tailscale-serve.nix
@@ -13,7 +13,7 @@
 # Serve設定のライフサイクルがユニットのライフサイクルと完全に一致する。
 # `--bg`と違いoffによる明示的な登録解除も、
 # モジュール削除後にtailscaledへ設定が残留する心配も不要になる。
-{ config, ... }:
+{ config, hardening, ... }:
 let
   tailscale = config.services.tailscale.package;
   port = config.containers.comfyui.config.services.comfyui.port;
@@ -34,42 +34,15 @@ in
       "tailscaled.service"
     ];
     wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
+    # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
+    # 実際のプロキシ転送はtailscaled側が行うため、
+    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
+    serviceConfig = hardening.network // {
       ExecStart = "${tailscale}/bin/tailscale serve --https=443 --set-path=/comfyui http://127.0.0.1:${toString port}";
       # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
       # 終了コードによらず常に再起動して復帰させる。
       Restart = "always";
       RestartSec = "10s";
-      # Hardening
-      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
-      # 実際のプロキシ転送はtailscaled側が行うため、
-      # capabilityも書き込み可能なファイルシステムも不要。
-      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-      # 空文字列でbounding setを空集合にリセットする。
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      MemoryDenyWriteExecute = true;
-      NoNewPrivileges = true;
-      PrivateDevices = true;
-      PrivateTmp = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHome = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      ProtectSystem = "strict";
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
-      RestrictNamespaces = true;
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-      SystemCallFilter = [ "@system-service" ];
     };
   };
 }

--- a/nixos/host/seminar/forgejo.nix
+++ b/nixos/host/seminar/forgejo.nix
@@ -29,6 +29,8 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    # PostgreSQLのpeer認証がホストと同一のUIDでの接続を要求するため、
+    # pickにはできずidentity(UID分離なし、capability分離のみ)のまま。
     privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -135,8 +135,12 @@ in
       # idmap対応のtmpfs(/run)に置き直してからコンテナへbind mountする。
       # コンテナ内ではPID 1(コンテナroot)がEnvironmentFileとして読むので、
       # idmapで同一視されるroot:rootの0400で置く。
-      # 独立したユニットにするとRuntimeDirectoryの寿命やrestartの伝播が
-      # コンテナと噛み合わなくなるため、コンテナ自身の起動処理に含める。
+      # 複製を独立したユニットで行うと以下の問題があるため、
+      # コンテナ自身の起動処理に含めて寿命を一致させる。
+      # - 独立ユニットの再起動でRuntimeDirectoryの/run/garageが作り直されると、
+      #   bind mount済みのコンテナは削除済みの古いinodeを掴んだままになり、
+      #   以後コンテナ内で環境ファイルが読めなくなる
+      # - requires/afterだけでは独立ユニットのrestartがコンテナへ伝播しない
       serviceConfig.ExecStartPre = [
         "${pkgs.coreutils}/bin/install -d -m 0700 ${envDir}"
         "${pkgs.coreutils}/bin/install -m 0400 ${config.sops.templates."garage-env".path} ${envFile}"

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -14,7 +14,7 @@ let
   };
   # コンテナ内へbind mountされる環境ファイルのパス。
   # sops-nixの展開先はramfsでidmapped mountに対応していないため、
-  # garage-env.serviceがtmpfsである/runへ複製したものをbind mountする。
+  # container@garageのExecStartPreがtmpfsである/runへ複製したものをbind mountする。
   envDir = "/run/garage";
   envFile = "${envDir}/garage.env";
   garageWithEnv = pkgs.writeShellApplication {
@@ -146,33 +146,23 @@ in
   };
 
   systemd = {
-    services = {
+    services."container@garage" = {
+      requires = [ "sops-install-secrets.service" ];
+      after = [ "sops-install-secrets.service" ];
+      # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
+      # 明示的に指定して/mnt/noaのマウントを待つ。
+      unitConfig.RequiresMountsFor = [ "/mnt/noa/garage/data" ];
       # sopsテンプレートの環境ファイルをtmpfsへ複製する。
       # 展開先の/run/secrets.dはramfsでidmapped mountできないため、
       # idmap対応のtmpfs(/run)に置き直してからコンテナへbind mountする。
       # コンテナ内ではPID 1(コンテナroot)がEnvironmentFileとして読むので、
       # idmapで同一視されるroot:rootの0400で置く。
-      garage-env = {
-        description = "Copy garage environment file to tmpfs for idmapped bind mount";
-        requires = [ "sops-install-secrets.service" ];
-        after = [ "sops-install-secrets.service" ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          RuntimeDirectory = "garage";
-          RuntimeDirectoryMode = "0700";
-          ExecStart = "${pkgs.coreutils}/bin/install -m 0400 ${
-            config.sops.templates."garage-env".path
-          } ${envFile}";
-        };
-      };
-      "container@garage" = {
-        requires = [ "garage-env.service" ];
-        after = [ "garage-env.service" ];
-        # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
-        # 明示的に指定して/mnt/noaのマウントを待つ。
-        unitConfig.RequiresMountsFor = [ "/mnt/noa/garage/data" ];
-      };
+      # 独立したユニットにするとRuntimeDirectoryの寿命やrestartの伝播が
+      # コンテナと噛み合わなくなるため、コンテナ自身の起動処理に含める。
+      serviceConfig.ExecStartPre = [
+        "${pkgs.coreutils}/bin/install -d -m 0700 ${envDir}"
+        "${pkgs.coreutils}/bin/install -m 0400 ${config.sops.templates."garage-env".path} ${envFile}"
+      ];
     };
     tmpfiles.rules = [
       "d /var/lib/garage      0750 garage garage -"
@@ -194,6 +184,9 @@ in
       owner = "garage";
       group = "garage";
       mode = "0400";
+      # シークレットのローテート時に/run/garageへの複製とコンテナ内のgarageを
+      # 新しい内容で確実にやり直すため、コンテナごと再起動する。
+      restartUnits = [ "container@garage.service" ];
     };
     # sops-nixで管理している。
     # 作成方法(初回のみ):

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -141,10 +141,20 @@ in
       #   bind mount済みのコンテナは削除済みの古いinodeを掴んだままになり、
       #   以後コンテナ内で環境ファイルが読めなくなる
       # - requires/afterだけでは独立ユニットのrestartがコンテナへ伝播しない
-      serviceConfig.ExecStartPre = [
-        "${pkgs.coreutils}/bin/install -d -m 0700 ${envDir}"
-        "${pkgs.coreutils}/bin/install -m 0400 ${config.sops.templates."garage-env".path} ${envFile}"
-      ];
+      serviceConfig = {
+        # /run/garageはRuntimeDirectoryで管理して、
+        # コンテナ停止時に平文シークレットごと自動削除させる。
+        # systemdはRuntimeDirectoryをExecStartPreより前に作成するので複製に間に合う。
+        # 上流モジュールがephemeral時に設定するnixos-containers/%iとはリストマージで共存する。
+        # RuntimeDirectoryModeは指定しない。
+        # ユニット内の全RuntimeDirectoryへ適用されるため、
+        # 0700にするとコンテナルートFSのnixos-containers/%i(0755)のモードまで変わってしまう。
+        # ディレクトリが0755でも環境ファイル自体が0400なので内容は漏れない。
+        RuntimeDirectory = "garage";
+        ExecStartPre = "${pkgs.coreutils}/bin/install -m 0400 ${
+          config.sops.templates."garage-env".path
+        } ${envFile}";
+      };
     };
     tmpfiles.rules = [
       "d /var/lib/garage      0750 garage garage -"

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  hardening,
   ...
 }:
 let
@@ -106,35 +107,12 @@ in
         # GarageはRustバイナリで、必要なのはS3/RPC/Admin APIのTCP通信と、
         # bind mountされたmetadata_dirとdata_dirへのファイルアクセスだけ。
         # これらは上流モジュールのStateDirectory/ReadWritePathsで書き込み可能になっている。
-        systemd.services.garage.serviceConfig = {
+        systemd.services.garage.serviceConfig = hardening.network // {
           DynamicUser = lib.mkForce false;
           User = "garage";
           Group = "garage";
-          ProtectSystem = "strict";
-          PrivateTmp = true;
-          RestrictSUIDSGID = true;
+          # DynamicUser=trueが暗黙に有効化していたIPC隔離を再有効化する。
           RemoveIPC = true;
-          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-          # 空文字列でbounding setを空集合にリセットする。
-          CapabilityBoundingSet = "";
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          PrivateDevices = true;
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          RestrictAddressFamilies = [
-            "AF_INET"
-            "AF_INET6"
-            "AF_UNIX"
-          ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [ "@system-service" ];
         };
         environment.systemPackages = [ pkgs.garage_2 ];
       };

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -12,13 +12,18 @@ let
     group = "garage";
     isSystemUser = true;
   };
+  # コンテナ内へbind mountされる環境ファイルのパス。
+  # sops-nixの展開先はramfsでidmapped mountに対応していないため、
+  # garage-env.serviceがtmpfsである/runへ複製したものをbind mountする。
+  envDir = "/run/garage";
+  envFile = "${envDir}/garage.env";
   garageWithEnv = pkgs.writeShellApplication {
     name = "garage-with-env";
     runtimeInputs = [ ];
     text = ''
       set -a
       # shellcheck source=/dev/null
-      source /etc/garage.env
+      source ${envFile}
       set +a
       exec garage "$@"
     '';
@@ -40,23 +45,22 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
-    privateUsers = "identity";
+    # 毎起動ランダムな高位UID範囲へマップして、
+    # コンテナを脱出されてもホスト上では無権限のUIDになるようにする。
+    # identityと違いコンテナ内rootがホストのUID 0を持たなくなる。
+    # garageはUNIXソケットのpeer認証を使わないためpickにできる。
+    privateUsers = "pick";
     hostAddress = addr.host;
     localAddress = addr.guest;
-    bindMounts = {
-      "/etc/garage.env" = {
-        hostPath = config.sops.templates."garage-env".path;
-        isReadOnly = true;
-      };
-      "/var/lib/garage/meta" = {
-        hostPath = "/var/lib/garage/meta";
-        isReadOnly = false;
-      };
-      "/mnt/noa/garage/data" = {
-        hostPath = "/mnt/noa/garage/data";
-        isReadOnly = false;
-      };
-    };
+    # pickでは素のbind mountだと所有者が無効なUIDに見えてアクセスできないため、
+    # idmapオプションで数値IDをホストとコンテナで同一視させる。
+    # データディレクトリはbtrfs、環境ファイルはtmpfs上にありどちらもidmap対応。
+    # `bindMounts`はマウントオプションを渡せないのでextraFlagsで指定する。
+    extraFlags = [
+      "--bind-ro=${envDir}:${envDir}:idmap"
+      "--bind=/var/lib/garage/meta:/var/lib/garage/meta:idmap"
+      "--bind=/mnt/noa/garage/data:/mnt/noa/garage/data:idmap"
+    ];
     config =
       { lib, ... }:
       {
@@ -77,7 +81,7 @@ in
           garage = {
             enable = true;
             package = pkgs.garage_2;
-            environmentFile = "/etc/garage.env";
+            environmentFile = envFile;
             settings = {
               metadata_dir = "/var/lib/garage/meta";
               data_dir = "/mnt/noa/garage/data";
@@ -142,9 +146,33 @@ in
   };
 
   systemd = {
-    services."container@garage" = {
-      requires = [ "sops-install-secrets.service" ];
-      after = [ "sops-install-secrets.service" ];
+    services = {
+      # sopsテンプレートの環境ファイルをtmpfsへ複製する。
+      # 展開先の/run/secrets.dはramfsでidmapped mountできないため、
+      # idmap対応のtmpfs(/run)に置き直してからコンテナへbind mountする。
+      # コンテナ内ではPID 1(コンテナroot)がEnvironmentFileとして読むので、
+      # idmapで同一視されるroot:rootの0400で置く。
+      garage-env = {
+        description = "Copy garage environment file to tmpfs for idmapped bind mount";
+        requires = [ "sops-install-secrets.service" ];
+        after = [ "sops-install-secrets.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          RuntimeDirectory = "garage";
+          RuntimeDirectoryMode = "0700";
+          ExecStart = "${pkgs.coreutils}/bin/install -m 0400 ${
+            config.sops.templates."garage-env".path
+          } ${envFile}";
+        };
+      };
+      "container@garage" = {
+        requires = [ "garage-env.service" ];
+        after = [ "garage-env.service" ];
+        # extraFlagsのbind mountはbindMountsと違いRequiresMountsForが自動付与されないため、
+        # 明示的に指定して/mnt/noaのマウントを待つ。
+        unitConfig.RequiresMountsFor = [ "/mnt/noa/garage/data" ];
+      };
     };
     tmpfiles.rules = [
       "d /var/lib/garage      0750 garage garage -"

--- a/nixos/host/seminar/garage.nix
+++ b/nixos/host/seminar/garage.nix
@@ -23,8 +23,8 @@ let
       exec garage "$@"
     '';
   };
-  # Host wrapper to execute garage CLI inside the container.
-  # Export the environment file to provide GARAGE_RPC_SECRET etc.
+  # コンテナ内のgarage CLIをホストから実行するためのラッパー。
+  # GARAGE_RPC_SECRETなどを渡すために環境ファイルをexportする。
   garageWrapper = pkgs.writeShellApplication {
     name = "garage";
     runtimeInputs = with pkgs; [
@@ -65,7 +65,7 @@ in
           useHostResolvConf = lib.mkForce false;
           firewall.allowedTCPPorts = [
             3900 # S3 API
-            3903 # Admin API (host access only via private network)
+            3903 # Admin API (プライベートネットワーク経由でホストからのみアクセス)
           ];
         };
         users = {
@@ -96,8 +96,12 @@ in
             };
           };
         };
-        # Override DynamicUser to use explicit UIDs matching host bind-mount ownership.
-        # Re-enable security settings that DynamicUser=true would implicitly activate.
+        # ホスト側bind mountの所有権と一致する明示的なUIDを使うためDynamicUserを無効化する。
+        # DynamicUser=trueが暗黙に有効化していたセキュリティ設定を再有効化し、
+        # さらに追加のハードニングを上乗せする。
+        # GarageはRustバイナリで、必要なのはS3/RPC/Admin APIのTCP通信と、
+        # bind mountされたmetadata_dirとdata_dirへのファイルアクセスだけ。
+        # これらは上流モジュールのStateDirectory/ReadWritePathsで書き込み可能になっている。
         systemd.services.garage.serviceConfig = {
           DynamicUser = lib.mkForce false;
           User = "garage";
@@ -106,6 +110,27 @@ in
           PrivateTmp = true;
           RestrictSUIDSGID = true;
           RemoveIPC = true;
+          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+          # 空文字列でbounding setを空集合にリセットする。
+          CapabilityBoundingSet = "";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" ];
         };
         environment.systemPackages = [ pkgs.garage_2 ];
       };
@@ -142,14 +167,14 @@ in
       group = "garage";
       mode = "0400";
     };
-    # Managed by sops-nix.
-    # To create (first time only):
+    # sops-nixで管理している。
+    # 作成方法(初回のみ):
     # ```
     # rpc_secret=$(openssl rand -hex 32)
     # admin_token=$(openssl rand -base64 32)
     # metrics_token=$(openssl rand -base64 32)
     # ```
-    # Then `sops secrets/seminar/garage.yaml` and set:
+    # その後`sops secrets/seminar/garage.yaml`で以下を設定する:
     # ```
     # rpc_secret: <hex>
     # admin_token: <base64>
@@ -180,7 +205,7 @@ in
     };
   };
 
-  # Initial cluster setup (manual, first time only):
+  # クラスタの初期セットアップ(手動、初回のみ):
   # ```
   # sudo garage status
   # sudo garage layout assign <node-id> -z seminar -c 8T

--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -16,6 +16,7 @@
 {
   pkgs,
   config,
+  hardening,
   ...
 }:
 let
@@ -127,7 +128,9 @@ in
           description = "mcp-nixos HTTP server";
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
-          serviceConfig = {
+          # PythonはlibffiがW^X違反のメモリを使うことがあるため、
+          # MemoryDenyWriteExecuteは設定しません。
+          serviceConfig = builtins.removeAttrs hardening.network [ "MemoryDenyWriteExecute" ] // {
             # mcp-nixosはHTTPトランスポートをネイティブにサポートしているので、
             # 環境変数で設定して直接起動します。
             # パスは未指定だとデフォルトの`/mcp`になり、前段Caddyの転送先と一致します。
@@ -141,34 +144,6 @@ in
             DynamicUser = true;
             Restart = "always";
             RestartSec = 5;
-            # Hardening
-            # PythonはlibffiがW^X違反のメモリを使うことがあるため、
-            # MemoryDenyWriteExecuteは設定しません。
-            NoNewPrivileges = true;
-            ProtectSystem = "strict";
-            ProtectHome = true;
-            PrivateTmp = true;
-            PrivateDevices = true;
-            # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-            # 空文字列でbounding setを空集合にリセットする。
-            CapabilityBoundingSet = "";
-            LockPersonality = true;
-            ProtectClock = true;
-            ProtectControlGroups = true;
-            ProtectHostname = true;
-            ProtectKernelLogs = true;
-            ProtectKernelModules = true;
-            ProtectKernelTunables = true;
-            RestrictAddressFamilies = [
-              "AF_INET"
-              "AF_INET6"
-              "AF_UNIX"
-            ];
-            RestrictNamespaces = true;
-            RestrictRealtime = true;
-            RestrictSUIDSGID = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = [ "@system-service" ];
           };
         };
       };
@@ -199,38 +174,19 @@ in
       after = [ "microvm-tap-interfaces@mcp-nixos.service" ];
       bindsTo = [ "microvm-tap-interfaces@mcp-nixos.service" ];
       wantedBy = [ "microvm-tap-interfaces@mcp-nixos.service" ];
-      serviceConfig = {
+      serviceConfig = hardening.network // {
         Type = "oneshot";
         RemainAfterExit = true;
         ExecStart =
           "${pkgs.iproute2}/bin/tc qdisc replace dev vm-mcp-nixos root tbf"
           + " rate 100mbit burst 10mbit latency 400ms";
-        # Hardening
         # tcはnetlink経由でqdiscを設定するだけなので、
         # CAP_NET_ADMINとAF_NETLINKだけ許可する。
         CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateTmp = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectSystem = "strict";
         RestrictAddressFamilies = [
           "AF_NETLINK"
           "AF_UNIX"
         ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" ];
       };
     };
   };

--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -142,11 +142,33 @@ in
             Restart = "always";
             RestartSec = 5;
             # Hardening
+            # PythonはlibffiがW^X違反のメモリを使うことがあるため、
+            # MemoryDenyWriteExecuteは設定しません。
             NoNewPrivileges = true;
             ProtectSystem = "strict";
             ProtectHome = true;
             PrivateTmp = true;
             PrivateDevices = true;
+            # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+            # 空文字列でbounding setを空集合にリセットする。
+            CapabilityBoundingSet = "";
+            LockPersonality = true;
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_UNIX"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [ "@system-service" ];
           };
         };
       };
@@ -183,6 +205,32 @@ in
         ExecStart =
           "${pkgs.iproute2}/bin/tc qdisc replace dev vm-mcp-nixos root tbf"
           + " rate 100mbit burst 10mbit latency 400ms";
+        # Hardening
+        # tcはnetlink経由でqdiscを設定するだけなので、
+        # CAP_NET_ADMINとAF_NETLINKだけ許可する。
+        CapabilityBoundingSet = [ "CAP_NET_ADMIN" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
       };
     };
   };

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -19,6 +19,8 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    # PostgreSQLのpeer認証がホストと同一のUIDでの接続を要求するため、
+    # pickにはできずidentity(UID分離なし、capability分離のみ)のまま。
     privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -19,6 +19,8 @@ in
     autoStart = true;
     ephemeral = true;
     privateNetwork = true;
+    # PostgreSQLのpeer認証がホストと同一のUIDでの接続を要求するため、
+    # pickにはできずidentity(UID分離なし、capability分離のみ)のまま。
     privateUsers = "identity";
     hostAddress = addr.host;
     localAddress = addr.guest;

--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -84,6 +84,31 @@ in
       # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
       # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
       EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
+      # Hardening
+      # 上流モジュールのDynamicUser/ProtectSystem/DevicePolicy/NoNewPrivilegesに加えて締めます。
+      # スクレイプとOTLP送信のTCP通信とNSSのUNIXソケットだけ許可します。
+      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+      # 空文字列でbounding setを空集合にリセットする。
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
     };
     after = [ "sops-install-secrets.service" ];
     requires = [ "sops-install-secrets.service" ];

--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, hardening, ... }:
 let
   garageAddr = config.machineAddresses.garage.guest;
 in
@@ -74,42 +74,26 @@ in
   };
 
   systemd.services.opentelemetry-collector = {
-    serviceConfig = {
-      # collector内部のmemory_limiterに加えて、
-      # cgroupレベルでもメモリ上限を設けて二重に保護します。
-      # memory_limiterのlimit_mib(256MiB)より上に設定して、
-      # 通常はcollector側で先に制御が効くようにします。
-      MemoryHigh = "384M";
-      MemoryMax = "512M";
-      # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
-      # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
-      EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
-      # Hardening
-      # 上流モジュールのDynamicUser/ProtectSystem/DevicePolicy/NoNewPrivilegesに加えて締めます。
-      # スクレイプとOTLP送信のTCP通信とNSSのUNIXソケットだけ許可します。
-      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-      # 空文字列でbounding setを空集合にリセットする。
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      MemoryDenyWriteExecute = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHome = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
-      RestrictNamespaces = true;
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-      SystemCallFilter = [ "@system-service" ];
-    };
+    # 上流モジュールがDynamicUser/ProtectSystem/DevicePolicy/NoNewPrivilegesを設定済みなので、
+    # 上流と重複・衝突する属性は外してその上に締めます。
+    serviceConfig =
+      builtins.removeAttrs hardening.network [
+        "NoNewPrivileges"
+        "PrivateDevices"
+        "PrivateTmp"
+        "ProtectSystem"
+      ]
+      // {
+        # collector内部のmemory_limiterに加えて、
+        # cgroupレベルでもメモリ上限を設けて二重に保護します。
+        # memory_limiterのlimit_mib(256MiB)より上に設定して、
+        # 通常はcollector側で先に制御が効くようにします。
+        MemoryHigh = "384M";
+        MemoryMax = "512M";
+        # `EnvironmentFile`はsystemdがroot権限で読み込んでからプロセスに渡すため、
+        # `DynamicUser`で動くcollectorでも`0400 root`のままアクセスできます。
+        EnvironmentFile = [ config.sops.templates."otelcol-env".path ];
+      };
     after = [ "sops-install-secrets.service" ];
     requires = [ "sops-install-secrets.service" ];
   };

--- a/nixos/host/seminar/postgresql.nix
+++ b/nixos/host/seminar/postgresql.nix
@@ -2,6 +2,7 @@
   pkgs,
   config,
   lib,
+  hardening,
   ...
 }:
 let
@@ -140,7 +141,8 @@ in
         # それでも接続できなければ失敗とします。
         startLimitBurst = 30;
         startLimitIntervalSec = 60;
-        serviceConfig = {
+        # pg_isreadyはUNIXソケットに接続を試みるだけ。
+        serviceConfig = hardening.unixSocket // {
           Type = "oneshot";
           RemainAfterExit = true;
           User = "postgres";
@@ -148,32 +150,6 @@ in
           ExecStart = "${postgresql}/bin/pg_isready -h /run/postgresql --timeout=5";
           Restart = "on-failure";
           RestartSec = "1s";
-          # Hardening
-          # pg_isreadyはUNIXソケットに接続を試みるだけなので、
-          # ネットワーク名前空間ごと隔離してAF_UNIXだけ許可する。
-          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-          # 空文字列でbounding setを空集合にリセットする。
-          CapabilityBoundingSet = "";
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          NoNewPrivileges = true;
-          PrivateDevices = true;
-          PrivateNetwork = true;
-          PrivateTmp = true;
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectHome = true;
-          ProtectHostname = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          ProtectSystem = "strict";
-          RestrictAddressFamilies = [ "AF_UNIX" ];
-          RestrictNamespaces = true;
-          RestrictRealtime = true;
-          RestrictSUIDSGID = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [ "@system-service" ];
         };
       };
 

--- a/nixos/host/seminar/postgresql.nix
+++ b/nixos/host/seminar/postgresql.nix
@@ -143,6 +143,32 @@ in
           ExecStart = "${postgresql}/bin/pg_isready -h /run/postgresql --timeout=5";
           Restart = "on-failure";
           RestartSec = "1s";
+          # Hardening
+          # pg_isreadyはUNIXソケットに接続を試みるだけなので、
+          # ネットワーク名前空間ごと隔離してAF_UNIXだけ許可する。
+          # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+          # 空文字列でbounding setを空集合にリセットする。
+          CapabilityBoundingSet = "";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateNetwork = true;
+          PrivateTmp = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [ "AF_UNIX" ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [ "@system-service" ];
         };
       };
 

--- a/nixos/host/seminar/postgresql.nix
+++ b/nixos/host/seminar/postgresql.nix
@@ -29,6 +29,11 @@ in
       # ホストのネットワークスタックから隔離してTCP接続を遮断するために有効化している。
       # hostAddress/localAddressを意図的に設定せず、IPアドレスを持たない状態にしている。
       privateNetwork = true;
+      # peer認証はSO_PEERCREDで得たクライアントの実UIDを、
+      # このコンテナのユーザ名前空間で解決してユーザ名と照合する。
+      # クライアントはホストや他コンテナ(identity)のプロセスなので、
+      # pickにするとUIDが解決できず認証が全て失敗する。
+      # そのためidentity(UID分離なし、capability分離のみ)より厳しくできない。
       privateUsers = "identity";
       bindMounts = {
         # Unixソケットディレクトリ。

--- a/nixos/host/seminar/samba.nix
+++ b/nixos/host/seminar/samba.nix
@@ -65,6 +65,43 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
+      # Hardening
+      # smbpasswdはrootが所有する/var/lib/samba配下のpassdbを直接更新するため、
+      # 追加のcapabilityは不要。
+      # tdbのロックやキャッシュに触る可能性があるディレクトリは、
+      # `-`プレフィックスで存在する場合のみ書き込みを許可する。
+      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+      # 空文字列でbounding setを空集合にリセットする。
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectSystem = "strict";
+      ReadWritePaths = [
+        "/var/lib/samba"
+        "-/var/cache/samba"
+        "-/var/lock/samba"
+        "-/run/samba"
+      ];
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
     };
     script = ''
       set -euo pipefail

--- a/nixos/host/seminar/samba.nix
+++ b/nixos/host/seminar/samba.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  hardening,
   ...
 }:
 {
@@ -62,46 +63,19 @@
     after = [ "samba-smbd.service" ];
     bindsTo = [ "samba-smbd.service" ];
     wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
+    # smbpasswdはrootが所有する/var/lib/samba配下のpassdbを直接更新するため、
+    # 追加のcapabilityは不要。
+    serviceConfig = hardening.network // {
       Type = "oneshot";
       RemainAfterExit = true;
-      # Hardening
-      # smbpasswdはrootが所有する/var/lib/samba配下のpassdbを直接更新するため、
-      # 追加のcapabilityは不要。
       # tdbのロックやキャッシュに触る可能性があるディレクトリは、
       # `-`プレフィックスで存在する場合のみ書き込みを許可する。
-      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-      # 空文字列でbounding setを空集合にリセットする。
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      MemoryDenyWriteExecute = true;
-      NoNewPrivileges = true;
-      PrivateDevices = true;
-      PrivateTmp = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHome = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      ProtectSystem = "strict";
       ReadWritePaths = [
         "/var/lib/samba"
         "-/var/cache/samba"
         "-/var/lock/samba"
         "-/run/samba"
       ];
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
-      RestrictNamespaces = true;
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-      SystemCallFilter = [ "@system-service" ];
     };
     script = ''
       set -euo pipefail

--- a/nixos/host/seminar/samba.nix
+++ b/nixos/host/seminar/samba.nix
@@ -63,9 +63,13 @@
     after = [ "samba-smbd.service" ];
     bindsTo = [ "samba-smbd.service" ];
     wantedBy = [ "multi-user.target" ];
-    # smbpasswdはrootが所有する/var/lib/samba配下のpassdbを直接更新するため、
-    # 追加のcapabilityは不要。
-    serviceConfig = hardening.network // {
+    # smbpasswdはrootが所有する/var/lib/samba配下のpassdbを直接更新するだけで、
+    # 追加のcapabilityもネットワーク通信も不要なので、
+    # UNIXソケットのみ許可のハードニングまで絞る。
+    # 平文のSMBパスワードを読むユニットなので絞る価値が大きい。
+    # seminar上で同等のサンドボックスを再現して、
+    # `smbpasswd -a -s`が成功することを確認済み。
+    serviceConfig = hardening.unixSocket // {
       Type = "oneshot";
       RemainAfterExit = true;
       # tdbのロックやキャッシュに触る可能性があるディレクトリは、

--- a/nixos/host/seminar/tailscale-serve.nix
+++ b/nixos/host/seminar/tailscale-serve.nix
@@ -30,8 +30,10 @@ in
     wantedBy = [ "multi-user.target" ];
     # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
     # 実際のプロキシ転送はtailscaled側が行うため、
-    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
-    serviceConfig = hardening.network // {
+    # UNIXソケットのみ許可のハードニングまで絞れる。
+    # seminar上で同等のサンドボックスを再現して、
+    # フォアグラウンドのserveセッションが登録・維持できることを確認済み。
+    serviceConfig = hardening.unixSocket // {
       ExecStart = "${tailscale}/bin/tailscale serve --https=8443 http://127.0.0.1:8081";
       # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
       # 終了コードによらず常に再起動して復帰させる。

--- a/nixos/host/seminar/tailscale-serve.nix
+++ b/nixos/host/seminar/tailscale-serve.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, hardening, ... }:
 let
   tailscale = config.services.tailscale.package;
 in
@@ -28,42 +28,15 @@ in
       "tailscaled.service"
     ];
     wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
+    # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
+    # 実際のプロキシ転送はtailscaled側が行うため、
+    # capabilityも書き込み可能なファイルシステムも不要でハードニングをそのまま適用できる。
+    serviceConfig = hardening.network // {
       ExecStart = "${tailscale}/bin/tailscale serve --https=8443 http://127.0.0.1:8081";
       # tailscaledの再起動などでセッションが切れるとプロセスが終了するため、
       # 終了コードによらず常に再起動して復帰させる。
       Restart = "always";
       RestartSec = "10s";
-      # Hardening
-      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
-      # 実際のプロキシ転送はtailscaled側が行うため、
-      # capabilityも書き込み可能なファイルシステムも不要。
-      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
-      # 空文字列でbounding setを空集合にリセットする。
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      MemoryDenyWriteExecute = true;
-      NoNewPrivileges = true;
-      PrivateDevices = true;
-      PrivateTmp = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHome = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      ProtectSystem = "strict";
-      RestrictAddressFamilies = [
-        "AF_INET"
-        "AF_INET6"
-        "AF_UNIX"
-      ];
-      RestrictNamespaces = true;
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-      SystemCallFilter = [ "@system-service" ];
     };
   };
 }

--- a/nixos/host/seminar/tailscale-serve.nix
+++ b/nixos/host/seminar/tailscale-serve.nix
@@ -34,6 +34,36 @@ in
       # 終了コードによらず常に再起動して復帰させる。
       Restart = "always";
       RestartSec = "10s";
+      # Hardening
+      # tailscale CLIはtailscaledのLocalAPIにUNIXソケット経由で接続してセッションを維持するだけで、
+      # 実際のプロキシ転送はtailscaled側が行うため、
+      # capabilityも書き込み可能なファイルシステムも不要。
+      # 空リストはNixOSモジュールがディレクティブごと省略してしまうため、
+      # 空文字列でbounding setを空集合にリセットする。
+      CapabilityBoundingSet = "";
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectClock = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [ "@system-service" ];
     };
   };
 }

--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  hardening,
+  ...
+}:
 {
   boot = {
     loader = {
@@ -68,35 +73,15 @@
       unitConfig = {
         ConditionPathExists = limineLastBootedEntryPath;
       };
-      serviceConfig = {
+      # efivarfsの変数を削除するだけでソケットは使わない。
+      # /sysへの書き込みが必要なのでProtectKernelTunablesは設定できない。
+      serviceConfig = builtins.removeAttrs hardening.isolated [ "ProtectKernelTunables" ] // {
         Type = "oneshot";
-        # Hardening
-        # efivarfsの変数削除に必要なもの以外を締める。
         # chattrによるimmutable属性の解除にCAP_LINUX_IMMUTABLEが必要。
+        CapabilityBoundingSet = [ "CAP_LINUX_IMMUTABLE" ];
         # `ProtectSystem = "strict"`は/sysを読み書き可能なまま残すが、
         # efivarfsは/sys配下の別マウントなので明示的にReadWritePathsへ入れる。
-        # /sysへの書き込みが必要なのでProtectKernelTunablesは設定できない。
-        CapabilityBoundingSet = [ "CAP_LINUX_IMMUTABLE" ];
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateNetwork = true;
-        PrivateTmp = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectSystem = "strict";
         ReadWritePaths = [ "/sys/firmware/efi/efivars" ];
-        RestrictAddressFamilies = [ "AF_UNIX" ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" ];
         ExecStart = lib.getExe (
           pkgs.writeShellApplication {
             name = "limine-forget-last-entry";

--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -70,6 +70,33 @@
       };
       serviceConfig = {
         Type = "oneshot";
+        # Hardening
+        # efivarfsの変数削除に必要なもの以外を締める。
+        # chattrによるimmutable属性の解除にCAP_LINUX_IMMUTABLEが必要。
+        # `ProtectSystem = "strict"`は/sysを読み書き可能なまま残すが、
+        # efivarfsは/sys配下の別マウントなので明示的にReadWritePathsへ入れる。
+        # /sysへの書き込みが必要なのでProtectKernelTunablesは設定できない。
+        CapabilityBoundingSet = [ "CAP_LINUX_IMMUTABLE" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateNetwork = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/sys/firmware/efi/efivars" ];
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
         ExecStart = lib.getExe (
           pkgs.writeShellApplication {
             name = "limine-forget-last-entry";

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -71,10 +71,9 @@ lib.mkMerge [
             "credentials=${config.sops.templates."cifs-credentials".path}"
             "uid=${toString userConfig.uid}"
             "gid=${toString config.users.groups.${userConfig.group}.gid}"
-            # 所有グループ(users)にも書き込みを許可する。
-            # bulletのComfyUIコンテナなど、
-            # uidの異なるサービスユーザがグループ経由で書き込めるようにするため。
-            # デフォルトの0755ではファイルが実行可能に見えてしまう問題も直る。
+            # デフォルトの0755/0755だとファイルが実行可能に見えてしまうため、
+            # ファイルから実行ビットを落とす。
+            # 所有グループ(users)への書き込み許可も維持する。
             "dir_mode=0775"
             "file_mode=0664"
             # systemdはデフォルトだと`Before=remote-fs.target`を追加します。

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -8,22 +8,10 @@
 }:
 let
   userConfig = config.users.users.${username};
-  # seminarのSMBポートへ実際にTCP接続できるまで待つスクリプト。
-  # `network-online.target`や`tailscale-online.service`はどちらも
-  # 「seminarに到達できる」ことまでは保証しないため、
-  # マウント前に実到達性を確認する必要がある。
-  waitForSeminar = pkgs.writeShellApplication {
-    name = "wait-for-seminar";
-    runtimeInputs = with pkgs; [
-      bash
-      coreutils
-    ];
-    text = ''
-      until timeout 5 bash -c ': < /dev/tcp/seminar/445'; do
-        sleep 2
-      done
-    '';
-  };
+  inherit (import ../../lib/seminar-cifs.nix { inherit pkgs; })
+    baseMountOptions
+    waitForSeminar
+    ;
 in
 lib.mkMerge [
   (lib.mkIf (hostName != "seminar") {
@@ -66,32 +54,23 @@ lib.mkMerge [
           what = "//seminar/chihiro";
           where = "/mnt/chihiro";
           type = "cifs";
-          options = lib.concatStringsSep "," [
-            # 認証
-            "credentials=${config.sops.templates."cifs-credentials".path}"
-            "uid=${toString userConfig.uid}"
-            "gid=${toString config.users.groups.${userConfig.group}.gid}"
-            # デフォルトの0755/0755だとファイルが実行可能に見えてしまうため、
-            # ファイルから実行ビットを落とす。
-            # 所有グループ(users)への書き込み許可も維持する。
-            "dir_mode=0775"
-            "file_mode=0664"
-            # systemdはデフォルトだと`Before=remote-fs.target`を追加します。
-            # `nofail`を指定することでその挙動が抑制され、
-            # `remote-fs.target`経由のブートブロックを防ぎます。
-            "nofail"
-            # セキュリティ
-            "nodev"
-            "noexec"
-            "nosuid"
-            # パフォーマンス
-            "noatime"
-            # SMBダイアレクトを明示的に指定。
-            # 未指定だとkernelが`No dialect specified on mount`の警告を出す。
-            # `vers=3`はSMB3.0以上を意味し、ネゴシエーションで3.x系の最新版が選択される。
-            # SMB1/SMB2系を排除しつつ、将来のマイナーバージョン更新にも自動追従する。
-            "vers=3"
-          ];
+          # 認証・セキュリティ・ダイアレクトの共通部分は`lib/seminar-cifs.nix`で管理する。
+          options = lib.concatStringsSep "," (
+            baseMountOptions config.sops.templates."cifs-credentials".path
+            ++ [
+              "uid=${toString userConfig.uid}"
+              "gid=${toString config.users.groups.${userConfig.group}.gid}"
+              # デフォルトの0755/0755だとファイルが実行可能に見えてしまうため、
+              # ファイルから実行ビットを落とす。
+              # 所有グループ(users)への書き込み許可も維持する。
+              "dir_mode=0775"
+              "file_mode=0664"
+              # systemdはデフォルトだと`Before=remote-fs.target`を追加します。
+              # `nofail`を指定することでその挙動が抑制され、
+              # `remote-fs.target`経由のブートブロックを防ぎます。
+              "nofail"
+            ]
+          );
           mountConfig = {
             TimeoutSec = 30;
           };

--- a/nixos/native-linux/cifs.nix
+++ b/nixos/native-linux/cifs.nix
@@ -10,6 +10,7 @@ let
   userConfig = config.users.users.${username};
   inherit (import ../../lib/seminar-cifs.nix { inherit pkgs; })
     baseMountOptions
+    mkRetryService
     waitForSeminar
     ;
 in
@@ -103,36 +104,10 @@ lib.mkMerge [
 
         # マウント失敗時にOnFailureから起動されるリトライサービス。
         # 到達性が回復するまで待ってから再マウントする。
-        mnt-chihiro-retry = {
+        mnt-chihiro-retry = mkRetryService {
+          name = "mnt-chihiro";
           description = "Retry mounting /mnt/chihiro after failure";
-          unitConfig = {
-            # mount側のStartLimitだけに停止保証を頼らない。
-            # mountがstart-limit-hitで拒否された場合にOnFailureが再発火するかは、
-            # systemdのバージョンで挙動が異なるため(systemd/systemd#33710)、
-            # 再発火する環境でもこのサービス自身の起動制限でループを確実に打ち切る。
-            StartLimitIntervalSec = 600;
-            StartLimitBurst = 5;
-          };
-          serviceConfig = {
-            Type = "oneshot";
-            TimeoutStartSec = 600;
-            ExecStart = lib.getExe (
-              pkgs.writeShellApplication {
-                name = "retry-mnt-chihiro";
-                runtimeInputs = with pkgs; [
-                  coreutils
-                  systemd
-                  waitForSeminar
-                ];
-                # 失敗直後の即時再試行は同じ理由で失敗しやすいので少し置く。
-                text = ''
-                  sleep 10
-                  wait-for-seminar
-                  systemctl restart mnt-chihiro.mount
-                '';
-              }
-            );
-          };
+          mountUnit = "mnt-chihiro.mount";
         };
       };
 


### PR DESCRIPTION
独自定義しているsystemdサービスとNixOSコンテナに対して、
動作に影響がない範囲でsystemdの隔離機構を適用し、
サービスの侵害やコンテナ脱出が起きた時の被害を軽減します。

独自サービスにはcapabilityとアドレスファミリの最小化を軸とした、
サンドボックス設定を追加します。
`systemd-analyze security`のスコアはtailscale系で9台(UNSAFE)から、
2.0前後(OK)まで改善しています。

またcomfyuiとgarageコンテナは`privateUsers = "pick"`にして、
UID空間をホストから分離します。
コンテナ内rootがホストのUID 0を持たなくなるため、
脱出されてもホスト上では無権限の高位UIDになります。
bind mountの所有権はidmapオプションで解決し、
idmapped mountに対応しないCIFS(comfyuiの出力先)は、
コンテナのライフサイクルに連動する専用マウントへ切り替えます。
PostgreSQLのpeer認証を使うコンテナ群は、
ホストと同一UIDでの接続が必要なため`identity`のままとし、
理由をコメントで明文化します。

副産物として`CapabilityBoundingSet = [ ];`のような空リストが、
NixOSモジュールにディレクティブごと省略され無効になっていた問題を発見し、
既存のgpg-vault.nixも含めて空文字列へ修正します。

bullet上では適用して主要サービスとComfyUIコンテナの動作を確認済みです。
seminarへの適用時はgarageコンテナ周りの動作確認を推奨します。

https://claude.ai/code/session_01C374RgSEFYZ5orpyH7qF9Z