### PR TITLE
feat(comfyui): 出力をワークフロー別ディレクトリと日時ファイル名にします

### DIFF
--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -99,6 +99,9 @@ in
       {
         imports = [ inputs.utensils-comfyui-nix.nixosModules.default ];
         system.stateVersion = "26.05";
+        # コンテナにはホストのタイムゾーンが伝播しないため明示する。
+        # 未設定だとUTCになり、出力ファイル名の生成日時がJSTとずれる。
+        time.timeZone = "Asia/Tokyo";
         networking.useHostResolvConf = lib.mkForce false;
         services.resolved.enable = true;
         users = {

--- a/nixos/host/bullet/comfyui/workflow/anime-basic.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-basic.nix
@@ -8,6 +8,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     promptNodes
     promptLinks
     ;
@@ -62,7 +63,7 @@ in
         ];
         order = 6;
         inputs = [ (mkInput "images" "IMAGE" 9) ];
-        widgets = [ "anime-basic" ];
+        widgets = [ (mkFilenamePrefix "anime-basic") ];
       })
     ];
     links = promptLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow/anime-basic.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-basic.nix
@@ -1,6 +1,7 @@
 # txt2imgの基本形。
 { lib, ... }:
 let
+  name = "anime-basic";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -14,7 +15,7 @@ let
     ;
 in
 {
-  local.comfyui.workflows.anime-basic = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInputWith 2 "text" {
@@ -63,7 +64,7 @@ in
         ];
         order = 6;
         inputs = [ (mkInput "images" "IMAGE" 9) ];
-        widgets = [ (mkFilenamePrefix "anime-basic") ];
+        widgets = [ (mkFilenamePrefix name) ];
       })
     ];
     links = promptLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow/anime-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-edit.nix
@@ -9,6 +9,7 @@
 # 0.7以上で構図だけ借りた大胆な変更。
 { lib, ... }:
 let
+  name = "anime-edit";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -22,7 +23,7 @@ let
     ;
 in
 {
-  local.comfyui.workflows.anime-edit = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInput 4 "image")
@@ -121,7 +122,7 @@ in
           ];
           order = 7;
           inputs = [ (mkInput "images" "IMAGE" 9) ];
-          widgets = [ (mkFilenamePrefix "anime-edit") ];
+          widgets = [ (mkFilenamePrefix name) ];
         })
       ];
     links = promptBaseLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow/anime-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-edit.nix
@@ -16,6 +16,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     promptNodes
     promptBaseLinks
     ;
@@ -120,7 +121,7 @@ in
           ];
           order = 7;
           inputs = [ (mkInput "images" "IMAGE" 9) ];
-          widgets = [ "anime-edit" ];
+          widgets = [ (mkFilenamePrefix "anime-edit") ];
         })
       ];
     links = promptBaseLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow/anime-standard.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-standard.nix
@@ -7,6 +7,6 @@
     inherit lib;
     width = 832;
     height = 1216;
-    filenamePrefix = "anime-standard";
+    name = "anime-standard";
   };
 }

--- a/nixos/host/bullet/comfyui/workflow/anime-standard.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-standard.nix
@@ -2,11 +2,13 @@
 # SDXLのポートレートバケット解像度で生成して、
 # 1.5倍のhires fixで1248x1824が出力される。
 { lib, ... }:
+let
+  name = "anime-standard";
+in
 {
-  local.comfyui.workflows.anime-standard = import ./lib/standard.nix {
-    inherit lib;
+  local.comfyui.workflows.${name} = import ./lib/standard.nix {
+    inherit lib name;
     width = 832;
     height = 1216;
-    name = "anime-standard";
   };
 }

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -42,6 +42,7 @@
 # 8-bit RGBから4:2:0への色変換があるため厳密な可逆圧縮ではない。
 { lib, ... }:
 let
+  name = "anime-video-extend";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -60,7 +61,7 @@ let
   negativePrompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走，写实风格，照片级，3D渲染，真人";
 in
 {
-  local.comfyui.workflows.anime-video-extend = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInput 9 "file")
@@ -650,7 +651,7 @@ in
         order = 24;
         inputs = [ (mkInput "images" "IMAGE" 33) ];
         widgets = [
-          (mkFilenamePrefix "anime-video-extend") # filename_prefix
+          (mkFilenamePrefix name) # filename_prefix
           "av1" # codec
           16 # fps
           1 # crf

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -49,6 +49,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     seedWidgets
     ;
   # 実写バイアスを打ち消すために常にプロンプトへ前置するスタイル指定。
@@ -649,7 +650,7 @@ in
         order = 24;
         inputs = [ (mkInput "images" "IMAGE" 33) ];
         widgets = [
-          "anime-video-extend" # filename_prefix
+          (mkFilenamePrefix "anime-video-extend") # filename_prefix
           "av1" # codec
           16 # fps
           1 # crf

--- a/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
@@ -12,6 +12,7 @@
 # CRF 1はnear-losslessだが、4:2:0への色差変換があるため厳密な可逆圧縮ではない。
 { lib, ... }:
 let
+  name = "anime-video-upscale";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -23,7 +24,7 @@ let
     ;
 in
 {
-  local.comfyui.workflows.anime-video-upscale = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInput 1 "file")
@@ -210,7 +211,7 @@ in
         outputs = [ ];
         widgets = [
           24 # fpsはリンクで上書きされる
-          (mkFilenamePrefix "anime-video-upscale") # filename_prefix
+          (mkFilenamePrefix name) # filename_prefix
           1 # CRF: near-lossless
           4 # preset: 品質優先
         ];

--- a/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
@@ -19,6 +19,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     ;
 in
 {
@@ -209,7 +210,7 @@ in
         outputs = [ ];
         widgets = [
           24 # fpsはリンクで上書きされる
-          "anime-video-upscale-svt-av1"
+          (mkFilenamePrefix "anime-video-upscale") # filename_prefix
           1 # CRF: near-lossless
           4 # preset: 品質優先
         ];

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -47,6 +47,7 @@
 # 8-bit RGBから4:2:0への色変換があるため厳密な可逆圧縮ではない。
 { lib, ... }:
 let
+  name = "anime-video";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -63,7 +64,7 @@ let
   negativePrompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走，写实风格，照片级，3D渲染，真人";
 in
 {
-  local.comfyui.workflows.anime-video = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInput 9 "image")
@@ -751,7 +752,7 @@ in
         order = 20;
         inputs = [ (mkInput "images" "IMAGE" 21) ];
         widgets = [
-          (mkFilenamePrefix "anime-video") # filename_prefix
+          (mkFilenamePrefix name) # filename_prefix
           "av1" # codec
           16 # fps
           1 # crf

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -54,6 +54,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     seedWidgets
     ;
   # 実写バイアスを打ち消すために常にプロンプトへ前置するスタイル指定。
@@ -750,7 +751,7 @@ in
         order = 20;
         inputs = [ (mkInput "images" "IMAGE" 21) ];
         widgets = [
-          "anime-video" # filename_prefix
+          (mkFilenamePrefix "anime-video") # filename_prefix
           "av1" # codec
           16 # fps
           1 # crf

--- a/nixos/host/bullet/comfyui/workflow/anime-wallpaper.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-wallpaper.nix
@@ -2,11 +2,13 @@
 # SDXLが破綻しにくい1280x720で生成して、
 # 1.5倍のhires fixでちょうど標準的なモニタサイズの1920x1080が出力される。
 { lib, ... }:
+let
+  name = "anime-wallpaper";
+in
 {
-  local.comfyui.workflows.anime-wallpaper = import ./lib/standard.nix {
-    inherit lib;
+  local.comfyui.workflows.${name} = import ./lib/standard.nix {
+    inherit lib name;
     width = 1280;
     height = 720;
-    name = "anime-wallpaper";
   };
 }

--- a/nixos/host/bullet/comfyui/workflow/anime-wallpaper.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-wallpaper.nix
@@ -7,6 +7,6 @@
     inherit lib;
     width = 1280;
     height = 720;
-    filenamePrefix = "anime-wallpaper";
+    name = "anime-wallpaper";
   };
 }

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -19,6 +19,12 @@ let
     "randomize"
   ];
 
+  # 出力をワークフローごとのサブディレクトリへ分けて、
+  # ファイル名を連番だけでなく生成日時にするfilename_prefixを組み立てる。
+  # %year%などの置換はサーバ側のfolder_paths.get_save_image_pathが行うため、
+  # フロントエンドの%date:...%と違い自作ノードを含む全ての保存ノードで機能する。
+  mkFilenamePrefix = name: "${name}/${name}-%year%-%month%-%day%-%hour%-%minute%-%second%";
+
   mkNode =
     {
       id,
@@ -295,6 +301,7 @@ in
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     promptNodes
     promptBaseLinks
     promptLinks

--- a/nixos/host/bullet/comfyui/workflow/lib/standard.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/standard.nix
@@ -12,7 +12,8 @@
   lib,
   width,
   height,
-  filenamePrefix,
+  # ワークフロー名。出力先サブディレクトリとファイル名の元になる。
+  name,
 }:
 let
   inherit (import ./builder.nix { inherit lib; })
@@ -22,6 +23,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     promptNodes
     promptLinks
     seedWidgets
@@ -300,7 +302,7 @@ mkWorkflow {
         ];
         order = 14;
         inputs = [ (mkInput "images" "IMAGE" 27) ];
-        widgets = [ filenamePrefix ];
+        widgets = [ (mkFilenamePrefix name) ];
       })
     ];
   links = promptLinks ++ [

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -17,6 +17,7 @@
 # この基本形では1枚だけ使う。
 { lib, ... }:
 let
+  name = "qwen-edit";
   inherit (import ./lib/builder.nix { inherit lib; })
     mkNode
     mkInput
@@ -29,7 +30,7 @@ let
     ;
 in
 {
-  local.comfyui.workflows.qwen-edit = mkWorkflow {
+  local.comfyui.workflows.${name} = mkWorkflow {
     app = {
       inputs = [
         (mkAppInput 4 "image")
@@ -355,7 +356,7 @@ in
         ];
         order = 12;
         inputs = [ (mkInput "images" "IMAGE" 18) ];
-        widgets = [ (mkFilenamePrefix "qwen-edit") ];
+        widgets = [ (mkFilenamePrefix name) ];
       })
     ];
     links = [

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -24,6 +24,7 @@ let
     mkAppInput
     mkAppInputWith
     mkWorkflow
+    mkFilenamePrefix
     seedWidgets
     ;
 in
@@ -354,7 +355,7 @@ in
         ];
         order = 12;
         inputs = [ (mkInput "images" "IMAGE" 18) ];
-        widgets = [ "qwen-edit" ];
+        widgets = [ (mkFilenamePrefix "qwen-edit") ];
       })
     ];
     links = [


### PR DESCRIPTION
出力ディレクトリ直下のファイル数が増えすぎて、
ワークフローごとのファイル名プレフィクス分けでは管理が限界になったため、
出力先を`ワークフロー名/ワークフロー名-生成日時_連番_.拡張子`へ変更します。

共通ビルダーに`mkFilenamePrefix`を追加して、
全ワークフローの保存ノードの`filename_prefix`を生成します。
日時プレースホルダにはフロントエンドの`%date:...%`ではなく、
サーバ側の`folder_paths.get_save_image_path`が置換する`%year%`系を使います。
`%date:...%`はフロントエンド拡張が標準保存ノードだけに適用する置換なので、
自作ノードの`SaveSvtAv1`には効かないためです。
サブディレクトリも同関数が自動作成します。

`standard.nix`の引数は内部でプレフィクスを組み立てるようになったため、
`filenamePrefix`から`name`へ改名します。
anime-video-upscaleのプレフィクスはエンコーダ情報が拡張子で分かるため、
`anime-upscale-svt-av1`からワークフロー名だけへ簡略化します。

コンテナにはホストのタイムゾーンが伝播せずUTCになってしまうため、
`time.timeZone`を明示して生成日時をJSTにします。
NixOSはホストの`/etc/localtime`を`/usr/share/zoneinfo`外へ向けるうえ、
コンテナ内に`/usr/share/zoneinfo`もないため、
systemd-nspawnのタイムゾーン同期(`--timezone=auto`)は機能しません。

bullet上では適用して以下の動作を確認済みです。

- コンテナ内の`date`がJSTを返すこと
- 既存出力507ファイルのプレフィクス別サブディレクトリへの移行
