### PR TITLE
feat(mcp): konokaのMCPサーバを直接設定します

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -291,6 +291,7 @@ in
           "mcp__plugin_claude-code-home-manager_backlog__get_wiki"
           "mcp__plugin_claude-code-home-manager_backlog__get_wiki_pages"
           "mcp__plugin_claude-code-home-manager_backlog__get_wikis_count"
+          "mcp__plugin_claude-code-home-manager_cloudflare"
           "mcp__plugin_claude-code-home-manager_context7"
           "mcp__plugin_claude-code-home-manager_deepwiki"
           "mcp__plugin_claude-code-home-manager_github__get_commit"
@@ -316,6 +317,9 @@ in
           "mcp__plugin_claude-code-home-manager_github__search_pull_requests"
           "mcp__plugin_claude-code-home-manager_github__search_repositories"
           "mcp__plugin_claude-code-home-manager_github__search_users"
+          "mcp__plugin_claude-code-home-manager_mdn"
+          "mcp__plugin_claude-code-home-manager_microsoft-learn"
+          "mcp__plugin_claude-code-home-manager_nixos"
           "mcp__plugin_nix-tasuke_nixos"
         ];
         ask = [

--- a/home/core/mcp.nix
+++ b/home/core/mcp.nix
@@ -18,6 +18,9 @@ in
           BACKLOG_DOMAIN.file = config.sops.secrets."backlog-mcp-server/domain".path;
         };
       };
+      cloudflare = {
+        url = "https://docs.mcp.cloudflare.com/mcp";
+      };
       context7 = {
         command = lib.getExe pkgs.context7-mcp;
       };
@@ -32,6 +35,15 @@ in
         env = {
           GITHUB_PERSONAL_ACCESS_TOKEN.file = config.sops.secrets."github-mcp-server/pat".path;
         };
+      };
+      mdn = {
+        url = "https://mcp.mdn.mozilla.net/";
+      };
+      microsoft-learn = {
+        url = "https://learn.microsoft.com/api/mcp";
+      };
+      nixos = {
+        url = "https://mcp-nixos.ncaq.net/mcp";
       };
     };
   };


### PR DESCRIPTION
OpenCodeはClaude Code形式のkonokaプラグインからMCP定義を読み込めないため、
以下のHTTP MCPサーバをHome Managerで設定します。

- Cloudflare
- MDN
- Microsoft Learn
- NixOS

Claude CodeではHome Manager由来の各MCPサーバを自動承認します。
NixOS MCPはkonokaプラグイン側の名前も引き続き許可し、
どちらの経路でも利用可能にします。
konoka由来の定義と重複しても実害は小さいため、
重複を許容します。
