### PR TITLE
fix(comfyui): ワークフローをGraph Modeで開きます

### DIFF
--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -81,7 +81,8 @@ let
       groups = [ ];
       config = { };
       extra = lib.optionalAttrs (app != null) {
-        linearMode = true;
+        # App Mode向けの入力定義は保持しつつ、通常はNode Graphで開く。
+        linearMode = false;
         linearData = app;
       };
       version = 0.4;


### PR DESCRIPTION
App Mode向けの入力定義は残したままにします。
PCでの通常利用時はNode Graphを初期表示します。
