### PR TITLE
feat: OpenCodeのデフォルトモデルをgpt-5.6-solに変更

### DIFF
--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -29,7 +29,7 @@
     settings = {
       # パッケージはNixで管理しているため自己アップデートは無効にします。
       autoupdate = false;
-      model = "github-copilot/gpt-5.6-terra";
+      model = "github-copilot/gpt-5.6-sol";
       small_model = "github-copilot/gpt-5-mini";
       lsp = true;
       permission.external_directory = {


### PR DESCRIPTION
圧倒的にSolの方が使うことが多かったため。
節約したいときだけTerraなどを使うことにします。
