### PR TITLE
feat(wake-on-lan): seminarからbulletを起動できるようにします

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,24 +200,35 @@
           ;
       };
 
-      hostDefs = {
-        "SSD0086" = mkNixosSystem {
+      # 各ホストの静的な情報。
+      # NixOSのoptionはホストの構成内で閉じていて他のホストからは参照できないため、
+      # 他のホストが知る必要のある情報はここに書いて、
+      # `specialArgs`の`hostInfo`として全ホストのモジュールに渡す。
+      hostInfo = {
+        "SSD0086" = {
           system = "x86_64-linux";
-          hostName = "SSD0086";
         };
-        "bullet" = mkNixosSystem {
+        "bullet" = {
           system = "x86_64-linux";
-          hostName = "bullet";
+          # オンボード有線NICのMACアドレス。
+          # seminarがWake-on-LANのmagic packetを送る宛先に使う。
+          macAddress = "34:5a:60:bf:07:ad";
         };
-        "creep" = mkNixosSystem {
+        "creep" = {
           system = "x86_64-linux";
-          hostName = "creep";
         };
-        "seminar" = mkNixosSystem {
+        "seminar" = {
           system = "x86_64-linux";
-          hostName = "seminar";
         };
       };
+
+      hostDefs = lib.mapAttrs (
+        hostName: info:
+        mkNixosSystem {
+          inherit (info) system;
+          inherit hostName hostInfo;
+        }
+      ) hostInfo;
 
       nixosConfigurations = lib.mapAttrs (_: def: def.nixosSystem) hostDefs;
 

--- a/lib/mk-nixos-system.nix
+++ b/lib/mk-nixos-system.nix
@@ -9,6 +9,7 @@
 {
   system,
   hostName,
+  hostInfo,
 }:
 let
   specialArgs = {
@@ -18,6 +19,7 @@ let
       inputs
 
       hostName
+      hostInfo
       ;
     username = "ncaq";
     pkgs-unstable = importPkgsUnstable system;

--- a/nixos/host/bullet/wake-on-lan.nix
+++ b/nixos/host/bullet/wake-on-lan.nix
@@ -1,0 +1,27 @@
+# bulletをWake-on-LANのmagic packetで起動できるようにする、受け取る側の設定です。
+# magic packetを送る側の設定はseminarにあります。
+#
+# NICのWoL設定はNetworkManagerの接続プロファイルで行います。
+# NixOSには`networking.interfaces.<name>.wakeOnLan`もありますが、
+# あれはsystemdの`.link`ファイルを生成するもので、
+# `.link`はデバイスに最初にマッチした1つだけが適用される仕様のため、
+# systemd標準の`99-default.link`が持つ`NamePolicy`を打ち消して、
+# NICの名前を変えてしまう危険があります。
+# NetworkManagerのプロファイルは宣言的に管理しているので、
+# そちらで有効化するほうが既存の管理方法とも一貫します。
+#
+# なおOS側の設定だけではシャットダウン状態から起動することはできません。
+# NICへ待機電力を供給するようにUEFIセットアップで設定する必要があります。
+# MSIのマザーボードでは概ね以下の項目が該当します。
+#
+# - `ErP Ready`を`Disabled`にして、電源オフ状態でもNICへ給電する
+# - `Resume By PCI-E Device`を`Enabled`にして、NICからの起床を許可する
+_: {
+  networking.networkmanager.ensureProfiles.profiles.basic-ethernet.ethernet = {
+    # NetworkManagerのkeyfileではフラグを数値で指定します。
+    # 64(0x40)は`magic`を意味し、magic packetを受信した時だけ起床します。
+    # ブロードキャストやunicastでも起床する設定にすると、
+    # 日常的なLANの通信で意図せず起きてしまいます。
+    wake-on-lan = 64;
+  };
+}

--- a/nixos/host/seminar/wake-on-lan.nix
+++ b/nixos/host/seminar/wake-on-lan.nix
@@ -1,0 +1,20 @@
+# LAN内のbulletをWake-on-LANで起動するコマンドを提供します。
+# magic packetを受け取る側の設定はbulletにあります。
+#
+# seminarは常時稼働していてtailnet経由でどこからでも入れるので、
+# 外出先からbulletを使いたい時はseminarにログインして`wake-bullet`を実行します。
+{ pkgs, hostInfo, ... }:
+let
+  wakeBullet = pkgs.writeShellApplication {
+    name = "wake-bullet";
+    runtimeInputs = [ pkgs.wakeonlan ];
+    # magic packetはブロードキャストのUDPパケットを投げるだけで応答は返りません。
+    # 実際に起動したかどうかは`ping bullet`などで確認します。
+    text = ''
+      wakeonlan ${hostInfo.bullet.macAddress}
+    '';
+  };
+in
+{
+  environment.systemPackages = [ wakeBullet ];
+}


### PR DESCRIPTION
bulletは常時稼働させていないので、
外出先から使いたくなった時に起動する手段がありませんでした。
seminarは常時稼働していてtailnet経由でどこからでも入れるため、
seminarにログインして`wake-bullet`を実行すればbulletが起きるようにします。

bullet側の受信設定はNetworkManagerの接続プロファイルで行います。
NixOSには`networking.interfaces.<name>.wakeOnLan`もありますが、
あれが生成するsystemdの`.link`ファイルは最初にマッチした1つだけが適用される仕様で、
systemd標準の`99-default.link`が持つ`NamePolicy`を打ち消してNICの名前を変えてしまう危険があります。
NetworkManagerのプロファイルは既に宣言的に管理しているので、
そちらで有効化するほうが一貫もします。

magic packetの宛先となるbulletのMACアドレスは`flake.nix`の`hostInfo`へ新設します。
NixOSのoptionはホストの構成内で閉じていて他のホストからは参照できないため、
seminarがbulletの情報を知る手段が`specialArgs`しかないからです。
あわせて`hostDefs`は`hostInfo`からの`lib.mapAttrs`にして、
ホスト名の重複した記述をなくします。

なおOS側の設定だけではシャットダウン状態から起動することはできず、
NICへ待機電力を供給するようにUEFIセットアップで設定する必要があります。
該当する項目は`nixos/host/bullet/wake-on-lan.nix`のコメントに残しました。

両ホストへ適用した上で、
電源を切ったbulletが`wake-bullet`の1回の実行で実際に起動することを確認済みです。
