### PR TITLE
feat(comfyui): ワークフローからLoRAを適用できるようにします

### DIFF
--- a/nixos/host/bullet/comfyui/workflow/anime-basic.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-basic.nix
@@ -44,7 +44,7 @@ in
           210
           46
         ];
-        order = 5;
+        order = 6;
         inputs = [
           (mkInput "samples" "LATENT" 7)
           (mkInput "vae" "VAE" 8)
@@ -62,7 +62,7 @@ in
           420
           470
         ];
-        order = 6;
+        order = 7;
         inputs = [ (mkInput "images" "IMAGE" 9) ];
         widgets = [ (mkFilenamePrefix name) ];
       })

--- a/nixos/host/bullet/comfyui/workflow/anime-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-edit.nix
@@ -57,7 +57,7 @@ in
           type = "LoadImage";
           pos = [
             (-40)
-            620
+            700
           ];
           size = [
             340

--- a/nixos/host/bullet/comfyui/workflow/anime-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-edit.nix
@@ -46,7 +46,7 @@ in
       promptNodes {
         # EmptyLatentImageの代わりにLoadImage+VAEEncodeからLATENTを供給する。
         withEmptyLatent = false;
-        samplerOrder = 5;
+        samplerOrder = 6;
         denoise = 0.5;
         # VAEEncodeへ。
         extraVaeLinks = [ 13 ];
@@ -57,13 +57,13 @@ in
           type = "LoadImage";
           pos = [
             (-40)
-            500
+            620
           ];
           size = [
             340
             314
           ];
-          order = 3;
+          order = 4;
           outputs = [
             (mkOutput "IMAGE" "IMAGE" [ 12 ])
             (mkOutput "MASK" "MASK" [ ])
@@ -84,7 +84,7 @@ in
             210
             46
           ];
-          order = 4;
+          order = 5;
           inputs = [
             (mkInput "pixels" "IMAGE" 12)
             (mkInput "vae" "VAE" 13)
@@ -102,7 +102,7 @@ in
             210
             46
           ];
-          order = 6;
+          order = 7;
           inputs = [
             (mkInput "samples" "LATENT" 7)
             (mkInput "vae" "VAE" 8)
@@ -120,7 +120,7 @@ in
             420
             470
           ];
-          order = 7;
+          order = 8;
           inputs = [ (mkInput "images" "IMAGE" 9) ];
           widgets = [ (mkFilenamePrefix name) ];
         })

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -125,7 +125,7 @@ in
         title = "low noiseモデル";
         pos = [
           1260
-          572
+          702
         ];
         size = [
           385
@@ -144,7 +144,7 @@ in
         title = "LoRA(low noise用)";
         pos = [
           1260
-          704
+          834
         ];
         order = 3;
         modelLink = 37;
@@ -194,6 +194,8 @@ in
         ];
         widgets = [ "wan_2.1_vae.safetensors" ];
       })
+      # 動画を読み込むとプレビューがここより下へ展開されて伸びる。
+      # その分の場所は`lib/overlap.nix`の`growHeights`が見込んで空けさせている。
       (mkNode {
         id = 9;
         type = "LoadVideo";
@@ -457,7 +459,7 @@ in
         type = "WanFirstLastFrameToVideo";
         pos = [
           1260
-          1320
+          1550
         ];
         size = [
           315
@@ -513,7 +515,7 @@ in
         title = "shift(high)";
         pos = [
           1260
-          1104
+          1334
         ];
         size = [
           315
@@ -530,7 +532,7 @@ in
         title = "shift(low)";
         pos = [
           1260
-          1212
+          1442
         ];
         size = [
           315

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -51,6 +51,7 @@ let
     mkNode
     mkInput
     mkOutput
+    mkLoraLoader
     mkAppInput
     mkAppInputWith
     mkWorkflow
@@ -105,61 +106,18 @@ in
         ];
       })
       # オプショナルなLoRA適用(high noise側)。
-      # 未指定ならMODELをそのまま素通しする。
-      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
       # Wan 2.2のLoRAはhigh/lowで別ファイルなので対応する側へ入れる。
       # WanのLoRAはUNETにだけ作用するのでCLIPは繋がない。
-      (mkNode {
+      (mkLoraLoader {
         id = 29;
-        type = "Lora Loader (LoraManager)";
         title = "LoRA(high noise用)";
         pos = [
           1260
           172
         ];
-        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
-        size = [
-          385
-          350
-        ];
         order = 1;
-        inputs = [
-          (mkInput "model" "MODEL" 36)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          {
-            name = "clip";
-            type = "CLIP";
-            shape = 7;
-            link = null;
-          }
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" [ 1 ])
-          (mkOutput "CLIP" "CLIP" [ ])
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 36;
+        modelLinks = [ 1 ];
       })
       (mkNode {
         id = 2;
@@ -181,56 +139,16 @@ in
         ];
       })
       # オプショナルなLoRA適用(low noise側)。
-      (mkNode {
+      (mkLoraLoader {
         id = 30;
-        type = "Lora Loader (LoraManager)";
         title = "LoRA(low noise用)";
         pos = [
           1260
           704
         ];
-        size = [
-          385
-          350
-        ];
         order = 3;
-        inputs = [
-          (mkInput "model" "MODEL" 37)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          {
-            name = "clip";
-            type = "CLIP";
-            shape = 7;
-            link = null;
-          }
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" [ 2 ])
-          (mkOutput "CLIP" "CLIP" [ ])
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 37;
+        modelLinks = [ 2 ];
       })
       (mkNode {
         id = 3;

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -98,10 +98,67 @@ in
           82
         ];
         order = 0;
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 1 ]) ];
+        outputs = [ (mkOutput "MODEL" "MODEL" [ 36 ]) ];
         widgets = [
           "wan2.2_i2v_A14b_high_noise_lightx2v_4step_720p_260412.safetensors"
           "default" # weight_dtype
+        ];
+      })
+      # オプショナルなLoRA適用(high noise側)。
+      # 未指定ならMODELをそのまま素通しする。
+      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
+      # Wan 2.2のLoRAはhigh/lowで別ファイルなので対応する側へ入れる。
+      # WanのLoRAはUNETにだけ作用するのでCLIPは繋がない。
+      (mkNode {
+        id = 29;
+        type = "Lora Loader (LoraManager)";
+        title = "LoRA(high noise用)";
+        pos = [
+          1260
+          172
+        ];
+        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+        size = [
+          385
+          350
+        ];
+        order = 1;
+        inputs = [
+          (mkInput "model" "MODEL" 36)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          {
+            name = "clip";
+            type = "CLIP";
+            shape = 7;
+            link = null;
+          }
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 1 ])
+          (mkOutput "CLIP" "CLIP" [ ])
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
+        ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
         ];
       })
       (mkNode {
@@ -110,17 +167,69 @@ in
         title = "low noiseモデル";
         pos = [
           1260
-          180
+          572
         ];
         size = [
           385
           82
         ];
-        order = 1;
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 2 ]) ];
+        order = 2;
+        outputs = [ (mkOutput "MODEL" "MODEL" [ 37 ]) ];
         widgets = [
           "wan2.2_i2v_A14b_low_noise_lightx2v_4step_720p_260412.safetensors"
           "default" # weight_dtype
+        ];
+      })
+      # オプショナルなLoRA適用(low noise側)。
+      (mkNode {
+        id = 30;
+        type = "Lora Loader (LoraManager)";
+        title = "LoRA(low noise用)";
+        pos = [
+          1260
+          704
+        ];
+        size = [
+          385
+          350
+        ];
+        order = 3;
+        inputs = [
+          (mkInput "model" "MODEL" 37)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          {
+            name = "clip";
+            type = "CLIP";
+            shape = 7;
+            link = null;
+          }
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 2 ])
+          (mkOutput "CLIP" "CLIP" [ ])
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
+        ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
         ];
       })
       (mkNode {
@@ -134,7 +243,7 @@ in
           385
           106
         ];
-        order = 2;
+        order = 4;
         outputs = [
           (mkOutput "CLIP" "CLIP" [
             3
@@ -158,7 +267,7 @@ in
           385
           58
         ];
-        order = 3;
+        order = 5;
         outputs = [
           (mkOutput "VAE" "VAE" [
             5
@@ -179,7 +288,7 @@ in
           340
           310
         ];
-        order = 4;
+        order = 6;
         outputs = [ (mkOutput "VIDEO" "VIDEO" [ 11 ]) ];
         widgets = [ "example.webm" ];
       })
@@ -198,7 +307,7 @@ in
           340
           314
         ];
-        order = 5;
+        order = 7;
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [ 34 ])
           (mkOutput "MASK" "MASK" [ ])
@@ -219,7 +328,7 @@ in
           240
           106
         ];
-        order = 6;
+        order = 8;
         inputs = [ (mkInput "video" "VIDEO" 11) ];
         outputs = [
           (mkOutput "images" "IMAGE" [
@@ -244,7 +353,7 @@ in
           315
           106
         ];
-        order = 7;
+        order = 9;
         inputs = [ (mkInput "image" "IMAGE" 12) ];
         outputs = [ (mkOutput "IMAGE" "IMAGE" [ 14 ]) ];
         widgets = [
@@ -267,7 +376,7 @@ in
           315
           130
         ];
-        order = 8;
+        order = 10;
         inputs = [ (mkInput "image" "IMAGE" 14) ];
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [
@@ -286,14 +395,14 @@ in
         id = 22;
         type = "GetImageSize";
         pos = [
-          1160
           800
+          960
         ];
         size = [
           240
           86
         ];
-        order = 9;
+        order = 11;
         inputs = [ (mkInput "image" "IMAGE" 16) ];
         outputs = [
           (mkOutput "width" "INT" [ 17 ])
@@ -315,7 +424,7 @@ in
           420
           200
         ];
-        order = 10;
+        order = 12;
         outputs = [ (mkOutput "english_text" "STRING" [ 19 ]) ];
         widgets = [ "カメラはゆっくりと近づく。キャラクターは穏やかに微笑み、髪と服が風に揺れる。" ];
       })
@@ -332,7 +441,7 @@ in
           340
           130
         ];
-        order = 11;
+        order = 13;
         inputs = [
           (
             mkInput "string_b" "STRING" 19
@@ -369,7 +478,7 @@ in
           340
           200
         ];
-        order = 12;
+        order = 14;
         inputs = [ (mkInput "source" "*" 21) ];
       })
       (mkNode {
@@ -384,7 +493,7 @@ in
           420
           160
         ];
-        order = 13;
+        order = 15;
         inputs = [
           (mkInput "clip" "CLIP" 3)
           (
@@ -413,7 +522,7 @@ in
           420
           160
         ];
-        order = 14;
+        order = 16;
         inputs = [ (mkInput "clip" "CLIP" 4) ];
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" [ 23 ]) ];
         widgets = [ negativePrompt ];
@@ -430,13 +539,13 @@ in
         type = "WanFirstLastFrameToVideo";
         pos = [
           1260
-          520
+          1320
         ];
         size = [
           315
           230
         ];
-        order = 15;
+        order = 17;
         inputs = [
           (mkInput "positive" "CONDITIONING" 22)
           (mkInput "negative" "CONDITIONING" 23)
@@ -486,13 +595,13 @@ in
         title = "shift(high)";
         pos = [
           1260
-          310
+          1104
         ];
         size = [
           315
           58
         ];
-        order = 16;
+        order = 18;
         inputs = [ (mkInput "model" "MODEL" 1) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 9 ]) ];
         widgets = [ 5 ]; # shift
@@ -503,13 +612,13 @@ in
         title = "shift(low)";
         pos = [
           1260
-          410
+          1212
         ];
         size = [
           315
           58
         ];
-        order = 17;
+        order = 19;
         inputs = [ (mkInput "model" "MODEL" 2) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 10 ]) ];
         widgets = [ 5 ]; # shift
@@ -527,7 +636,7 @@ in
           315
           334
         ];
-        order = 18;
+        order = 20;
         inputs = [
           (mkInput "model" "MODEL" 9)
           (mkInput "positive" "CONDITIONING" 24)
@@ -562,7 +671,7 @@ in
           315
           334
         ];
-        order = 19;
+        order = 21;
         inputs = [
           (mkInput "model" "MODEL" 10)
           (mkInput "positive" "CONDITIONING" 25)
@@ -594,7 +703,7 @@ in
           210
           46
         ];
-        order = 20;
+        order = 22;
         inputs = [
           (mkInput "samples" "LATENT" 30)
           (mkInput "vae" "VAE" 6)
@@ -616,7 +725,7 @@ in
           315
           106
         ];
-        order = 21;
+        order = 23;
         inputs = [ (mkInput "image" "IMAGE" 31) ];
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [
@@ -645,7 +754,7 @@ in
           420
           470
         ];
-        order = 22;
+        order = 24;
         inputs = [ (mkInput "images" "IMAGE" 35) ];
         widgets = [
           (mkFilenamePrefixWith name "-segment") # filename_prefix
@@ -666,7 +775,7 @@ in
           240
           78
         ];
-        order = 23;
+        order = 25;
         inputs = [
           (mkInput "images.image0" "IMAGE" 13)
           (mkInput "images.image1" "IMAGE" 32)
@@ -686,7 +795,7 @@ in
           420
           470
         ];
-        order = 24;
+        order = 26;
         inputs = [ (mkInput "images" "IMAGE" 33) ];
         widgets = [
           (mkFilenamePrefix name) # filename_prefix
@@ -697,16 +806,32 @@ in
     ];
     links = [
       [
+        36
         1
+        0
+        29
+        0
+        "MODEL"
+      ]
+      [
         1
+        29
         0
         7
         0
         "MODEL"
       ]
       [
+        37
         2
+        0
+        30
+        0
+        "MODEL"
+      ]
+      [
         2
+        30
         0
         8
         0

--- a/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-upscale.nix
@@ -50,6 +50,8 @@ in
       ];
     };
     nodes = [
+      # 動画を読み込むとプレビューがここより下へ展開されて伸びる。
+      # その分の場所は`lib/overlap.nix`の`growHeights`が見込んで空けさせている。
       (mkNode {
         id = 1;
         type = "LoadVideo";

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -123,7 +123,7 @@ in
         title = "low noiseモデル";
         pos = [
           1340
-          930
+          1060
         ];
         size = [
           385
@@ -142,7 +142,7 @@ in
         title = "LoRA(low noise用)";
         pos = [
           1340
-          1062
+          1192
         ];
         order = 3;
         modelLink = 39;
@@ -587,7 +587,7 @@ in
         title = "shift(high)";
         pos = [
           1340
-          572
+          702
         ];
         size = [
           315
@@ -604,7 +604,7 @@ in
         title = "shift(low)";
         pos = [
           1340
-          1462
+          1692
         ];
         size = [
           315
@@ -629,7 +629,7 @@ in
         title = "コンテキスト窓(high)";
         pos = [
           1340
-          680
+          810
         ];
         size = [
           330
@@ -656,7 +656,7 @@ in
         title = "コンテキスト窓(low)";
         pos = [
           1340
-          1570
+          1800
         ];
         size = [
           330

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -96,10 +96,67 @@ in
           82
         ];
         order = 0;
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 1 ]) ];
+        outputs = [ (mkOutput "MODEL" "MODEL" [ 38 ]) ];
         widgets = [
           "wan2.2_i2v_A14b_high_noise_lightx2v_4step_720p_260412.safetensors"
           "default" # weight_dtype
+        ];
+      })
+      # オプショナルなLoRA適用(high noise側)。
+      # 未指定ならMODELをそのまま素通しする。
+      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
+      # Wan 2.2のLoRAはhigh/lowで別ファイルなので対応する側へ入れる。
+      # WanのLoRAはUNETにだけ作用するのでCLIPは繋がない。
+      (mkNode {
+        id = 31;
+        type = "Lora Loader (LoraManager)";
+        title = "LoRA(high noise用)";
+        pos = [
+          1340
+          172
+        ];
+        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+        size = [
+          385
+          350
+        ];
+        order = 1;
+        inputs = [
+          (mkInput "model" "MODEL" 38)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          {
+            name = "clip";
+            type = "CLIP";
+            shape = 7;
+            link = null;
+          }
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 1 ])
+          (mkOutput "CLIP" "CLIP" [ ])
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
+        ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
         ];
       })
       (mkNode {
@@ -108,17 +165,69 @@ in
         title = "low noiseモデル";
         pos = [
           1340
-          740
+          930
         ];
         size = [
           385
           82
         ];
-        order = 1;
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 2 ]) ];
+        order = 2;
+        outputs = [ (mkOutput "MODEL" "MODEL" [ 39 ]) ];
         widgets = [
           "wan2.2_i2v_A14b_low_noise_lightx2v_4step_720p_260412.safetensors"
           "default" # weight_dtype
+        ];
+      })
+      # オプショナルなLoRA適用(low noise側)。
+      (mkNode {
+        id = 32;
+        type = "Lora Loader (LoraManager)";
+        title = "LoRA(low noise用)";
+        pos = [
+          1340
+          1062
+        ];
+        size = [
+          385
+          350
+        ];
+        order = 3;
+        inputs = [
+          (mkInput "model" "MODEL" 39)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          {
+            name = "clip";
+            type = "CLIP";
+            shape = 7;
+            link = null;
+          }
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 2 ])
+          (mkOutput "CLIP" "CLIP" [ ])
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
+        ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
         ];
       })
       (mkNode {
@@ -132,7 +241,7 @@ in
           385
           106
         ];
-        order = 2;
+        order = 4;
         outputs = [
           (mkOutput "CLIP" "CLIP" [
             3
@@ -156,7 +265,7 @@ in
           385
           58
         ];
-        order = 3;
+        order = 5;
         outputs = [
           (mkOutput "VAE" "VAE" [
             5
@@ -177,7 +286,7 @@ in
           340
           314
         ];
-        order = 4;
+        order = 6;
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [ 11 ])
           (mkOutput "MASK" "MASK" [ ])
@@ -202,7 +311,7 @@ in
           340
           314
         ];
-        order = 5;
+        order = 7;
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [ 37 ])
           (mkOutput "MASK" "MASK" [ ])
@@ -227,7 +336,7 @@ in
           315
           130
         ];
-        order = 6;
+        order = 8;
         inputs = [ (mkInput "image" "IMAGE" 11) ];
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [
@@ -253,7 +362,7 @@ in
           240
           86
         ];
-        order = 7;
+        order = 9;
         inputs = [ (mkInput "image" "IMAGE" 27) ];
         outputs = [
           (mkOutput "width" "INT" [ 28 ])
@@ -275,7 +384,7 @@ in
           460
           106
         ];
-        order = 8;
+        order = 10;
         outputs = [ (mkOutput "INT" "INT" [ 32 ]) ];
         widgets = [
           1 # value
@@ -299,7 +408,7 @@ in
           315
           106
         ];
-        order = 9;
+        order = 11;
         inputs = [
           (mkInput "values.a" "FLOAT,INT,BOOLEAN" 32)
           # autogrowの次の空きスロット。shape 7はoptionalの意味。
@@ -333,7 +442,7 @@ in
           315
           106
         ];
-        order = 10;
+        order = 12;
         inputs = [
           (mkInput "values.a" "FLOAT,INT,BOOLEAN" 35)
           # autogrowの次の空きスロット。shape 7はoptionalの意味。
@@ -366,7 +475,7 @@ in
           240
           106
         ];
-        order = 11;
+        order = 13;
         inputs = [ (mkInput "source" "*" 36) ];
       })
       # 動きの指示をここに書く。
@@ -383,7 +492,7 @@ in
           420
           200
         ];
-        order = 12;
+        order = 14;
         outputs = [ (mkOutput "english_text" "STRING" [ 23 ]) ];
         widgets = [ "カメラはゆっくりと近づく。キャラクターは穏やかに微笑み、髪と服が風に揺れる。" ];
       })
@@ -400,7 +509,7 @@ in
           340
           130
         ];
-        order = 13;
+        order = 15;
         inputs = [
           (
             mkInput "string_b" "STRING" 23
@@ -437,7 +546,7 @@ in
           340
           200
         ];
-        order = 14;
+        order = 16;
         inputs = [ (mkInput "source" "*" 25) ];
       })
       (mkNode {
@@ -452,7 +561,7 @@ in
           420
           160
         ];
-        order = 15;
+        order = 17;
         inputs = [
           (mkInput "clip" "CLIP" 3)
           (
@@ -481,7 +590,7 @@ in
           420
           160
         ];
-        order = 16;
+        order = 18;
         inputs = [ (mkInput "clip" "CLIP" 4) ];
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" [ 13 ]) ];
         widgets = [ negativePrompt ];
@@ -502,7 +611,7 @@ in
           315
           230
         ];
-        order = 17;
+        order = 19;
         inputs = [
           (mkInput "positive" "CONDITIONING" 12)
           (mkInput "negative" "CONDITIONING" 13)
@@ -560,13 +669,13 @@ in
         title = "shift(high)";
         pos = [
           1340
-          340
+          572
         ];
         size = [
           315
           58
         ];
-        order = 18;
+        order = 20;
         inputs = [ (mkInput "model" "MODEL" 1) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 9 ]) ];
         widgets = [ 5 ]; # shift
@@ -577,13 +686,13 @@ in
         title = "shift(low)";
         pos = [
           1340
-          1020
+          1462
         ];
         size = [
           315
           58
         ];
-        order = 19;
+        order = 21;
         inputs = [ (mkInput "model" "MODEL" 2) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 10 ]) ];
         widgets = [ 5 ]; # shift
@@ -602,13 +711,13 @@ in
         title = "コンテキスト窓(high)";
         pos = [
           1340
-          460
+          680
         ];
         size = [
           330
           200
         ];
-        order = 20;
+        order = 22;
         inputs = [ (mkInput "model" "MODEL" 9) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 33 ]) ];
         widgets = [
@@ -629,13 +738,13 @@ in
         title = "コンテキスト窓(low)";
         pos = [
           1340
-          1140
+          1570
         ];
         size = [
           330
           200
         ];
-        order = 21;
+        order = 23;
         inputs = [ (mkInput "model" "MODEL" 10) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 34 ]) ];
         widgets = [
@@ -663,7 +772,7 @@ in
           315
           334
         ];
-        order = 22;
+        order = 24;
         inputs = [
           (mkInput "model" "MODEL" 33)
           (mkInput "positive" "CONDITIONING" 14)
@@ -698,7 +807,7 @@ in
           315
           334
         ];
-        order = 23;
+        order = 25;
         inputs = [
           (mkInput "model" "MODEL" 34)
           (mkInput "positive" "CONDITIONING" 15)
@@ -730,7 +839,7 @@ in
           210
           46
         ];
-        order = 24;
+        order = 26;
         inputs = [
           (mkInput "samples" "LATENT" 20)
           (mkInput "vae" "VAE" 6)
@@ -749,7 +858,7 @@ in
           420
           470
         ];
-        order = 25;
+        order = 27;
         inputs = [ (mkInput "images" "IMAGE" 21) ];
         widgets = [
           (mkFilenamePrefix name) # filename_prefix
@@ -760,16 +869,32 @@ in
     ];
     links = [
       [
+        38
         1
+        0
+        31
+        0
+        "MODEL"
+      ]
+      [
         1
+        31
         0
         7
         0
         "MODEL"
       ]
       [
+        39
         2
+        0
+        32
+        0
+        "MODEL"
+      ]
+      [
         2
+        32
         0
         8
         0

--- a/nixos/host/bullet/comfyui/workflow/anime-video.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video.nix
@@ -52,6 +52,7 @@ let
     mkNode
     mkInput
     mkOutput
+    mkLoraLoader
     mkAppInput
     mkAppInputWith
     mkWorkflow
@@ -103,61 +104,18 @@ in
         ];
       })
       # オプショナルなLoRA適用(high noise側)。
-      # 未指定ならMODELをそのまま素通しする。
-      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
       # Wan 2.2のLoRAはhigh/lowで別ファイルなので対応する側へ入れる。
       # WanのLoRAはUNETにだけ作用するのでCLIPは繋がない。
-      (mkNode {
+      (mkLoraLoader {
         id = 31;
-        type = "Lora Loader (LoraManager)";
         title = "LoRA(high noise用)";
         pos = [
           1340
           172
         ];
-        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
-        size = [
-          385
-          350
-        ];
         order = 1;
-        inputs = [
-          (mkInput "model" "MODEL" 38)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          {
-            name = "clip";
-            type = "CLIP";
-            shape = 7;
-            link = null;
-          }
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" [ 1 ])
-          (mkOutput "CLIP" "CLIP" [ ])
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 38;
+        modelLinks = [ 1 ];
       })
       (mkNode {
         id = 2;
@@ -179,56 +137,16 @@ in
         ];
       })
       # オプショナルなLoRA適用(low noise側)。
-      (mkNode {
+      (mkLoraLoader {
         id = 32;
-        type = "Lora Loader (LoraManager)";
         title = "LoRA(low noise用)";
         pos = [
           1340
           1062
         ];
-        size = [
-          385
-          350
-        ];
         order = 3;
-        inputs = [
-          (mkInput "model" "MODEL" 39)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          {
-            name = "clip";
-            type = "CLIP";
-            shape = 7;
-            link = null;
-          }
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" [ 2 ])
-          (mkOutput "CLIP" "CLIP" [ ])
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 39;
+        modelLinks = [ 2 ];
       })
       (mkNode {
         id = 3;

--- a/nixos/host/bullet/comfyui/workflow/lib/builder-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder-test.nix
@@ -1,0 +1,106 @@
+# `mkLoraLoader`が生成するノードの形状を検証する。
+#
+# `Lora Loader (LoraManager)`は入力スロットの並びとウィジェットの並びが、
+# LoRA Manager側のノード定義と一致していないと、
+# 管理画面のSend to Workflowがこのノードを見つけられず動かなくなる。
+# 他のassertionはリンクやorderしか見ないため、
+# 綴りや並びが崩れてもビルドは通ってUIで開くまで気付けない。
+{ lib }:
+let
+  builder = import ./builder.nix { inherit lib; };
+  # CLIPも通す場合。
+  withClip = builder.mkLoraLoader {
+    id = 16;
+    pos = [
+      0
+      0
+    ];
+    order = 1;
+    modelLink = 28;
+    clipLink = 29;
+    modelLinks = [ 1 ];
+    clipLinks = [
+      2
+      3
+    ];
+  };
+  # UNETにだけ作用するLoRA向けにCLIPを繋がない場合。
+  withoutClip = builder.mkLoraLoader {
+    id = 31;
+    title = "LoRA(high noise用)";
+    pos = [
+      0
+      0
+    ];
+    order = 1;
+    modelLink = 38;
+    modelLinks = [ 1 ];
+  };
+  slotNames = map (slot: slot.name);
+  slotTypes = map (slot: slot.type);
+in
+assert lib.assertMsg (withClip.type == "Lora Loader (LoraManager)") "ノード型が想定と違います";
+assert lib.assertMsg (
+  slotNames withClip.inputs == [
+    "model"
+    "text"
+    "clip"
+    "lora_stack"
+  ]
+) "入力スロットの名前か並びが想定と違います";
+assert lib.assertMsg (
+  slotTypes withClip.inputs == [
+    "MODEL"
+    "AUTOCOMPLETE_TEXT_LORAS"
+    "CLIP"
+    "LORA_STACK"
+  ]
+) "入力スロットの型が想定と違います";
+assert lib.assertMsg (
+  slotNames withClip.outputs == [
+    "MODEL"
+    "CLIP"
+    "trigger_words"
+    "loaded_loras"
+  ]
+) "出力スロットの名前か並びが想定と違います";
+# LoRA一覧の内部状態、テキスト、有効なLoRAのリストの順。
+assert lib.assertMsg (
+  withClip.widgets_values == [
+    {
+      version = 1;
+      textWidgetName = "text";
+    }
+    ""
+    [ ]
+  ]
+) "ウィジェットの内容か並びが想定と違います";
+# textスロットはウィジェットと連動する入力なのでwidget属性が要る。
+assert lib.assertMsg (
+  (lib.elemAt withClip.inputs 1).widget.name == "text"
+) "textスロットのwidget名が想定と違います";
+# オプション入力はshape 7で描かれる。
+assert lib.assertMsg (
+  (lib.elemAt withClip.inputs 2).shape == 7 && (lib.elemAt withClip.inputs 3).shape == 7
+) "オプション入力のshapeが想定と違います";
+assert lib.assertMsg (
+  (lib.elemAt withClip.inputs 0).link == 28 && (lib.elemAt withClip.inputs 2).link == 29
+) "入力リンクが引数どおりに設定されていません";
+assert lib.assertMsg (
+  (lib.elemAt withClip.outputs 0).links == [ 1 ]
+  &&
+    (lib.elemAt withClip.outputs 1).links == [
+      2
+      3
+    ]
+) "出力リンクが引数どおりに設定されていません";
+# clipLink省略時もスロット自体は同じ並びで残し、リンクだけ未接続にする。
+assert lib.assertMsg (
+  slotNames withoutClip.inputs == slotNames withClip.inputs
+) "clipLink省略時に入力スロットの並びが変わりました";
+assert lib.assertMsg (
+  (lib.elemAt withoutClip.inputs 2).link == null && (lib.elemAt withoutClip.outputs 1).links == [ ]
+) "clipLink省略時にCLIPが未接続になっていません";
+assert lib.assertMsg (withoutClip.title == "LoRA(high noise用)") "titleが反映されていません";
+assert lib.assertMsg (!(withClip ? title)) "title未指定なのにtitleが付いています";
+true

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -112,6 +112,8 @@ let
         ;
       type = "Lora Loader (LoraManager)";
       # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+      # 実際の描画がこれを上回った場合の場所は、
+      # `lib/overlap.nix`の`growHeights`が見込んで空けさせている。
       size = [
         385
         350

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -85,9 +85,7 @@ let
   # 入力スロットの並びとウィジェットの並びはノード定義に一致させる必要があり、
   # 崩れるとSend to Workflowが動かなくなる。
   # UIで開くまで気付けないため、ここに一箇所だけ定義して`lib/builder-test.nix`で検証する。
-  # ウィジェットは順に、LoRA一覧を保持する内部状態、テキスト、有効なLoRAのリスト。
   #
-  # CLIPとlora_stackは`shape = 7`のオプション入力になっている。
   # UNETにだけ作用するLoRAを扱うワークフローでは、
   # `clipLink`を省略してCLIPを繋がずに使う。
   mkLoraLoader =
@@ -120,6 +118,8 @@ let
       ];
       inputs = [
         (mkInput "model" "MODEL" modelLink)
+        # textウィジェットに対応する入力スロット。
+        # ソケットへ繋がずウィジェットとして使うので`link`はnullのまま。
         {
           name = "text";
           type = "AUTOCOMPLETE_TEXT_LORAS";
@@ -128,7 +128,9 @@ let
           };
           link = null;
         }
+        # shape 7はoptionalの意味。
         ((mkInput "clip" "CLIP" clipLink) // { shape = 7; })
+        # 他のLoRAノードから積み上げる時だけ使うオプション入力。
         {
           name = "lora_stack";
           type = "LORA_STACK";
@@ -139,16 +141,20 @@ let
       outputs = [
         (mkOutput "MODEL" "MODEL" modelLinks)
         (mkOutput "CLIP" "CLIP" clipLinks)
+        # LoRAのトリガーワードと適用したLoRAの一覧を文字列で出す補助出力。
+        # プロンプトへ繋ぐ使い方があるが、ここでは使わないので未接続にする。
         (mkOutput "trigger_words" "STRING" [ ])
         (mkOutput "loaded_loras" "STRING" [ ])
       ];
       widgets = [
+        # __lm_autocomplete_meta_text
+        # (テキスト補完のメタデータ。対応するテキストウィジェット名を持つ隠しウィジェット)
         {
           version = 1;
           textWidgetName = "text";
         }
-        ""
-        [ ]
+        "" # text(`<lora:名前:強度>`形式のLoRA指定)
+        [ ] # loras(LoRAごとの名前と強度と有効状態のリスト。Send to Workflowが書き込む)
       ];
     };
   mkWorkflow =

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -77,6 +77,80 @@ let
     widgetName
     config
   ];
+  # LoRA Managerの`Lora Loader (LoraManager)`ノード。
+  # LoRAが未指定ならMODELとCLIPをそのまま素通しするので、
+  # 常に配線したままで良い。
+  # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
+  #
+  # 入力スロットの並びとウィジェットの並びはノード定義に一致させる必要があり、
+  # 崩れるとSend to Workflowが動かなくなる。
+  # UIで開くまで気付けないため、ここに一箇所だけ定義して`lib/builder-test.nix`で検証する。
+  # ウィジェットは順に、LoRA一覧を保持する内部状態、テキスト、有効なLoRAのリスト。
+  #
+  # CLIPとlora_stackは`shape = 7`のオプション入力になっている。
+  # UNETにだけ作用するLoRAを扱うワークフローでは、
+  # `clipLink`を省略してCLIPを繋がずに使う。
+  mkLoraLoader =
+    {
+      id,
+      pos,
+      order,
+      title ? null,
+      # MODEL入力へ繋ぐリンクID。
+      modelLink,
+      # CLIP入力へ繋ぐリンクID。nullならCLIPは未接続にする。
+      clipLink ? null,
+      # MODEL出力から出るリンクIDのリスト。
+      modelLinks,
+      # CLIP出力から出るリンクIDのリスト。
+      clipLinks ? [ ],
+    }:
+    mkNode {
+      inherit
+        id
+        pos
+        order
+        title
+        ;
+      type = "Lora Loader (LoraManager)";
+      # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+      size = [
+        385
+        350
+      ];
+      inputs = [
+        (mkInput "model" "MODEL" modelLink)
+        {
+          name = "text";
+          type = "AUTOCOMPLETE_TEXT_LORAS";
+          widget = {
+            name = "text";
+          };
+          link = null;
+        }
+        ((mkInput "clip" "CLIP" clipLink) // { shape = 7; })
+        {
+          name = "lora_stack";
+          type = "LORA_STACK";
+          shape = 7;
+          link = null;
+        }
+      ];
+      outputs = [
+        (mkOutput "MODEL" "MODEL" modelLinks)
+        (mkOutput "CLIP" "CLIP" clipLinks)
+        (mkOutput "trigger_words" "STRING" [ ])
+        (mkOutput "loaded_loras" "STRING" [ ])
+      ];
+      widgets = [
+        {
+          version = 1;
+          textWidgetName = "text";
+        }
+        ""
+        [ ]
+      ];
+    };
   mkWorkflow =
     {
       nodes,
@@ -150,59 +224,21 @@ let
         widgets = [ checkpoint ];
       })
       # オプショナルなLoRA適用。
-      # 未指定ならMODELとCLIPをそのまま素通しする。
-      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
-      (mkNode {
+      (mkLoraLoader {
         id = 16;
-        type = "Lora Loader (LoraManager)";
         pos = [
           (-40)
           200
         ];
-        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
-        size = [
-          385
-          350
-        ];
         order = 1;
-        inputs = [
-          (mkInput "model" "MODEL" 28)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          ((mkInput "clip" "CLIP" 29) // { shape = 7; })
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" ([ 1 ] ++ extraModelLinks))
-          (mkOutput "CLIP" "CLIP" (
-            [
-              2
-              3
-            ]
-            ++ extraClipLinks
-          ))
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 28;
+        clipLink = 29;
+        modelLinks = [ 1 ] ++ extraModelLinks;
+        clipLinks = [
+          2
+          3
+        ]
+        ++ extraClipLinks;
       })
       (mkNode {
         id = 2;
@@ -378,6 +414,7 @@ in
     mkNode
     mkInput
     mkOutput
+    mkLoraLoader
     mkAppInput
     mkAppInputWith
     mkWorkflow

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -186,8 +186,14 @@ let
   # 追加のリンクIDを引数で受け取る。
   # MODELとCLIPの追加リンクはLoRA適用後のLoraLoader(ノード16)から出る。
   #
-  # LoraLoaderのノードID 16とリンクID 28/29は、
-  # 呼び出し元が使うIDと衝突しない大きめの値を予約している。
+  # ここが使うのはノードID 1から5と16、
+  # リンクID 1から8(`withEmptyLatent = false`なら6を除く)と28/29なので、
+  # 呼び出し元はこれらを避けて番号を振る。
+  # LoraLoaderのノード16とリンク28/29には余裕がない。
+  # 最も多くのノードを使う`lib/standard.nix`はノード15とリンク27まで使い切っていて、
+  # これらはちょうど次の空き番号だからで、
+  # 呼び出し元がノードやリンクを1つ足すだけで自然に衝突する。
+  # 衝突した場合は`lib/duplicate.nix`の検証が評価時に検出する。
   #
   # img2imgのようにEmptyLatentImage以外からLATENTを供給する場合は、
   # `withEmptyLatent = false`にして、

--- a/nixos/host/bullet/comfyui/workflow/lib/builder.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/builder.nix
@@ -97,12 +97,17 @@ let
       version = 0.4;
     };
 
-  # checkpoint読み込みとプロンプトエンコードの共通部分。
+  # checkpoint読み込み、LoRA適用、プロンプトエンコードの共通部分。
   # どのワークフローも同じノードIDとリンクIDで始まる。
-  # リンク: 1=MODEL→KSampler, 2/3=CLIP→TextEncode,
+  # リンク: 28=MODEL→LoraLoader, 29=CLIP→LoraLoader,
+  # 1=MODEL→KSampler, 2/3=CLIP→TextEncode,
   # 4/5=CONDITIONING→KSampler, 6=LATENT→KSampler
   # 後段の構成によっては同じ出力を追加のノードにも繋ぐので、
   # 追加のリンクIDを引数で受け取る。
+  # MODELとCLIPの追加リンクはLoRA適用後のLoraLoader(ノード16)から出る。
+  #
+  # LoraLoaderのノードID 16とリンクID 28/29は、
+  # 呼び出し元が使うIDと衝突しない大きめの値を予約している。
   #
   # img2imgのようにEmptyLatentImage以外からLATENTを供給する場合は、
   # `withEmptyLatent = false`にして、
@@ -117,7 +122,7 @@ let
       denoise ? 1,
       # withEmptyLatent = falseで代替ノードを複数挟む場合に、
       # KSamplerのorderを後ろへずらすための値。
-      samplerOrder ? 4,
+      samplerOrder ? 5,
       extraModelLinks ? [ ],
       extraClipLinks ? [ ],
       extraVaeLinks ? [ ],
@@ -130,13 +135,54 @@ let
         type = "CheckpointLoaderSimple";
         pos = [
           (-40)
-          200
+          20
         ];
         size = [
           385
           98
         ];
         order = 0;
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 28 ])
+          (mkOutput "CLIP" "CLIP" [ 29 ])
+          (mkOutput "VAE" "VAE" ([ 8 ] ++ extraVaeLinks))
+        ];
+        widgets = [ checkpoint ];
+      })
+      # オプショナルなLoRA適用。
+      # 未指定ならMODELとCLIPをそのまま素通しする。
+      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
+      (mkNode {
+        id = 16;
+        type = "Lora Loader (LoraManager)";
+        pos = [
+          (-40)
+          200
+        ];
+        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+        size = [
+          385
+          350
+        ];
+        order = 1;
+        inputs = [
+          (mkInput "model" "MODEL" 28)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          ((mkInput "clip" "CLIP" 29) // { shape = 7; })
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
         outputs = [
           (mkOutput "MODEL" "MODEL" ([ 1 ] ++ extraModelLinks))
           (mkOutput "CLIP" "CLIP" (
@@ -146,9 +192,17 @@ let
             ]
             ++ extraClipLinks
           ))
-          (mkOutput "VAE" "VAE" ([ 8 ] ++ extraVaeLinks))
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
         ];
-        widgets = [ checkpoint ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
+        ];
       })
       (mkNode {
         id = 2;
@@ -161,7 +215,7 @@ let
           420
           160
         ];
-        order = 1;
+        order = 2;
         inputs = [ (mkInput "clip" "CLIP" 2) ];
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" ([ 4 ] ++ extraPositiveLinks)) ];
         widgets = [ positivePrompt ];
@@ -177,7 +231,7 @@ let
           420
           160
         ];
-        order = 2;
+        order = 3;
         inputs = [ (mkInput "clip" "CLIP" 3) ];
         outputs = [ (mkOutput "CONDITIONING" "CONDITIONING" ([ 5 ] ++ extraNegativeLinks)) ];
         widgets = [ negativePrompt ];
@@ -194,7 +248,7 @@ let
         315
         106
       ];
-      order = 3;
+      order = 4;
       outputs = [ (mkOutput "LATENT" "LATENT" [ 6 ]) ];
       widgets = [
         width
@@ -236,8 +290,24 @@ let
   # 代替のLATENT源からリンク6を自前で張る。
   promptBaseLinks = [
     [
+      28
+      1
+      0
+      16
+      0
+      "MODEL"
+    ]
+    [
+      29
       1
       1
+      16
+      2
+      "CLIP"
+    ]
+    [
+      1
+      16
       0
       5
       0
@@ -245,7 +315,7 @@ let
     ]
     [
       2
-      1
+      16
       1
       2
       0
@@ -253,7 +323,7 @@ let
     ]
     [
       3
-      1
+      16
       1
       3
       0

--- a/nixos/host/bullet/comfyui/workflow/lib/duplicate-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/duplicate-test.nix
@@ -1,0 +1,48 @@
+{ lib }:
+let
+  duplicate = import ./duplicate.nix { inherit lib; };
+  validWorkflow = {
+    nodes = [
+      {
+        id = 1;
+        type = "TestNode";
+      }
+      {
+        id = 2;
+        type = "TestNode";
+      }
+    ];
+    links = [
+      [
+        1
+        1
+        0
+        2
+        0
+        "TEST"
+      ]
+      [
+        2
+        1
+        1
+        2
+        1
+        "TEST"
+      ]
+    ];
+  };
+  duplicatedNodeWorkflow = validWorkflow // {
+    nodes = map (node: if node.id == 2 then node // { id = 1; } else node) validWorkflow.nodes;
+  };
+  duplicatedLinkWorkflow = validWorkflow // {
+    links = map (link: [ 1 ] ++ lib.tail link) validWorkflow.links;
+  };
+in
+assert lib.assertMsg (duplicate.duplicateIdErrors validWorkflow == [ ]) "重複のないワークフローを拒否しました";
+assert lib.assertMsg (
+  duplicate.duplicateIdErrors duplicatedNodeWorkflow != [ ]
+) "重複したノードIDを検出できませんでした";
+assert lib.assertMsg (
+  duplicate.duplicateIdErrors duplicatedLinkWorkflow != [ ]
+) "重複したリンクIDを検出できませんでした";
+true

--- a/nixos/host/bullet/comfyui/workflow/lib/duplicate.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/duplicate.nix
@@ -1,0 +1,36 @@
+# ワークフローのノードIDとリンクIDの重複の検証。
+#
+# IDが重複してもリンクの参照検証は素通りする。
+# `lib/link.nix`の探索が`lib.findFirst`で先頭だけを返すため、
+# 後から同じIDを振ったノードやリンクは存在しないのと同じ扱いになり、
+# 参照は先頭のものへ解決されて整合しているように見えてしまう。
+# `mkWorkflow`の`last_node_id`と`last_link_id`も最大値から算出するので、
+# 重複したままUIで開くとノードやリンクの追加時にIDが衝突する。
+#
+# `lib/builder.nix`の`promptNodes`のように、
+# 呼び出し元と共有部品でIDの割り当てを分担している構造では、
+# 片方が使う範囲を広げた時に静かに衝突するため機械的に検出する。
+{ lib }:
+{
+  # ノードIDとリンクIDの重複のメッセージのリストを返す。
+  # 問題がなければ空リスト。
+  duplicateIdErrors =
+    workflow:
+    let
+      label = node: node.title or node.type;
+      describeNode = node: "${toString node.id}(${label node})";
+      # 重複しているIDごとに、そのIDを持つ要素をまとめて返す。
+      duplicatedBy =
+        id: items:
+        lib.filterAttrs (_: duplicated: 1 < builtins.length duplicated) (
+          lib.groupBy (item: toString (id item)) items
+        );
+      nodeErrors = lib.mapAttrsToList (
+        id: nodes: "  ノードID=${id}がノード${lib.concatMapStringsSep ", " describeNode nodes}で重複しています"
+      ) (duplicatedBy (node: node.id) workflow.nodes);
+      linkErrors = lib.mapAttrsToList (
+        id: links: "  リンクID=${id}が${toString (builtins.length links)}本のリンクで重複しています"
+      ) (duplicatedBy lib.head workflow.links);
+    in
+    nodeErrors ++ linkErrors;
+}

--- a/nixos/host/bullet/comfyui/workflow/lib/overlap-test.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/overlap-test.nix
@@ -40,7 +40,57 @@ let
     else
       node
   ) validNodes;
+  # 実行時に下へ広がるノードの真下に、宣言サイズ基準では重ならないノードを置いた配置。
+  # 広がりを見込まなければ余白があるように見えてしまう。
+  growingType = "LoadVideo";
+  growHeight = overlap.growHeights.${growingType};
+  belowGrowingNodes = [
+    {
+      id = 1;
+      type = growingType;
+      pos = [
+        0
+        0
+      ];
+      size = [
+        100
+        100
+      ];
+    }
+    {
+      id = 2;
+      type = "TestNode";
+      pos = [
+        0
+        (100 + overlap.titleHeight + overlap.margin)
+      ];
+      size = [
+        100
+        100
+      ];
+    }
+  ];
+  # 広がりの分まで空けた配置。
+  clearOfGrowingNodes = map (
+    node:
+    if node.id == 2 then
+      node
+      // {
+        pos = [
+          0
+          (100 + overlap.titleHeight + overlap.margin + growHeight)
+        ];
+      }
+    else
+      node
+  ) belowGrowingNodes;
 in
 assert lib.assertMsg (overlap.overlappingNodePairs validNodes == [ ]) "重なっていないノードを拒否しました";
 assert lib.assertMsg (overlap.overlappingNodePairs overlappingNodes != [ ]) "重なったノードを検出できませんでした";
+assert lib.assertMsg (
+  overlap.overlappingNodePairs belowGrowingNodes != [ ]
+) "下へ広がるノードの真下のノードを検出できませんでした";
+assert lib.assertMsg (
+  overlap.overlappingNodePairs clearOfGrowingNodes == [ ]
+) "下へ広がる分を空けた配置を拒否しました";
 true

--- a/nixos/host/bullet/comfyui/workflow/lib/overlap.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/overlap.nix
@@ -12,6 +12,26 @@ rec {
   # ノード間に最低限確保する余白。
   margin = 10;
 
+  # 宣言した`size`より下へ広がるノード種別と、その追加分の高さ。
+  #
+  # `size`はワークフローを開いた直後の寸法でしかなく、
+  # フロントエンドが中身に応じてノードを下へ広げることがある。
+  # 広がった状態は保存されないので`size`からは分からず、
+  # 実際に使い始めてから初めて下のノードと重なる。
+  # そのため重なり検出では最初からこの分も占有しているものとして扱い、
+  # 下に別のノードを置けないようにする。
+  growHeights = {
+    # 動画を読み込むとプレビューがノードの下へ展開されて伸びる。
+    # プレビューはノード幅いっぱいに元動画のアスペクト比で描かれるので、
+    # 幅340のノードに縦長(2:3)の動画を読み込んだ場合の高さを見込む。
+    LoadVideo = 500;
+    # LoRA一覧の領域はフロントエンドが最小の高さを確保する。
+    # LoRAを増やしても一覧の中がスクロールするだけでノードは伸びないが、
+    # 確保される最小の高さは宣言した350より大きくなり得るため余裕を持たせる。
+    "Lora Loader (LoraManager)" = 100;
+  };
+  growHeight = node: growHeights.${node.type} or 0;
+
   # ノードのリストから重なっているペア{a, b}のリストを返す。
   # aとbは{id, label, x0, y0, x1, y1}の矩形情報。
   overlappingNodePairs =
@@ -23,7 +43,7 @@ rec {
         x0 = builtins.elemAt node.pos 0;
         y0 = builtins.elemAt node.pos 1;
         x1 = x0 + builtins.elemAt node.size 0;
-        y1 = y0 + builtins.elemAt node.size 1 + titleHeight;
+        y1 = y0 + builtins.elemAt node.size 1 + titleHeight + growHeight node;
       };
       intersects =
         a: b: a.x0 < b.x1 + margin && b.x0 < a.x1 + margin && a.y0 < b.y1 + margin && b.y0 < a.y1 + margin;

--- a/nixos/host/bullet/comfyui/workflow/lib/standard.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/standard.nix
@@ -84,7 +84,7 @@ mkWorkflow {
           210
           46
         ];
-        order = 7;
+        order = 8;
         inputs = [
           (mkInput "samples" "LATENT" 7)
           (mkInput "vae" "VAE" 8)
@@ -102,7 +102,7 @@ mkWorkflow {
           315
           58
         ];
-        order = 5;
+        order = 6;
         outputs = [ (mkOutput "UPSCALE_MODEL" "UPSCALE_MODEL" [ 9 ]) ];
         widgets = [ "4x-AnimeSharp.safetensors" ];
       })
@@ -117,7 +117,7 @@ mkWorkflow {
           240
           46
         ];
-        order = 8;
+        order = 9;
         inputs = [
           (mkInput "upscale_model" "UPSCALE_MODEL" 9)
           (mkInput "image" "IMAGE" 10)
@@ -137,7 +137,7 @@ mkWorkflow {
           315
           82
         ];
-        order = 9;
+        order = 10;
         inputs = [ (mkInput "image" "IMAGE" 11) ];
         outputs = [ (mkOutput "IMAGE" "IMAGE" [ 12 ]) ];
         widgets = [
@@ -156,7 +156,7 @@ mkWorkflow {
           210
           46
         ];
-        order = 10;
+        order = 11;
         inputs = [
           (mkInput "pixels" "IMAGE" 12)
           (mkInput "vae" "VAE" 13)
@@ -175,7 +175,7 @@ mkWorkflow {
           315
           262
         ];
-        order = 11;
+        order = 12;
         inputs = [
           (mkInput "model" "MODEL" 14)
           (mkInput "positive" "CONDITIONING" 15)
@@ -202,7 +202,7 @@ mkWorkflow {
           210
           46
         ];
-        order = 12;
+        order = 13;
         inputs = [
           (mkInput "samples" "LATENT" 18)
           (mkInput "vae" "VAE" 19)
@@ -220,7 +220,7 @@ mkWorkflow {
           315
           78
         ];
-        order = 6;
+        order = 7;
         outputs = [
           (mkOutput "BBOX_DETECTOR" "BBOX_DETECTOR" [ 26 ])
           (mkOutput "SEGM_DETECTOR" "SEGM_DETECTOR" [ ])
@@ -238,7 +238,7 @@ mkWorkflow {
           400
           800
         ];
-        order = 13;
+        order = 14;
         inputs = [
           (mkInput "image" "IMAGE" 20)
           (mkInput "model" "MODEL" 21)
@@ -300,7 +300,7 @@ mkWorkflow {
           420
           470
         ];
-        order = 14;
+        order = 15;
         inputs = [ (mkInput "images" "IMAGE" 27) ];
         widgets = [ (mkFilenamePrefix name) ];
       })
@@ -348,7 +348,7 @@ mkWorkflow {
     ]
     [
       14
-      1
+      16
       0
       11
       0
@@ -404,7 +404,7 @@ mkWorkflow {
     ]
     [
       21
-      1
+      16
       0
       14
       1
@@ -412,7 +412,7 @@ mkWorkflow {
     ]
     [
       22
-      1
+      16
       1
       14
       2

--- a/nixos/host/bullet/comfyui/workflow/lib/standard.nix
+++ b/nixos/host/bullet/comfyui/workflow/lib/standard.nix
@@ -8,6 +8,12 @@
 #
 # FaceDetailerの`widgets_values`の並びは、
 # ComfyUI-Impact-Pack 8.28の定義に合わせている。
+#
+# `promptNodes`が使うノード1から5と16、
+# リンク1から8と28/29は避けて番号を振る必要がある。
+# ここはノード15とリンク27まで使っていて、
+# 次の空き番号が`promptNodes`のLoraLoaderに当たるため、
+# ノードやリンクを足す時は16と28/29を飛ばして17と30から振る。
 {
   lib,
   width,

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -79,7 +79,7 @@ in
         type = "CLIPLoader";
         pos = [
           (-40)
-          640
+          700
         ];
         size = [
           385
@@ -103,7 +103,7 @@ in
         type = "VAELoader";
         pos = [
           (-40)
-          800
+          860
         ];
         size = [
           385
@@ -126,7 +126,7 @@ in
         title = "編集する画像";
         pos = [
           (-40)
-          920
+          980
         ];
         size = [
           340

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -55,10 +55,65 @@ in
           82
         ];
         order = 0;
-        outputs = [ (mkOutput "MODEL" "MODEL" [ 1 ]) ];
+        outputs = [ (mkOutput "MODEL" "MODEL" [ 21 ]) ];
         widgets = [
           "qwen_image_edit_2511_fp8mixed.safetensors"
           "default" # weight_dtype
+        ];
+      })
+      # オプショナルなLoRA適用。
+      # 未指定ならMODELをそのまま素通しする。
+      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
+      # Qwen系のLoRAはUNETにだけ作用するのでCLIPは繋がない。
+      (mkNode {
+        id = 16;
+        type = "Lora Loader (LoraManager)";
+        pos = [
+          (-40)
+          200
+        ];
+        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
+        size = [
+          385
+          350
+        ];
+        order = 1;
+        inputs = [
+          (mkInput "model" "MODEL" 21)
+          {
+            name = "text";
+            type = "AUTOCOMPLETE_TEXT_LORAS";
+            widget = {
+              name = "text";
+            };
+            link = null;
+          }
+          {
+            name = "clip";
+            type = "CLIP";
+            shape = 7;
+            link = null;
+          }
+          {
+            name = "lora_stack";
+            type = "LORA_STACK";
+            shape = 7;
+            link = null;
+          }
+        ];
+        outputs = [
+          (mkOutput "MODEL" "MODEL" [ 1 ])
+          (mkOutput "CLIP" "CLIP" [ ])
+          (mkOutput "trigger_words" "STRING" [ ])
+          (mkOutput "loaded_loras" "STRING" [ ])
+        ];
+        widgets = [
+          {
+            version = 1;
+            textWidgetName = "text";
+          }
+          ""
+          [ ]
         ];
       })
       (mkNode {
@@ -66,13 +121,13 @@ in
         type = "CLIPLoader";
         pos = [
           (-40)
-          200
+          640
         ];
         size = [
           385
           106
         ];
-        order = 1;
+        order = 2;
         outputs = [
           (mkOutput "CLIP" "CLIP" [
             2
@@ -90,13 +145,13 @@ in
         type = "VAELoader";
         pos = [
           (-40)
-          360
+          800
         ];
         size = [
           385
           58
         ];
-        order = 2;
+        order = 3;
         outputs = [
           (mkOutput "VAE" "VAE" [
             4
@@ -113,13 +168,13 @@ in
         title = "編集する画像";
         pos = [
           (-40)
-          480
+          920
         ];
         size = [
           340
           314
         ];
-        order = 3;
+        order = 4;
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [ 8 ])
           (mkOutput "MASK" "MASK" [ ])
@@ -141,7 +196,7 @@ in
           240
           46
         ];
-        order = 4;
+        order = 5;
         inputs = [ (mkInput "image" "IMAGE" 8) ];
         outputs = [
           (mkOutput "IMAGE" "IMAGE" [
@@ -165,7 +220,7 @@ in
           420
           200
         ];
-        order = 5;
+        order = 6;
         outputs = [
           (mkOutput "english_text" "STRING" [
             19
@@ -188,7 +243,7 @@ in
           340
           200
         ];
-        order = 6;
+        order = 7;
         inputs = [ (mkInput "source" "*" 20) ];
       })
       # 編集指示。画像を参照しながら指示文をエンコードする。
@@ -206,7 +261,7 @@ in
           420
           200
         ];
-        order = 7;
+        order = 8;
         inputs = [
           (mkInput "clip" "CLIP" 2)
           (mkInput "vae" "VAE" 4)
@@ -236,7 +291,7 @@ in
           420
           160
         ];
-        order = 8;
+        order = 9;
         inputs = [
           (mkInput "clip" "CLIP" 3)
           (mkInput "vae" "VAE" 5)
@@ -256,7 +311,7 @@ in
           315
           58
         ];
-        order = 9;
+        order = 10;
         inputs = [ (mkInput "model" "MODEL" 1) ];
         outputs = [ (mkOutput "MODEL" "MODEL" [ 14 ]) ];
         widgets = [ 3.1 ]; # shift
@@ -272,7 +327,7 @@ in
           315
           82
         ];
-        order = 10;
+        order = 11;
         inputs = [ (mkInput "model" "MODEL" 14) ];
         outputs = [ (mkOutput "patched_model" "MODEL" [ 15 ]) ];
         widgets = [
@@ -291,7 +346,7 @@ in
           210
           46
         ];
-        order = 11;
+        order = 12;
         inputs = [
           (mkInput "pixels" "IMAGE" 11)
           (mkInput "vae" "VAE" 6)
@@ -309,7 +364,7 @@ in
           315
           262
         ];
-        order = 12;
+        order = 13;
         inputs = [
           (mkInput "model" "MODEL" 15)
           (mkInput "positive" "CONDITIONING" 12)
@@ -336,7 +391,7 @@ in
           210
           46
         ];
-        order = 13;
+        order = 14;
         inputs = [
           (mkInput "samples" "LATENT" 17)
           (mkInput "vae" "VAE" 7)
@@ -354,15 +409,23 @@ in
           420
           470
         ];
-        order = 14;
+        order = 15;
         inputs = [ (mkInput "images" "IMAGE" 18) ];
         widgets = [ (mkFilenamePrefix name) ];
       })
     ];
     links = [
       [
+        21
         1
+        0
+        16
+        0
+        "MODEL"
+      ]
+      [
         1
+        16
         0
         8
         0

--- a/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
+++ b/nixos/host/bullet/comfyui/workflow/qwen-edit.nix
@@ -22,6 +22,7 @@ let
     mkNode
     mkInput
     mkOutput
+    mkLoraLoader
     mkAppInput
     mkAppInputWith
     mkWorkflow
@@ -62,59 +63,16 @@ in
         ];
       })
       # オプショナルなLoRA適用。
-      # 未指定ならMODELをそのまま素通しする。
-      # LoRA Managerの管理画面のSend to Workflowがこのノードへ流し込む。
       # Qwen系のLoRAはUNETにだけ作用するのでCLIPは繋がない。
-      (mkNode {
+      (mkLoraLoader {
         id = 16;
-        type = "Lora Loader (LoraManager)";
         pos = [
           (-40)
           200
         ];
-        # フロントエンドがLoRA一覧の領域を確保するため最低でもこの程度の高さで描画される。
-        size = [
-          385
-          350
-        ];
         order = 1;
-        inputs = [
-          (mkInput "model" "MODEL" 21)
-          {
-            name = "text";
-            type = "AUTOCOMPLETE_TEXT_LORAS";
-            widget = {
-              name = "text";
-            };
-            link = null;
-          }
-          {
-            name = "clip";
-            type = "CLIP";
-            shape = 7;
-            link = null;
-          }
-          {
-            name = "lora_stack";
-            type = "LORA_STACK";
-            shape = 7;
-            link = null;
-          }
-        ];
-        outputs = [
-          (mkOutput "MODEL" "MODEL" [ 1 ])
-          (mkOutput "CLIP" "CLIP" [ ])
-          (mkOutput "trigger_words" "STRING" [ ])
-          (mkOutput "loaded_loras" "STRING" [ ])
-        ];
-        widgets = [
-          {
-            version = 1;
-            textWidgetName = "text";
-          }
-          ""
-          [ ]
-        ];
+        modelLink = 21;
+        modelLinks = [ 1 ];
       })
       (mkNode {
         id = 2;

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -8,6 +8,7 @@
 # ワークフローを追加するだけで自動的に検証対象になる。
 { config, lib, ... }:
 let
+  builderTest = import ./lib/builder-test.nix { inherit lib; };
   link = import ./lib/link.nix { inherit lib; };
   linkTest = import ./lib/link-test.nix { inherit lib; };
   order = import ./lib/order.nix { inherit lib; };
@@ -32,6 +33,7 @@ let
     ) config.local.comfyui.models
   );
 in
+assert builderTest;
 assert linkTest;
 assert orderTest;
 assert overlapTest;

--- a/nixos/host/bullet/comfyui/workflow/validate.nix
+++ b/nixos/host/bullet/comfyui/workflow/validate.nix
@@ -1,6 +1,7 @@
 # 宣言された全ワークフローの構造とレイアウトを評価時に検証する。
 #
 # 存在しないノードへのリンクやノードの重なり、
+# ノードIDやリンクIDの重複、
 # 実行順(`order`)の重複や依存への逆行はUIで開くまで気付きにくく、
 # ノードを追加するたびに手動検証が漏れて何度も再発したため、
 # NixOSのassertionsで機械的に検出する。
@@ -9,6 +10,8 @@
 { config, lib, ... }:
 let
   builderTest = import ./lib/builder-test.nix { inherit lib; };
+  duplicate = import ./lib/duplicate.nix { inherit lib; };
+  duplicateTest = import ./lib/duplicate-test.nix { inherit lib; };
   link = import ./lib/link.nix { inherit lib; };
   linkTest = import ./lib/link-test.nix { inherit lib; };
   order = import ./lib/order.nix { inherit lib; };
@@ -34,6 +37,7 @@ let
   );
 in
 assert builderTest;
+assert duplicateTest;
 assert linkTest;
 assert orderTest;
 assert overlapTest;
@@ -42,6 +46,7 @@ assert overlapTest;
     lib.mapAttrsToList (
       name: workflow:
       let
+        duplicateIdErrors = duplicate.duplicateIdErrors workflow;
         linkErrors = link.invalidReferences workflow;
         orderErrors = order.orderErrors workflow;
         overlappingNodePairs = overlap.overlappingNodePairs workflow.nodes;
@@ -61,6 +66,13 @@ assert overlapTest;
         missingModels = lib.filter (model: !(lib.elem model modelNames)) referencedModels;
       in
       [
+        {
+          assertion = duplicateIdErrors == [ ];
+          message = ''
+            ComfyUIワークフロー${name}で以下のIDが重複しています:
+            ${lib.concatStringsSep "\n" duplicateIdErrors}
+          '';
+        }
         {
           assertion = linkErrors == [ ];
           message = ''


### PR DESCRIPTION
LoRA Managerの管理画面から取得したLoRAを既存ワークフローへ送っても、
適用先となるローダーノードがなかったため生成処理へ反映できませんでした。

共通の画像生成ワークフローとQwen画像編集に、
MODELと必要に応じてCLIPへ適用するLoRA Loaderを追加します。
未指定時は入力をそのまま通すため、
従来の生成結果を維持します。

Wan 2.2動画生成ではLoRAがhigh noise用とlow noise用に分かれるため、
各UNETの直後へ個別のローダーを配置します。