### PR TITLE
feat(claude-code): デフォルトモデルをOpusに変更

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -30,9 +30,9 @@ in
       # 常にフルの表示を要求します。
       verbose = true;
       # 頻繁に最適な値が変わるので設定するその時に最適なものを選びます。
-      model = "fable";
+      model = "opus"; # Opusで十分賢いのでデフォルトではfableより安いモデルを使います。
       fallbackModel = [
-        "opus"
+        "fable"
         "sonnet"
       ];
       # メッセージにCo-Authored-Byフッターを付与しません。


### PR DESCRIPTION
Opus 5がリリースされて、
Fable 5に迫る性能だったため、
リミットまでの消費を抑えるために、
デフォルトではOpusの方を使い、
使用量を抑えます。
長時間のタスクなどを行う場合などは適時Fableに切り替えます。
