### PR TITLE
fix(claude-code): `opus`を`opus[1m]`に修正

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -30,7 +30,7 @@ in
       # 常にフルの表示を要求します。
       verbose = true;
       # 頻繁に最適な値が変わるので設定するその時に最適なものを選びます。
-      model = "opus"; # Opusで十分賢いのでデフォルトではfableより安いモデルを使います。
+      model = "opus[1m]"; # Opusのクラスで十分賢いのでデフォルトではfableより安いモデルを使います。
       fallbackModel = [
         "fable"
         "sonnet"


### PR DESCRIPTION
Maxプランだと自動的になるとどこかで見たけれど、
Claude Codeの区分だと異なるみたいなので修正。
