### PR TITLE
perf(creep): バッテリー駆動時の消費電力を抑えます

### DIFF
--- a/nixos/host/creep/bees.nix
+++ b/nixos/host/creep/bees.nix
@@ -1,3 +1,7 @@
+{ pkgs, ... }:
+let
+  beesUnit = "beesd@root.service";
+in
 {
   # btrfsの重複排除デーモン。
   # 上流のsystemdユニットがNice=19とIOSchedulingClass=idleを設定しているため、
@@ -21,4 +25,14 @@
       "3.0"
     ];
   };
+  # 重複排除はそこまで急ぎの処理ではないので、
+  # バッテリー駆動中は停止します。
+  systemd.services."beesd@root".unitConfig.ConditionACPower = true;
+  services.acpid.acEventCommands = ''
+    if [ "$(< /sys/class/power_supply/AC/online)" = 1 ]; then
+      ${pkgs.systemd}/bin/systemctl start ${beesUnit}
+    else
+      ${pkgs.systemd}/bin/systemctl stop ${beesUnit}
+    fi
+  '';
 }

--- a/nixos/laptop/tlp.nix
+++ b/nixos/laptop/tlp.nix
@@ -39,6 +39,9 @@ _: {
         # バッテリー時は電力を更に重視したいので、
         # `balance_power`から`power`に変更します。
         CPU_ENERGY_PERF_POLICY_ON_BAT = "power";
+
+        # バッテリー時はファームウェアにも省電力を優先させます。
+        PLATFORM_PROFILE_ON_BAT = "low-power";
       };
     };
   };


### PR DESCRIPTION
バッテリー駆動時のplatform profileをlow-powerへ変更します。

重複排除は急を要しないため、
バッテリー駆動中はbeesdを停止し、
AC電源へ接続したときに再開します。