### PR TITLE
build(comfyui): comfyui-nix 0.30.0へ更新します

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -706,11 +706,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1784566540,
-        "narHash": "sha256-QnpjSwatSWXLpNylUgx8DkQ05Johc4mbPboISPWcY40=",
+        "lastModified": 1785892222,
+        "narHash": "sha256-GUPEjtGuYsGjd3ayo4GZTp6fZtju6LOza4WIOu3GRhE=",
         "owner": "utensils",
         "repo": "comfyui-nix",
-        "rev": "068803a26235f0c43a93d1f9c3d75a22564e9ba7",
+        "rev": "1f1abf022dfe9350dde7cd54e74c8f30293d640d",
         "type": "github"
       },
       "original": {

--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -93,19 +93,11 @@ in
         torch = lib.findFirst (
           pkg: lib.getName pkg == "torch"
         ) (throw "torch not found in comfyui heavyDeps") config.services.comfyui.package.heavyDeps;
-        inherit (torch) cudaPackages;
-        cudaNvcc = cudaPackages.cuda_nvcc;
-        cudaNvrtc = cudaPackages.cuda_nvrtc;
         sageattention = comfyuiPython.pkgs.callPackage ../../../../pkgs/sageattention.nix {
           inherit torch;
           # torchの全CUDA世代ではなく、RTX 5090向けのカーネルだけをビルドする。
           cudaCapabilities = [ "12.0" ];
         };
-        # カスタムノードが追加で必要とするPython依存。
-        # 各ノードがcustom-node.nixで`passthru.pythonPathDeps`として添付したものを集める。
-        customNodePythonDeps = lib.concatMap (node: node.pythonPathDeps or [ ]) (
-          lib.attrValues config.services.comfyui.customNodes
-        );
       in
       {
         imports = [ inputs.utensils-comfyui-nix.nixosModules.default ];
@@ -142,20 +134,11 @@ in
             "--use-sage-attention"
           ];
         };
-        # Tritonは未指定時にNixOSには存在しない`/sbin/ldconfig`でlibcudaを探す。
-        systemd.services.comfyui.environment = {
-          CC = lib.getExe pkgs.stdenv.cc;
-          # SeedVR2のVAE attentionが実行時コンパイルにNVRTCを使う。
-          # ComfyUIのtorchと同じCUDAパッケージセットから検索パスを指定する。
-          LD_LIBRARY_PATH = lib.makeLibraryPath [ cudaNvrtc ];
-          PYTHONPATH = lib.makeSearchPath comfyuiPython.sitePackages (
-            [ sageattention ] ++ customNodePythonDeps
-          );
-          TRITON_CUDACRT_PATH = "${cudaPackages.cuda_cudart}/include";
-          TRITON_LIBCUDA_PATH = "/run/opengl-driver/lib";
-          TRITON_LIBDEVICE_PATH = "${cudaNvcc}/nvvm/libdevice/libdevice.10.bc";
-          TRITON_PTXAS_PATH = "${cudaNvcc}/bin/ptxas";
-        };
+        # comfyui-nix同梱のSageAttention 1.0.6より新しい2.2.0を優先する。
+        # extraPythonPackagesでは同名パッケージが衝突するため、検索パスで差し替える。
+        systemd.services.comfyui.environment.PYTHONPATH = lib.makeSearchPath comfyuiPython.sitePackages [
+          sageattention
+        ];
         systemd.services.comfyui.path = with pkgs; [ ffmpeg ];
       };
   };

--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -7,9 +7,7 @@
 # comfyui-nixのPython環境には主要カスタムノードの依存
 # (ultralytics, segment-anything, opencv4など)が同梱されているので、
 # 大抵はソースを配置するだけでよい。
-# 同梱されていない依存が必要なノードは、
-# `passthru.pythonPathDeps`としてノード自身に添付する。
-# container.nixが全ノードから集めてPYTHONPATHへ載せる。
+# 同梱されていない依存は`services.comfyui.extraPythonPackages`で追加する。
 {
   lib,
   pkgs,
@@ -52,16 +50,7 @@ in
           ${checkPythonSyntax source}
           install -D -m 0644 ${source} $out/__init__.py
         '';
-      # ノードのPython依存をPYTHONPATHへ載せるための添付。
-      # passthruはderivation本体に影響しないので再ビルドは発生しない。
-      withPythonPathDeps =
-        deps: node:
-        node.overrideAttrs (old: {
-          passthru = (old.passthru or { }) // {
-            pythonPathDeps = deps;
-          };
-        });
-      loraManagerSrc = pkgs.fetchFromGitHub {
+      loraManager = pkgs.fetchFromGitHub {
         owner = "willmiao";
         repo = "ComfyUI-Lora-Manager";
         tag = "v1.2.0";
@@ -73,9 +62,9 @@ in
       # PyPI名をnixpkgsの属性名へ正規化して参照するので、
       # nixpkgsに存在しない依存が増えた場合は評価エラーで検出される。
       # バージョン制約は無視してnixpkgsのバージョンをそのまま使う。
-      loraManagerPythonEnv = comfyuiPython.withPackages (
+      loraManagerPythonPackages =
         pythonPkgs:
-        lib.pipe (builtins.readFile "${loraManagerSrc}/requirements.txt") [
+        lib.pipe (builtins.readFile "${loraManager}/requirements.txt") [
           (lib.splitString "\n")
           # 行頭のパッケージ名だけを取り出す。
           # コメント行と空行はマッチしないのでnullになる。
@@ -85,43 +74,42 @@ in
           # requirements.txt内の並び替えだけで環境が再ビルドされないように順序を正規化する。
           (lib.sort lib.lessThan)
           (map (name: pythonPkgs.${name}))
-        ]
-      );
+        ];
     in
     {
-      services.comfyui.customNodes = {
-        # FaceDetailerなどディテール修復ノード群。ADetailer相当。
-        # comfyui-nixがパッケージ済みのものを使う。
-        # Impact Packの顔cropは任意寸法になり、Cosmos系のAnimaではlatentが、
-        # spatial patch sizeで割り切れずFaceDetailerが失敗する。
-        # 上流で修正されたら補正パッチを削除する。
-        # https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/1186
-        "ComfyUI-Impact-Pack" = pkgs.comfyui-custom-nodes.impact-pack.overrideAttrs (old: {
-          patches = (old.patches or [ ]) ++ [ ./impact-pack-anima-size.patch ];
-          # 上流更新で文脈がずれた場合に別の関数へ黙って適用しないようfuzzを無効化する。
-          # overrideAttrsで指定するため、上流パッケージにpatchesが追加された場合も同じフラグが適用される。
-          patchFlags = [
-            "-p1"
-            "-F0"
-          ];
-          # パッチのインデント崩れをComfyUI起動前のビルド時に検出する。
-          postPatch = (old.postPatch or "") + checkPythonSyntax "modules/impact/core.py";
-        });
-        # Power Lora Loaderなどワークフロー整理のノード群。
-        # comfyui-nixがパッケージ済みのものを使う。
-        "rgthree-comfy" = pkgs.comfyui-custom-nodes.rgthree-comfy;
-        # Civitaiからの取得、プレビュー、トリガーワード、レシピを一元管理する。
-        # Civitaiにはpickle形式(.pt/.ckpt)のモデルもあり読み込み時の任意コード実行が懸念されるが、
-        # ComfyUI本体は非safetensorsも`torch.load(weights_only=True)`固定で読むことと、
-        # そもそも外部取得物の実行を想定したコンテナ隔離があることから受容する。
-        "ComfyUI-Lora-Manager" = withPythonPathDeps [ loraManagerPythonEnv ] loraManagerSrc;
-        # 複数フレームを同時に参照して時間的一貫性を保つ動画超解像。
-        # RTX 5090では7B FP16モデルをBlockSwapとVAE tiling付きで使う。
-        # 依存はrotary-embedding-torchのパッケージ単体だけをPYTHONPATHへ載せる。
-        # withPackagesで環境にすると推移的依存のtorch(override前の非CUDA版)が、
-        # 実行環境のCUDA wheel版torchを覆い隠してしまうため使わない。
-        "ComfyUI-SeedVR2_VideoUpscaler" = withPythonPathDeps [ comfyuiPython.pkgs.rotary-embedding-torch ] (
-          pkgs.applyPatches {
+      services.comfyui = {
+        extraPythonPackages =
+          pythonPkgs: [ pythonPkgs.rotary-embedding-torch ] ++ loraManagerPythonPackages pythonPkgs;
+        customNodes = {
+          # FaceDetailerなどディテール修復ノード群。ADetailer相当。
+          # comfyui-nixがパッケージ済みのものを使う。
+          # Impact Packの顔cropは任意寸法になり、Cosmos系のAnimaではlatentが、
+          # spatial patch sizeで割り切れずFaceDetailerが失敗する。
+          # 上流で修正されたら補正パッチを削除する。
+          # https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/1186
+          "ComfyUI-Impact-Pack" = pkgs.comfyui-custom-nodes.impact-pack.overrideAttrs (old: {
+            patches = (old.patches or [ ]) ++ [ ./impact-pack-anima-size.patch ];
+            # 上流更新で文脈がずれた場合に別の関数へ黙って適用しないようfuzzを無効化する。
+            # overrideAttrsで指定するため、上流パッケージにpatchesが追加された場合も同じフラグが適用される。
+            patchFlags = [
+              "-p1"
+              "-F0"
+            ];
+            # パッチのインデント崩れをComfyUI起動前のビルド時に検出する。
+            postPatch = (old.postPatch or "") + checkPythonSyntax "modules/impact/core.py";
+          });
+          # Power Lora Loaderなどワークフロー整理のノード群。
+          # comfyui-nixがパッケージ済みのものを使う。
+          "rgthree-comfy" = pkgs.comfyui-custom-nodes.rgthree-comfy;
+          # Civitaiからの取得、プレビュー、トリガーワード、レシピを一元管理する。
+          # Civitaiにはpickle形式(.pt/.ckpt)のモデルもあり読み込み時の任意コード実行が懸念されるが、
+          # ComfyUI本体は非safetensorsも`torch.load(weights_only=True)`固定で読むことと、
+          # そもそも外部取得物の実行を想定したコンテナ隔離があることから受容する。
+          "ComfyUI-Lora-Manager" = loraManager;
+          # 複数フレームを同時に参照して時間的一貫性を保つ動画超解像。
+          # RTX 5090では7B FP16モデルをBlockSwapとVAE tiling付きで使う。
+          # 依存はextraPythonPackagesからComfyUI本体と同じCUDA版torchを使う。
+          "ComfyUI-SeedVR2_VideoUpscaler" = pkgs.applyPatches {
             src = pkgs.fetchFromGitHub {
               owner = "numz";
               repo = "ComfyUI-SeedVR2_VideoUpscaler";
@@ -136,100 +124,100 @@ in
               "-p1"
               "-F0"
             ];
-          }
-        );
-        # SeedVR2 CLIのチャンク処理をComfyUIから起動し、長尺動画をRAM上限付きで処理する。
-        # 解像度の自動計算に使う、VIDEOから幅と高さを取り出す汎用ノードGetVideoSizeも同梱する。
-        "ComfyUI-SeedVR2-Streaming" =
-          writeCheckedInitPy "comfyui-seedvr2-streaming" ./custom-node/seedvr2-streaming/__init__.py;
-        # UltralyticsDetectorProvider(YOLOによる顔検出)を提供する。
-        # FaceDetailerに検出器を渡すために必要。
-        "ComfyUI-Impact-Subpack" = pkgs.fetchFromGitHub {
-          owner = "ltdrdata";
-          repo = "ComfyUI-Impact-Subpack";
-          tag = "1.3.4";
-          hash = "sha256-BHtfkaqCPf/YXfGbF/xyryjt+M8izkdoUAKNJLfyvqI=";
-        };
-        # 指示文を英語へ翻訳する自作ノード。
-        # Qwen-Image-Editなど指示文の公式サポートが英語と中国語のみのモデルに対して、
-        # 日本語で指示を書けるようにする。
-        # 依存はComfyUI環境に同梱済みのrequestsのみ。
-        # customNodesの型はpackageなのでプレーンなパスは渡せず、
-        # derivationに包んで渡す。
-        "ComfyUI-Translate-Text" =
-          writeCheckedInitPy "comfyui-translate-text" ./custom-node/translate-text/__init__.py;
-        # 画像を選ばないことも許可する自作LoadImage。
-        # (none)のままなら出力がNoneになり、optional入力が未接続扱いになる。
-        # WanFirstLastFrameToVideoのend_imageなど任意入力の有効・無効を、
-        # バイパス操作なしで画像指定の有無だけで切り替えるために使う。
-        "ComfyUI-Load-Image-Optional" =
-          writeCheckedInitPy "comfyui-load-image-optional" ./custom-node/load-image-optional/__init__.py;
-        # Animaなどlatent寸法に制約があるモデル向けの自作ノード群。
-        # 画像を指定した倍数へ中央cropするノードと、
-        # EmptyLatentImageへ渡す幅と高さを指定した倍数へ切り下げるノードを提供する。
-        "ComfyUI-Align-Image-Size" =
-          writeCheckedInitPy "comfyui-align-image-size" ./custom-node/align-image-size/__init__.py;
-        # 元fpsと音声を維持し、RGB48から10-bit SVT-AV1 losslessのWebMへ保存するノード。
-        "ComfyUI-Save-SVT-AV1" = pkgs.symlinkJoin {
-          name = "comfyui-save-svt-av1";
-          paths = [
-            (writeCheckedInitPy "comfyui-save-svt-av1-init" ./custom-node/save-svt-av1/__init__.py)
-            (pkgs.writeTextDir "web/notification.js" (
-              builtins.readFile ./custom-node/save-svt-av1/web/notification.js
-            ))
-          ];
-        };
-        # 複数行の指示からQwen編集画像を先に全て作り、
-        # そのキーフレーム間をWan FLF2Vで順番に動画化する。
-        # 各成果物を都度保存するため、長さに比例して画像テンソルをRAMへ蓄積しない。
-        "ComfyUI-Anime-Video-Quick" =
-          writeCheckedInitPy "comfyui-anime-video-quick" ./custom-node/anime-video-quick/__init__.py;
-        # danbooruタグのオートコンプリート。
-        # 日本語からの検索とpost count表示に対応していて、
-        # メジャーなタグかどうかを確認しながら入力できる。
-        "ComfyUI-Autocomplete-Plus" = pkgs.stdenv.mkDerivation (finalAttrs: {
-          pname = "comfyui-autocomplete-plus";
-          version = "1.11.0";
-          src = pkgs.fetchFromGitHub {
-            owner = "newtextdoc1111";
-            repo = "ComfyUI-Autocomplete-Plus";
-            tag = "v${finalAttrs.version}";
-            hash = "sha256-MjhGd38G5Wz46t1AchTe/IqmTzVO43mlXPDHie5i3EE=";
           };
-          # 新しいComfyUIフロントエンド(1.43以降)では、
-          # keyupの時点でカーソル位置がリセットされていて候補が表示されない。
-          # upstreamのissueコメントで提示されている修正パッチを適用する。
-          # https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus/issues/73#issuecomment-4761276962
-          # 修正がリリースされたらこのパッチは削除する。
-          #
-          # なおパッチとは別に、
-          # フロントエンド設定のVue DOMモード(Vueノード描画)が有効だと、
-          # この拡張はテキスト欄にattachできず一切動作しないので無効にしておくこと。
-          patches = [ ./autocomplete-plus-new-frontend.patch ];
-          # タグCSVを起動時に自ディレクトリ配下へダウンロードする作りだが、
-          # Nix storeは読み取り専用なので、書き込み先を可変領域に差し替える。
-          postPatch = ''
-            substituteInPlace modules/api.py modules/downloader.py \
-              --replace-fail \
-              'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "data"))' \
-              '"${autocompletePlusDataDir}/data"'
-            substituteInPlace modules/downloader.py \
-              --replace-fail \
-              'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", CSV_META_FILE_NAME))' \
-              'os.path.join("${autocompletePlusDataDir}", CSV_META_FILE_NAME)'
-          '';
-          installPhase = ''
-            runHook preInstall
-            mkdir -p $out
-            cp -r . $out/
-            runHook postInstall
-          '';
-          meta = {
-            description = "Danbooru tag autocomplete with Japanese search support for ComfyUI";
-            homepage = "https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus";
-            license = pkgs.lib.licenses.mit;
+          # SeedVR2 CLIのチャンク処理をComfyUIから起動し、長尺動画をRAM上限付きで処理する。
+          # 解像度の自動計算に使う、VIDEOから幅と高さを取り出す汎用ノードGetVideoSizeも同梱する。
+          "ComfyUI-SeedVR2-Streaming" =
+            writeCheckedInitPy "comfyui-seedvr2-streaming" ./custom-node/seedvr2-streaming/__init__.py;
+          # UltralyticsDetectorProvider(YOLOによる顔検出)を提供する。
+          # FaceDetailerに検出器を渡すために必要。
+          "ComfyUI-Impact-Subpack" = pkgs.fetchFromGitHub {
+            owner = "ltdrdata";
+            repo = "ComfyUI-Impact-Subpack";
+            tag = "1.3.4";
+            hash = "sha256-BHtfkaqCPf/YXfGbF/xyryjt+M8izkdoUAKNJLfyvqI=";
           };
-        });
+          # 指示文を英語へ翻訳する自作ノード。
+          # Qwen-Image-Editなど指示文の公式サポートが英語と中国語のみのモデルに対して、
+          # 日本語で指示を書けるようにする。
+          # 依存はComfyUI環境に同梱済みのrequestsのみ。
+          # customNodesの型はpackageなのでプレーンなパスは渡せず、
+          # derivationに包んで渡す。
+          "ComfyUI-Translate-Text" =
+            writeCheckedInitPy "comfyui-translate-text" ./custom-node/translate-text/__init__.py;
+          # 画像を選ばないことも許可する自作LoadImage。
+          # (none)のままなら出力がNoneになり、optional入力が未接続扱いになる。
+          # WanFirstLastFrameToVideoのend_imageなど任意入力の有効・無効を、
+          # バイパス操作なしで画像指定の有無だけで切り替えるために使う。
+          "ComfyUI-Load-Image-Optional" =
+            writeCheckedInitPy "comfyui-load-image-optional" ./custom-node/load-image-optional/__init__.py;
+          # Animaなどlatent寸法に制約があるモデル向けの自作ノード群。
+          # 画像を指定した倍数へ中央cropするノードと、
+          # EmptyLatentImageへ渡す幅と高さを指定した倍数へ切り下げるノードを提供する。
+          "ComfyUI-Align-Image-Size" =
+            writeCheckedInitPy "comfyui-align-image-size" ./custom-node/align-image-size/__init__.py;
+          # 元fpsと音声を維持し、RGB48から10-bit SVT-AV1 losslessのWebMへ保存するノード。
+          "ComfyUI-Save-SVT-AV1" = pkgs.symlinkJoin {
+            name = "comfyui-save-svt-av1";
+            paths = [
+              (writeCheckedInitPy "comfyui-save-svt-av1-init" ./custom-node/save-svt-av1/__init__.py)
+              (pkgs.writeTextDir "web/notification.js" (
+                builtins.readFile ./custom-node/save-svt-av1/web/notification.js
+              ))
+            ];
+          };
+          # 複数行の指示からQwen編集画像を先に全て作り、
+          # そのキーフレーム間をWan FLF2Vで順番に動画化する。
+          # 各成果物を都度保存するため、長さに比例して画像テンソルをRAMへ蓄積しない。
+          "ComfyUI-Anime-Video-Quick" =
+            writeCheckedInitPy "comfyui-anime-video-quick" ./custom-node/anime-video-quick/__init__.py;
+          # danbooruタグのオートコンプリート。
+          # 日本語からの検索とpost count表示に対応していて、
+          # メジャーなタグかどうかを確認しながら入力できる。
+          "ComfyUI-Autocomplete-Plus" = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "comfyui-autocomplete-plus";
+            version = "1.11.0";
+            src = pkgs.fetchFromGitHub {
+              owner = "newtextdoc1111";
+              repo = "ComfyUI-Autocomplete-Plus";
+              tag = "v${finalAttrs.version}";
+              hash = "sha256-MjhGd38G5Wz46t1AchTe/IqmTzVO43mlXPDHie5i3EE=";
+            };
+            # 新しいComfyUIフロントエンド(1.43以降)では、
+            # keyupの時点でカーソル位置がリセットされていて候補が表示されない。
+            # upstreamのissueコメントで提示されている修正パッチを適用する。
+            # https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus/issues/73#issuecomment-4761276962
+            # 修正がリリースされたらこのパッチは削除する。
+            #
+            # なおパッチとは別に、
+            # フロントエンド設定のVue DOMモード(Vueノード描画)が有効だと、
+            # この拡張はテキスト欄にattachできず一切動作しないので無効にしておくこと。
+            patches = [ ./autocomplete-plus-new-frontend.patch ];
+            # タグCSVを起動時に自ディレクトリ配下へダウンロードする作りだが、
+            # Nix storeは読み取り専用なので、書き込み先を可変領域に差し替える。
+            postPatch = ''
+              substituteInPlace modules/api.py modules/downloader.py \
+                --replace-fail \
+                'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "data"))' \
+                '"${autocompletePlusDataDir}/data"'
+              substituteInPlace modules/downloader.py \
+                --replace-fail \
+                'os.path.normpath(os.path.join(os.path.dirname(__file__), "..", CSV_META_FILE_NAME))' \
+                'os.path.join("${autocompletePlusDataDir}", CSV_META_FILE_NAME)'
+            '';
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out
+              cp -r . $out/
+              runHook postInstall
+            '';
+            meta = {
+              description = "Danbooru tag autocomplete with Japanese search support for ComfyUI";
+              homepage = "https://github.com/newtextdoc1111/ComfyUI-Autocomplete-Plus";
+              license = pkgs.lib.licenses.mit;
+            };
+          });
+        };
       };
     };
   systemd.tmpfiles.rules = [


### PR DESCRIPTION
comfyui-nixをComfyUI 0.30.0対応版へ更新します。

追加された`extraPythonPackages`を使い、
カスタムノードの依存を同じCUDA版Python環境へ統合します。

上流ランチャーが担うCUDAとTritonの環境設定を削除します。
同梱版と競合するSageAttention 2.2.0だけは`PYTHONPATH`で優先します。

bulletへ適用し、
実機で画像生成できることを確認しました。