### PR TITLE
feat(lsp): Language Server環境を共通化して拡充します

### DIFF
--- a/home/core/c.nix
+++ b/home/core/c.nix
@@ -8,8 +8,6 @@
 
     autoconf
     automake
-    ccls
-    clang-tools
     cmake
     gdb
     libgcc

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -99,9 +99,14 @@ in
       enabledPlugins = {
         ## lsp plugin
         "clangd-lsp@claude-plugins-official" = true;
+        "csharp-lsp@claude-plugins-official" = true;
         "gopls-lsp@claude-plugins-official" = true;
+        "jdtls-lsp@claude-plugins-official" = true;
+        "lua-lsp@claude-plugins-official" = true;
         "pyright-lsp@claude-plugins-official" = true;
+        "ruby-lsp@claude-plugins-official" = true;
         "rust-analyzer-lsp@claude-plugins-official" = true;
+        "swift-lsp@claude-plugins-official" = true;
         "typescript-lsp@claude-plugins-official" = true;
       };
       skipAutoPermissionPrompt = true; # auto modeをdefaultModeにしているので許可を求めない。

--- a/home/core/csharp.nix
+++ b/home/core/csharp.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    csharp-ls
-  ];
-}

--- a/home/core/docker.nix
+++ b/home/core/docker.nix
@@ -10,8 +10,6 @@
   home.packages = with pkgs; [
     act
     docker-client # clientOnlyなdockerパッケージ。buildx(BuildKit)とcomposeプラグイン同梱。
-    docker-compose-language-service
-    dockerfile-language-server
     hadolint
   ];
 }

--- a/home/core/go.nix
+++ b/home/core/go.nix
@@ -1,16 +1,11 @@
-{ pkgs, config, ... }:
+{ config, ... }:
 {
   programs.go = {
     enable = true;
     env.GOPATH = "${config.home.homeDirectory}/.go";
   };
 
-  home = {
-    packages = with pkgs; [
-      gopls
-    ];
-    sessionPath = [
-      "${config.home.homeDirectory}/.go/bin"
-    ];
-  };
+  home.sessionPath = [
+    "${config.home.homeDirectory}/.go/bin"
+  ];
 }

--- a/home/core/haskell.nix
+++ b/home/core/haskell.nix
@@ -37,7 +37,6 @@ in
         cabal-install
         fourmolu
         ghc
-        haskell-language-server
         hlint
         hpack
         pandoc

--- a/home/core/java.nix
+++ b/home/core/java.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    jdt-language-server
-  ];
-}

--- a/home/core/javascript.nix
+++ b/home/core/javascript.nix
@@ -50,8 +50,6 @@ in
     npm-check-updates
     prettier
     typescript
-    typescript-language-server
-    vscode-langservers-extracted
     yarn-berry
   ];
 }

--- a/home/core/kotlin.nix
+++ b/home/core/kotlin.nix
@@ -3,6 +3,5 @@
   home.packages = with pkgs; [
     gradle
     kotlin
-    kotlin-language-server
   ];
 }

--- a/home/core/lsp.nix
+++ b/home/core/lsp.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    ccls
+    clang-tools
+    csharp-ls
+    docker-compose-language-service
+    dockerfile-language-server
+    gopls
+    haskell-language-server
+    jdt-language-server
+    kotlin-language-server
+    lua-language-server
+    marksman
+    nil
+    ruby-lsp
+    sourcekit-lsp
+    typescript-language-server
+    vscode-langservers-extracted
+  ];
+}

--- a/home/core/lsp.nix
+++ b/home/core/lsp.nix
@@ -40,7 +40,6 @@
     prisma_7 # Prisma CLI内蔵のLanguage Server
     pyright # Pythonの型検査と補完
     ruby-lsp # Ruby
-    rust-analyzer # Rust
     serve-d # D
     sourcekit-lsp # SwiftとObjective-C
     sqls # SQL

--- a/home/core/lsp.nix
+++ b/home/core/lsp.nix
@@ -4,57 +4,57 @@
   # Emacsなどのテキストエディタや、
   # コーディングエージェントなどが利用します。
   home.packages = with pkgs; [
-    astro-language-server
-    bash-language-server
-    biome
-    ccls
-    clang-tools
-    clojure-lsp
-    cmake-language-server
-    csharp-ls
-    dart
-    dhall-lsp-server
-    docker-compose-language-service
-    dockerfile-language-server
-    elixir-ls
-    elmPackages.elm-language-server
-    erlang-language-platform
-    fortls
-    fsautocomplete
-    gleam
-    gopls
-    graphql-language-service-cli
-    haskell-language-server
-    jdt-language-server
-    kotlin-language-server
-    ltex-ls-plus
-    lua-language-server
-    marksman
-    metals
-    nginx-language-server
-    nil
-    nixd
-    ocamlPackages.ocaml-lsp
-    omnisharp-roslyn
-    oxlint
-    prisma_7
-    pyright
-    ruby-lsp
-    rust-analyzer
-    serve-d
-    sourcekit-lsp
-    sqls
-    svelte-language-server
-    tailwindcss-language-server
-    taplo
-    terraform-ls
-    texlab
-    tinymist
-    ty
-    typescript-language-server
-    vscode-langservers-extracted
-    vue-language-server
-    yaml-language-server
-    zls
+    astro-language-server # Astro
+    bash-language-server # Bashなどのシェルスクリプト
+    biome # JavaScriptやTypeScriptなどのWeb言語
+    ccls # CとC++
+    clang-tools # CとC++向けのclangdを含みます
+    clojure-lsp # Clojure
+    cmake-language-server # CMake
+    csharp-ls # C#
+    dart # Dart SDK内蔵のLanguage Server
+    dhall-lsp-server # Dhall
+    docker-compose-language-service # Docker Compose
+    dockerfile-language-server # Dockerfile
+    elixir-ls # Elixir
+    elmPackages.elm-language-server # Elm
+    erlang-language-platform # Erlang
+    fortls # Fortran
+    fsautocomplete # F#
+    gleam # Gleam内蔵のLanguage Server
+    gopls # Go
+    graphql-language-service-cli # GraphQL
+    haskell-language-server # Haskell
+    jdt-language-server # Java
+    kotlin-language-server # Kotlin
+    ltex-ls-plus # LaTeXやMarkdownなどの文法・スペル検査
+    lua-language-server # Lua
+    marksman # Markdown
+    metals # Scala
+    nginx-language-server # nginx設定
+    nil # Nix
+    nixd # Nix、評価や補完機能が豊富な実装
+    ocamlPackages.ocaml-lsp # OCaml
+    omnisharp-roslyn # C#向けのOmniSharp
+    oxlint # JavaScriptやTypeScript向けの高速LSPとlinter
+    prisma_7 # Prisma CLI内蔵のLanguage Server
+    pyright # Pythonの型検査と補完
+    ruby-lsp # Ruby
+    rust-analyzer # Rust
+    serve-d # D
+    sourcekit-lsp # SwiftとObjective-C
+    sqls # SQL
+    svelte-language-server # Svelte
+    tailwindcss-language-server # Tailwind CSS
+    taplo # TOML
+    terraform-ls # Terraform
+    texlab # LaTeX
+    tinymist # Typst
+    ty # Python向けの高速な型検査と補完
+    typescript-language-server # TypeScriptとJavaScript
+    vscode-langservers-extracted # HTML、CSS、JSON、ESLint
+    vue-language-server # Vue
+    yaml-language-server # YAML
+    zls # Zig
   ];
 }

--- a/home/core/lsp.nix
+++ b/home/core/lsp.nix
@@ -1,21 +1,50 @@
 { pkgs, ... }:
 {
+  # 様々なツールで利用するlspサーバをインストールします。
+  # Emacsなどのテキストエディタや、
+  # コーディングエージェントなどが利用します。
   home.packages = with pkgs; [
+    bash-language-server
     ccls
     clang-tools
+    clojure-lsp
+    cmake-language-server
     csharp-ls
+    dhall-lsp-server
     docker-compose-language-service
     dockerfile-language-server
+    elixir-ls
+    elmPackages.elm-language-server
+    erlang-language-platform
+    fortls
     gopls
+    graphql-language-service-cli
     haskell-language-server
     jdt-language-server
     kotlin-language-server
+    ltex-ls-plus
     lua-language-server
     marksman
+    metals
+    nginx-language-server
     nil
+    ocamlPackages.ocaml-lsp
+    omnisharp-roslyn
+    pyright
     ruby-lsp
+    rust-analyzer
+    serve-d
     sourcekit-lsp
+    sqls
+    svelte-language-server
+    tailwindcss-language-server
+    taplo
+    terraform-ls
+    texlab
     typescript-language-server
     vscode-langservers-extracted
+    vue-language-server
+    yaml-language-server
+    zls
   ];
 }

--- a/home/core/lsp.nix
+++ b/home/core/lsp.nix
@@ -4,12 +4,15 @@
   # Emacsなどのテキストエディタや、
   # コーディングエージェントなどが利用します。
   home.packages = with pkgs; [
+    astro-language-server
     bash-language-server
+    biome
     ccls
     clang-tools
     clojure-lsp
     cmake-language-server
     csharp-ls
+    dart
     dhall-lsp-server
     docker-compose-language-service
     dockerfile-language-server
@@ -17,6 +20,8 @@
     elmPackages.elm-language-server
     erlang-language-platform
     fortls
+    fsautocomplete
+    gleam
     gopls
     graphql-language-service-cli
     haskell-language-server
@@ -28,8 +33,11 @@
     metals
     nginx-language-server
     nil
+    nixd
     ocamlPackages.ocaml-lsp
     omnisharp-roslyn
+    oxlint
+    prisma_7
     pyright
     ruby-lsp
     rust-analyzer
@@ -41,6 +49,8 @@
     taplo
     terraform-ls
     texlab
+    tinymist
+    ty
     typescript-language-server
     vscode-langservers-extracted
     vue-language-server

--- a/home/core/lua.nix
+++ b/home/core/lua.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    lua-language-server
-  ];
-}

--- a/home/core/markdown.nix
+++ b/home/core/markdown.nix
@@ -8,7 +8,5 @@ let
   marksmanToml = (pkgs.formats.toml { }).generate "marksman-config" marksmanConfig;
 in
 {
-  home.packages = with pkgs; [ marksman ];
-
   xdg.configFile."marksman/config.toml".source = marksmanToml;
 }

--- a/home/core/nix.nix
+++ b/home/core/nix.nix
@@ -61,7 +61,6 @@ in
   home.packages = with pkgs; [
     cachix
     cachix-push-ncaq
-    nil
     niks3-push-ncaq
     nix-diff
     nix-fast-build-wrapper

--- a/home/core/ruby.nix
+++ b/home/core/ruby.nix
@@ -3,7 +3,6 @@
   home.packages = with pkgs; [
     rubocop
     ruby
-    ruby-lsp
     rubyfmt
   ];
 }

--- a/home/core/swift.nix
+++ b/home/core/swift.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    sourcekit-lsp
-  ];
-}


### PR DESCRIPTION
言語別モジュールに分散していたLanguage Serverパッケージを共通設定へ集約します。
パッケージごとの対象言語や用途もコメントで明記します。

EmacsとOpenCodeが対応するLanguage Serverを追加し、
インストール済みのサーバに対応するClaude Code公式LSPプラグインも有効にします。

RustのLanguage Serverはプロジェクト固有のrustupまたはFlake環境へ委ねます。

`nix fmt`と`./install.sh`で検証しました。