### PR TITLE
feat(nixos): デプロイ済みflakeを`/etc`へ公開します

### DIFF
--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -1,5 +1,8 @@
-{ config, ... }:
+{ config, inputs, ... }:
 {
+  # 現在デプロイされている構成を、編集可能な作業ツリーに依存せず再評価できるようにします。
+  environment.etc."nixos-flake".source = inputs.self.outPath;
+
   nix = {
     settings = {
       experimental-features = [


### PR DESCRIPTION
編集可能な作業ツリーへの依存をなくします。
これにより現在のNixOS構成を再評価できるようにします。