### PR TITLE
perf(snapper): btrfsのfull quotaをやめてFREE_LIMITだけにします

### DIFF
--- a/nixos/native-linux/snapper.nix
+++ b/nixos/native-linux/snapper.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+_:
 let
   # snapperのスナップショット作成・クリーンアップは緊急性がないので、
   # 他のプロセスを妨害しないようにCPUとI/Oの優先度を下げる。
@@ -26,10 +26,10 @@ in
         TIMELINE_CREATE = true;
         TIMELINE_CLEANUP = true;
 
-        # SPACE_LIMITやFREE_LIMITによる容量ベースのcleanupは、
+        # FREE_LIMITによる容量ベースのcleanupは、
         # timeline cleanupのリミットがmin-maxの範囲指定の時のみ機能する。
         # snapperはまず各カテゴリのmax値までcleanupし(1パス目)、
-        # それでもSPACE_LIMIT/FREE_LIMITを満たせない時だけ、
+        # それでもFREE_LIMITを満たせない時だけ、
         # min値まで追加で削除する(2パス目)。
         # maxは従来のデフォルト値、minは容量が逼迫した時に残す最低世代数。
         TIMELINE_LIMIT_HOURLY = "2-10";
@@ -37,68 +37,29 @@ in
         TIMELINE_LIMIT_MONTHLY = "2-10";
         TIMELINE_LIMIT_YEARLY = "2-10";
 
-        # スナップショットが使ってよい容量をファイルシステム全体の1割までに制限する。
-        # SPACE_LIMITはqgroup(btrfs quota)のexclusive使用量 / FS全体サイズで評価される、
-        # cleanup時のソフトリミット。
-        # quotaの有効化とqgroupの用意はsnapper-setup-quotaサービスで行い、
-        # 参照するqgroupは下のQGROUPで宣言的に指定する。
-        SPACE_LIMIT = "0.1";
-
-        # snapperが使用量計測に使うレベル1のqgroup。
-        # NixOSでは`/etc/snapper/configs/root`がread-onlyのため、
-        # configにQGROUPを書き込む`snapper setup-quota`は使えない。
-        # 代わりにこの値を宣言的に与え、qgroup自体はサービスで作成する。
-        QGROUP = "1/0";
-
         # 空き容量がこの割合を下回ると、timeline cleanupが世代数の制限とは別に、
         # 古いスナップショットから追加で削除して空き容量を確保する。
-        # 明示的に記述しておく。
         # FREE_LIMITはstatvfsベースで動作しquota(qgroup)を必要としない。
-        # SPACE_LIMITが信用できなかった場合の安全網として併用する。
+        #
+        # スナップショットの使用量を直接制限するSPACE_LIMITもあるが、
+        # そちらはbtrfsのfull quota(qgroup)を必要とするため使わない。
+        # full quotaはextentの参照が増減するたびにbackref walkを行うので、
+        # beesによる重複排除でextentの共有度が上がるほど、
+        # またスナップショットが増えるほどコストが膨らむ。
+        # 実際にbtrfs-transactionとbtrfs-cleanerがカーネル空間のCPUを占有し、
+        # トランザクションコミット待ちで無関係なプロセスまで停止していた。
+        # 加えてカーネルはsubtree dropが深くなるとqgroupの再計算を放棄して、
+        # quotaをinconsistentとしてマークするため、
+        # SPACE_LIMITが読む値自体が信用できない状態になっていた。
+        #
+        # 防ぎたいのはスナップショットで埋まって書き込めなくなる事態であり、
+        # それは空き容量で直接判定できるのでFREE_LIMITだけで足りる。
         FREE_LIMIT = "0.2";
       };
     };
   };
 
   systemd.services = {
-    # snapperのSPACE_LIMITはbtrfsのquota(qgroup)を前提とするが、
-    # NixOSにはquotaを宣言的に有効化するオプションがない。
-    # そのためquotaの有効化とqgroupの作成だけをoneshotサービスで命令的に行う。
-    # snapperは使用量の計算時にquota rescanを要求するため、
-    # rescanをサポートしないsimple quota(squota)ではなくfull quotaを使う。
-    snapper-setup-quota = {
-      description = "Enable btrfs quota and qgroup for snapper SPACE_LIMIT";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "local-fs.target" ];
-      before = [
-        "snapper-cleanup.service"
-        "snapper-timeline.service"
-        "snapperd.service"
-      ];
-      unitConfig.ConditionPathIsMountPoint = "/";
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-      };
-      path = with pkgs; [
-        btrfs-progs
-        gnugrep
-      ];
-      script = ''
-        # quotaモードは有効なまま変更できないため、squotaの場合だけ作り直す。
-        if btrfs quota status / | grep -qE '^  Mode:[[:space:]]+squota'; then
-          btrfs quota disable /
-        fi
-        # full quotaを有効化し、既存データのaccountingが完了するまで待つ。
-        btrfs quota enable /
-        btrfs quota rescan --wait-norescan /
-        # snapperが参照するレベル1のqgroupを用意する。既存ならスキップする。
-        if ! btrfs qgroup show / | grep -qE '^1/0[[:space:]]'; then
-          btrfs qgroup create 1/0 /
-        fi
-      '';
-    };
-
     # 実際の重いbtrfs操作(subvolume削除など)はD-Bus越しにsnapperdが行うため、
     # トリガとなるtimeline/cleanupだけでなくsnapperd本体にも適用する。
     snapper-cleanup.serviceConfig = lowPriority;


### PR DESCRIPTION
seminarでカーネル空間のCPU使用が続き、
sshが一時的に応答しなくなるほど重くなっていました。

btrfsのfull quotaはextentの参照が増減するたびにbackref walkを行うため、
コストは共有度とsubvolume数に比例して膨らみます。
beesによる重複排除はextentの共有度を上げる作業そのものなので、
これとsnapshotの世代数が掛け算になって効いていました。

seminarで起動から7分の時点のカーネルCPU消費は、
btrfs-cleanerが9870 ticks、
btrfs-transactionが6416 ticksでした。
どちらも100%がsysで、
システム全体のsys時間71649 ticksのうち88%がbees込みのbtrfs関連です。
btrfs-transactionのコミット待ちで無関係なプロセスまで止まるため、
sshの無反応もこれで説明できます。

コストを払っていた当のSPACE_LIMITも機能していませんでした。
カーネルはsubtree dropが深くなるとqgroupの再計算を放棄して、
quotaをinconsistentとしてマークします。
bulletとseminarはどちらもこの状態になっていて、
SPACE_LIMITが読む値自体が信用できませんでした。

そもそも防ぎたいのはsnapshotで埋まって書き込めなくなる事態であり、
それは空き容量で直接判定できます。
statvfsベースで動作しquotaを必要としないFREE_LIMITだけで足ります。

bulletとcreepとseminarで`btrfs quota disable /`を実行済みです。
無効化後のseminarでは60秒間のsys消費がbtrfs-cleanerで0 ticks、
btrfs-transactionで1 ticksになり、
load averageも1.05まで下がることを確認しました。
