### PR TITLE
feat(cursor): 4Kに合わせてマウスカーソルを拡大します

### DIFF
--- a/home/native-linux/pointer-cursor.nix
+++ b/home/native-linux/pointer-cursor.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+{
+  # マウスカーソルを明示的に設定します。
+  #
+  # ツールキット非依存の唯一の共通基盤であるXcursorに対して、
+  # 明示的にテーマとサイズを指定します。
+  # `home.pointerCursor`は以下を一括で設定してくれるため、
+  # GTKでもQtでもFirefoxでもXmonadのルートウィンドウでも同じサイズになります。
+  #
+  # - 環境変数`XCURSOR_THEME`と`XCURSOR_SIZE`
+  # - Xリソースの`Xcursor.theme`と`Xcursor.size`
+  # - `xsetroot -xcf`によるルートウィンドウのカーソル
+  # - GTKの`gtk-cursor-theme-name`と`gtk-cursor-theme-size`
+  # - `~/.icons`と`$XDG_DATA_HOME/icons`のテーマ配置
+  home.pointerCursor = {
+    enable = true;
+    # Adwaitaのカーソルは24, 30, 36, 48, 72, 96のサイズを内蔵しているため、
+    # 拡大してもぼやけません。
+    package = pkgs.adwaita-icon-theme;
+    name = "Adwaita";
+    # X11には解像度に応じてマウスカーソルを自動で拡大する仕組みは存在しません。
+    # あまり使わないフルHD画面などでマウスカーソルが大きすぎて困ることはそんなにないので、
+    # 一番使う4Kディスプレイに合わせてサイズを36に設定します。
+    size = 36;
+    x11.enable = true;
+    gtk.enable = true;
+  };
+}


### PR DESCRIPTION
4Kディスプレイでマウスカーソルが小さすぎて頻繁に見失っていました。

`Xft.dpi`は`grobi`が144に設定していますが、
カーソルのテーマとサイズはどこにも設定していませんでした。
`XCURSOR_SIZE`も`XCURSOR_THEME`も空で、
`Xcursor.theme`と`Xcursor.size`もXリソースに存在しませんでした。
既定の24pxのまま1.5倍のスケーリングと組み合わさるので、
実質16px相当の見た目になっていました。

X11には解像度に応じてカーソルを自動で拡大する仕組みは存在せず、
サイズはXサーバ単位のグローバルな値が1つあるだけです。
ディスプレイごとに変えることもできません。
一方でGTKもQtもFirefoxも最終的にはlibXcursorを通るため、
ツールキットを問わず効かせること自体は可能です。

問題は設定箇所が環境変数とXリソースとGTK設定と`~/.icons`に分散していることでした。
`home.pointerCursor`はこれらをまとめて生成するので、
`xsetroot`によるルートウィンドウのカーソルも含めて1箇所で揃います。

テーマにはAdwaitaを選びます。
24から96まで6段階のサイズを内蔵しているため、
拡大してもぼやけません。
NixOSの`/run/current-system/sw/share/icons`に既に入っているものと同じです。

サイズは1.5倍のスケーリングに比例する36にします。
これはAdwaitaが内蔵するサイズそのものでもあります。
あまり使わないフルHD画面で大きすぎて困ることはそんなにないので、
一番使う4Kディスプレイに合わせます。

WSLは`nixos/wsl/dpi.nix`が`XCURSOR_SIZE`をシステムレベルで設定済みなので、
二重管理を避けてネイティブLinux向けの層にだけ置きます。
