### PR TITLE
feat(ollama): 即答性を優先するflashModelsの枠を作ります

### DIFF
--- a/nixos/ollama/model.nix
+++ b/nixos/ollama/model.nix
@@ -25,6 +25,25 @@ let
         # このactive 3BのMoEは約19トークン/秒だった。
         "qwen3.6:35b-a3b"
       ];
+  # 即答性を優先したモデル。
+  flashModels =
+    if enableCuda then
+      [
+        # GPUなら9Bのdenseでも体感は即答なので、
+        # 速度のために品質を落とし過ぎない範囲で汎用モデルより一段小さいものを選ぶ。
+        "qwen3.5:9b"
+      ]
+    else
+      [
+        # active 1BのMoE。
+        # generalModelsと同じくCPUではactive parameterの少なさがそのまま速度になる。
+        # seminarでの実測では同じ質問への応答完了まで、
+        # `qwen3.6:35b-a3b`が約18トークン/秒で46秒かかるのに対し、
+        # このモデルは約45トークン/秒で7秒だった。
+        # 同程度の規模でも`granite4.1:3b`のdenseは約24トークン/秒、
+        # `qwen3.5:4b`のdenseは約16トークン/秒しか出ない。
+        "lfm2.5:8b"
+      ];
   # 表現の自由度を優先したモデル。
   # CPUで推論するホストには置かない。
   # seminarでの実測では24Bのdenseは約4トークン/秒しか出ず、
@@ -56,7 +75,6 @@ let
 in
 {
   local.ollama = {
-    loadModels = generalModels;
-    inherit freedomModels;
+    inherit generalModels flashModels freedomModels;
   };
 }

--- a/nixos/ollama/option.nix
+++ b/nixos/ollama/option.nix
@@ -30,9 +30,29 @@
       '';
     };
 
+    generalModels = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      description = ''
+        ハードウェアの限界の範囲で汎用的に使えるモデル。
+        用途を絞らない既定の選択肢で、速度にも品質にも極端に寄せない。
+      '';
+    };
+
+    flashModels = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      description = ''
+        回答の質よりも即答性を優先したモデル。
+        短い質問や補完のように、待たされること自体が使い勝手を損なう用途に使う。
+      '';
+    };
+
     loadModels = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       readOnly = true;
+      default = config.local.ollama.generalModels ++ config.local.ollama.flashModels;
+      defaultText = lib.literalExpression "config.local.ollama.generalModels ++ config.local.ollama.flashModels";
       description = "Ollama registryからpullするモデル。";
     };
 


### PR DESCRIPTION
汎用モデルは知能を優先して選んでいるため、
簡単な質問を投げても回答が返るまで待たされていました。
特にCPU推論のseminarでは`qwen3.6:35b-a3b`が約18トークン/秒で、
3行程度の説明を求めるだけでも46秒かかります。

`loadModels`を`generalModels`と`flashModels`の連結として導出するようにして、
用途の違うモデルを枠として分けます。
`loadModels`自体は従来通りpullする対象の一覧なので、
`services.ollama.loadModels`へ渡す側は変わりません。

CPUのホストには`lfm2.5:8b`を選びます。
active 1BのMoEで、
`generalModels`と同じくCPUではactive parameterの少なさがそのまま速度になります。

seminarで同じ質問を投げた実測は以下の通りです。

- `lfm2.5:8b`(MoE 8B/active 1B): 約45トークン/秒、応答完了まで7秒
- `granite4.1:3b`(dense 3B): 約24トークン/秒
- `qwen3.5:4b`(dense 4B): 約16トークン/秒
- `gemma4:e4b`: 約16トークン/秒

denseは4Bまで落としても`qwen3.6:35b-a3b`と大差なく、
規模ではなくactive parameterで決まることが改めて確認できました。
コールドロードもディスクから6.5秒で、
23GiBある汎用モデルの34秒に比べて軽いです。

なお`lfm2.5:8b`はthinkingモデルですが、
Ollamaの`think: false`が効かず常に思考を出力します。
それでも実際の待ち時間は候補の中で最短でした。

GPUのホストは元々どのモデルでも実用的な速度が出るため、
品質を落とし過ぎない範囲で汎用モデルより一段小さい`qwen3.5:9b`にします。

2つのモデルを同時に常駐させた状態でも、
seminarのコンテナのcgroupは約28GBで`MemoryHigh`の約33GBに収まるため、
上限は据え置きます。

計測のために一時的にpullした他のモデルは削除済みです。
