### PR TITLE
fix(caddy): 死活監視用のエンドポイントを立てて監視を復旧します

### DIFF
--- a/lib/test-nixos-boot.nix
+++ b/lib/test-nixos-boot.nix
@@ -47,6 +47,18 @@ lib.mapAttrs (
           machine.fail("${curl} --fail --silent --max-time 3 http://127.0.0.1:2019/config/")
         '';
 
+    # `nixos/core/caddy.nix`が立てる死活監視用のエンドポイントを確認します。
+    # 監視エージェントがここを叩いているので、
+    # パスやポートが変わると監視だけが静かに落ちます。
+    # 127.0.0.1に限定できているかも合わせて見ます。
+    caddyHealthTest =
+      lib.optionalString hostDef.nixosSystem.config.services.caddy.enable # python
+        ''
+          machine.wait_for_open_port(2020, "127.0.0.1")
+          machine.succeed("${curl} --fail --silent --max-time 3 http://127.0.0.1:2020/health")
+          machine.fail("${curl} --fail --silent --max-time 3 http://[::1]:2020/health")
+        '';
+
     redirectTest =
       # 文字列の中身は`runNixOSTest`のテストドライバが実行するPythonです。
       # 直前の`# python`はtree-sitterなどに埋め込み言語を伝えてハイライトさせる、
@@ -126,6 +138,7 @@ lib.mapAttrs (
       machine.wait_for_unit("${socket}.socket")
     '') proxySockets
     + caddyAdminTest
+    + caddyHealthTest
     + redirectTest;
   }
 ) (lib.filterAttrs (_: def: !(def.nixosSystem.config.wsl.enable or false)) hostDefs)

--- a/nixos/core/caddy.nix
+++ b/nixos/core/caddy.nix
@@ -29,5 +29,21 @@
     services.caddy.globalConfig = ''
       admin unix//run/caddy/admin.sock
     '';
+    # 死活監視用のエンドポイント。
+    # Caddyには`/health`のようなヘルスチェック専用のエンドポイントが公式には存在せず、
+    # admin APIの`/config/`を叩くのが慣習的な代用になっていますが、
+    # あれは設定を返すAPIであってHTTPリスナーが実際に応答できるかは分かりません。
+    # admin APIがUNIXソケットに移ってTCPから叩けなくなったこともあり、
+    # 公式ドキュメントが案内している`respond`で自前のエンドポイントを立てます。
+    # https://caddyserver.com/docs/caddyfile/directives/respond
+    #
+    # `:2020`はadmin APIの既定の`2019`の隣というだけの番号です。
+    # ホスト名を書くとlocal CAによる自動HTTPSの対象になってしまうため、
+    # ポートだけを書いて`bind`で127.0.0.1に限定し、
+    # 同じホストの監視エージェントからのみ届くようにします。
+    services.caddy.virtualHosts.":2020".extraConfig = ''
+      bind 127.0.0.1
+      respond /health 200
+    '';
   };
 }

--- a/nixos/host/seminar/mackerel.nix
+++ b/nixos/host/seminar/mackerel.nix
@@ -115,7 +115,8 @@ in
               name = "check-caddy";
               runtimeInputs = [ pkgs.curl ];
               text = ''
-                if curl -f -s --max-time 3 http://localhost:2019/config/ > /dev/null 2>&1; then
+                # `nixos/core/caddy.nix`が127.0.0.1限定で立てているヘルスエンドポイント。
+                if curl -f -s --max-time 3 http://127.0.0.1:2020/health > /dev/null 2>&1; then
                   echo "Caddy OK"
                   exit 0
                 else


### PR DESCRIPTION
admin APIをUNIXソケットへ移した結果、
Mackerelの`check-caddy`が叩いていた`http://localhost:2019/config/`が繋がらなくなり、
Caddyは正常なのに監視だけがCRITICALになっていました。

curlに`--unix-socket`を付けて追随させることもできますが、
admin APIの`/config/`は設定を返すAPIであって、
HTTPリスナーが実際に応答できるかは分かりません。
Caddyには`/health`のようなヘルスチェック専用のエンドポイントが公式には存在せず、
公式ドキュメントが案内しているのは`respond`で自前のエンドポイントを立てる方法なので、
それに従います。

`nixos/core/caddy.nix`に置いたのは、
Caddyを有効にした他のホストでも同じ手段で死活を見られるようにするためです。
ホスト名を書くとlocal CAによる自動HTTPSの対象になってしまうため、
ポートだけを書いて`bind`で127.0.0.1に限定します。

seminarに適用して`/health`が200を返すこと、
`check-caddy`が`Caddy OK`で終了することを確認しました。
VMテストではポートが127.0.0.1でのみ開いていることも合わせて見ます。
bulletとseminarのブートテストが通ることを確認済みです。
