### PR TITLE
feat(comfyui): 動画の拡張子にロスレス有無とコーデック名を入れます

### DIFF
--- a/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
@@ -24,6 +24,10 @@ from PIL import Image
 
 
 anime_style_prefix = "Anime style, 2D cel animation, flat colors."
+# 拡張子にロスレスかどうかとコーデック名も含めて、
+# メタデータを確認しなくてもファイル名だけで中身が分かるようにする。
+# 区間も結合後も10-bit SVT-AV1 losslessのWebMで書き出す。
+video_suffix = ".lossless.av1.webm"
 wan_frame_count = 81
 wan_fps = 16.0
 wan_temporal_compression = 4
@@ -320,9 +324,20 @@ def generate_segment(
     return flatten_image_batch(vae.decode(low["samples"]))
 
 
+def partial_video_path(path: Path) -> Path:
+    """書き込み途中の動画パス。
+
+    ffmpegがコンテナを拡張子から推定できるように、
+    `.partial`は末尾ではなく`video_suffix`の手前へ入れる。
+    """
+    return path.with_name(
+        f"{path.name.removesuffix(video_suffix)}.partial{video_suffix}"
+    )
+
+
 def save_video(images: torch.Tensor, path: Path) -> None:
     height, width = images.shape[1:3]
-    temporary = path.with_suffix(".partial.webm")
+    temporary = partial_video_path(path)
     with av.open(temporary, mode="w") as container:
         stream = container.add_stream(
             "libsvtav1", rate=Fraction(wan_fps).limit_denominator(1001)
@@ -353,7 +368,7 @@ def save_video(images: torch.Tensor, path: Path) -> None:
 
 def concat_videos(paths: list[Path], output_path: Path) -> None:
     list_path = paths[0].parent / "concat.txt"
-    temporary = output_path.with_suffix(".partial.webm")
+    temporary = partial_video_path(output_path)
     list_path.write_text(
         "".join(f"file '{path.name}'\n" for path in paths), encoding="utf-8"
     )
@@ -456,10 +471,12 @@ class AnimeVideoQuick:
                 for index in range(1, segment_count + 1)
             ),
             *(
-                output_dir / "segments" / f"{filename_prefix}-segment-{index:03}.webm"
+                output_dir
+                / "segments"
+                / f"{filename_prefix}-segment-{index:03}{video_suffix}"
                 for index in range(segment_count)
             ),
-            output_dir / f"{filename_prefix}-final.webm",
+            output_dir / f"{filename_prefix}-final{video_suffix}",
         ]
         if any(not path.is_file() for path in expected_paths):
             return float("NaN")
@@ -546,9 +563,10 @@ class AnimeVideoQuick:
             if first_missing_keyframe is not None:
                 first_affected_segment = first_missing_keyframe - 1
                 for index in range(first_affected_segment, len(translated_segments)):
-                    (segment_dir / f"{filename_prefix}-segment-{index:03}.webm").unlink(
-                        missing_ok=True
-                    )
+                    (
+                        segment_dir
+                        / f"{filename_prefix}-segment-{index:03}{video_suffix}"
+                    ).unlink(missing_ok=True)
 
             if first_missing_keyframe is not None:
                 previous_path = (
@@ -579,7 +597,7 @@ class AnimeVideoQuick:
                 del current
 
             video_paths = [
-                segment_dir / f"{filename_prefix}-segment-{index:03}.webm"
+                segment_dir / f"{filename_prefix}-segment-{index:03}{video_suffix}"
                 for index in range(len(translated_segments))
             ]
             if any(not path.exists() for path in video_paths):
@@ -637,7 +655,7 @@ class AnimeVideoQuick:
                     del start, end, frames
                     comfy.model_management.soft_empty_cache()
 
-            final_name = f"{filename_prefix}-final.webm"
+            final_name = f"{filename_prefix}-final{video_suffix}"
             final_path = output_dir / final_name
             if not final_path.exists() or any(
                 final_path.stat().st_mtime_ns < path.stat().st_mtime_ns

--- a/nixos/host/bullet/comfyui/custom-node/save-svt-av1/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/save-svt-av1/__init__.py
@@ -13,6 +13,11 @@ from server import PromptServer
 
 logger = logging.getLogger(__name__)
 
+# 拡張子にロスレスかどうかとコーデック名も含めて、
+# メタデータを確認しなくてもファイル名だけで中身が分かるようにする。
+# このノードは常に10-bit SVT-AV1 losslessのWebMを書き出す。
+video_suffix = "lossless.av1.webm"
+
 
 def warn_video_only(error: object) -> None:
     detail = f"音声を保存できなかったため、映像のみ保存します: {error}"
@@ -72,10 +77,10 @@ class SaveSvtAv1:
             width,
             height,
         )
-        output_name = f"{filename}_{counter:05}_.webm"
+        output_name = f"{filename}_{counter:05}_.{video_suffix}"
         output_path = os.path.join(output_dir, output_name)
         partial_path = os.path.join(
-            output_dir, f"{filename}_{counter:05}_.partial.webm"
+            output_dir, f"{filename}_{counter:05}_.partial.{video_suffix}"
         )
         frame_rate = Fraction(fps).limit_denominator(1001)
 

--- a/nixos/host/bullet/comfyui/custom-node/seedvr2-streaming/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/seedvr2-streaming/__init__.py
@@ -10,7 +10,7 @@
 #
 # OUTPUT_NODE = TrueかつRETURN_TYPES = ()で、出力は自身がファイルへ書き出す。
 # 出力は映像のみで元動画の音声や字幕は引き継がない。
-# `.partial.mp4`へ書いてから`os.replace`で確定させ、
+# `.partial`付きの名前へ書いてから`os.replace`で確定させ、
 # 中断時はCLIのプロセスグループごと終了させて中間ファイルも削除する。
 #
 # 汎用ノードGetVideoSize(VIDEOから幅と高さを取得)も同梱する。
@@ -192,9 +192,15 @@ class SeedVR2StreamingVideoUpscaler:
             output_width,
             output_height,
         )
-        output_name = f"{filename}_{counter:05}_.mp4"
+        # 拡張子にロスレスかどうかとコーデック名も含めて、
+        # メタデータを確認しなくてもファイル名だけで中身が分かるようにする。
+        # CLIへは常に`--10bit`を渡すのでコーデックはlibx265で固定される。
+        video_suffix = f"{'lossless.' if lossless else ''}hevc.mp4"
+        output_name = f"{filename}_{counter:05}_.{video_suffix}"
         output_path = Path(output_dir) / output_name
-        partial_path = Path(output_dir) / f"{filename}_{counter:05}_.partial.mp4"
+        partial_path = (
+            Path(output_dir) / f"{filename}_{counter:05}_.partial.{video_suffix}"
+        )
         model_dir = get_model_dir(dit["model"], cli_fixed_vae)
 
         command = [

--- a/nixos/host/bullet/comfyui/workflow/anime-video-quick.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-quick.nix
@@ -11,7 +11,7 @@
 #
 # 出力先のanime-video-quick/<job ID>/manifest.jsonに進捗を記録する。
 # 同じ入力とjob IDで再実行すると生成済みファイルを飛ばして途中から再開する。
-# 動画区間は0始まりで、N行目はsegments/*-segment-<N-1>.webmに対応する。
+# 動画区間は0始まりで、N行目はsegments/*-segment-<N-1>.lossless.av1.webmに対応する。
 # 破綻した動画区間を削除して再実行すると、その区間だけを作り直す。
 # 終了キーフレームは1始まりで、N行目はkeyframes/*-keyframe-<N>.pngに対応する。
 # 絵から作り直す場合は該当キーフレームを削除する。そこから後の画像と動画も再生成される。


### PR DESCRIPTION
出力される動画の拡張子がコンテナ名だけだったため、
中身がAV1なのかHEVCなのか、
ロスレスなのかを知るには毎回`ffprobe`などでメタデータを見る必要がありました。
ファイル名に書いておけば一覧を見るだけで判別できます。

`SaveSvtAv1`は`.lossless.av1.webm`、
`AnimeVideoQuick`の区間と結合後も`.lossless.av1.webm`にします。
どちらも常に10-bit SVT-AV1 losslessで書き出すので固定です。

`SeedVR2StreamingVideoUpscaler`は`lossless`入力で切り替わるので、
真なら`.lossless.hevc.mp4`、
偽なら`.hevc.mp4`にします。
CLIへは常に`--10bit`を渡していてコーデックはlibx265で固定されるため、
コーデック名だけは固定で構いません。

コーデック名は`ffprobe`の`codec_name`に合わせて`h265`ではなく`hevc`にしました。
AV1側の`av1`と同じく、
ツールが報告する名前とファイル名が一致していたほうが迷いません。

書き込み途中のファイルは`.partial`を新しい拡張子の手前へ入れて、
`foo_00001_.partial.lossless.av1.webm`のようにします。
ffmpegとPyAVはコンテナを拡張子から推定するので、
末尾は`.webm`や`.mp4`のままである必要があります。
`AnimeVideoQuick`では`Path.with_suffix`が最後の要素しか置換せず、
意図した位置へ`.partial`を入れられないので`partial_video_path`を追加しました。

`AnimeVideoQuick`の再開判定は生成済みファイルの存在で行うため、
旧名で残っている進行中のジョブは未生成扱いになり区間を作り直します。
引き継ぎたい場合は既存ファイルをリネームしてください。
