### PR TITLE
feat(comfyui): ロスレス動画の隣に配布用の圧縮版を自動で作ります

### DIFF
--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -50,6 +50,19 @@ in
           ${checkPythonSyntax source}
           install -D -m 0644 ${source} $out/__init__.py
         '';
+      # 複数の自作ノードで共有するPythonモジュールを構文検査してから配置する。
+      # symlinkJoinで各ノードのパッケージへ混ぜて相対importで読ませるため、
+      # `__init__.py`ではなくPythonのモジュール名になるファイル名で置く。
+      writeCheckedModulePy =
+        name: fileName: source:
+        pkgs.runCommand name { } ''
+          ${checkPythonSyntax source}
+          install -D -m 0644 ${source} $out/${fileName}
+        '';
+      # 保存したロスレス動画から配布向けの圧縮版を作る共有モジュール。
+      shareEncode =
+        writeCheckedModulePy "comfyui-share-encode" "share_encode.py"
+          ./custom-node/share_encode.py;
       loraManager = pkgs.fetchFromGitHub {
         owner = "willmiao";
         repo = "ComfyUI-Lora-Manager";
@@ -127,8 +140,13 @@ in
           };
           # SeedVR2 CLIのチャンク処理をComfyUIから起動し、長尺動画をRAM上限付きで処理する。
           # 解像度の自動計算に使う、VIDEOから幅と高さを取り出す汎用ノードGetVideoSizeも同梱する。
-          "ComfyUI-SeedVR2-Streaming" =
-            writeCheckedInitPy "comfyui-seedvr2-streaming" ./custom-node/seedvr2-streaming/__init__.py;
+          "ComfyUI-SeedVR2-Streaming" = pkgs.symlinkJoin {
+            name = "comfyui-seedvr2-streaming";
+            paths = [
+              (writeCheckedInitPy "comfyui-seedvr2-streaming-init" ./custom-node/seedvr2-streaming/__init__.py)
+              shareEncode
+            ];
+          };
           # UltralyticsDetectorProvider(YOLOによる顔検出)を提供する。
           # FaceDetailerに検出器を渡すために必要。
           "ComfyUI-Impact-Subpack" = pkgs.fetchFromGitHub {
@@ -164,13 +182,19 @@ in
               (pkgs.writeTextDir "web/notification.js" (
                 builtins.readFile ./custom-node/save-svt-av1/web/notification.js
               ))
+              shareEncode
             ];
           };
           # 複数行の指示からQwen編集画像を先に全て作り、
           # そのキーフレーム間をWan FLF2Vで順番に動画化する。
           # 各成果物を都度保存するため、長さに比例して画像テンソルをRAMへ蓄積しない。
-          "ComfyUI-Anime-Video-Quick" =
-            writeCheckedInitPy "comfyui-anime-video-quick" ./custom-node/anime-video-quick/__init__.py;
+          "ComfyUI-Anime-Video-Quick" = pkgs.symlinkJoin {
+            name = "comfyui-anime-video-quick";
+            paths = [
+              (writeCheckedInitPy "comfyui-anime-video-quick-init" ./custom-node/anime-video-quick/__init__.py)
+              shareEncode
+            ];
+          };
           # danbooruタグのオートコンプリート。
           # 日本語からの検索とpost count表示に対応していて、
           # メジャーなタグかどうかを確認しながら入力できる。

--- a/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
@@ -22,6 +22,8 @@ import torch
 from comfy_extras.nodes_model_advanced import ModelSamplingSD3
 from PIL import Image
 
+from .share_encode import start_share_encode
+
 
 anime_style_prefix = "Anime style, 2D cel animation, flat colors."
 # 拡張子にロスレスかどうかとコーデック名も含めて、
@@ -662,6 +664,8 @@ class AnimeVideoQuick:
                 for path in video_paths
             ):
                 concat_videos(video_paths, final_path)
+            # 区間は途中経過で配布物ではないので、結合後の完成品だけ圧縮版を作る。
+            start_share_encode(final_path, video_suffix)
             manifest["status"] = "completed"
             manifest["video"] = str(final_path)
             manifest.pop("error", None)

--- a/nixos/host/bullet/comfyui/custom-node/save-svt-av1/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/save-svt-av1/__init__.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 from fractions import Fraction
+from pathlib import Path
 from typing import Any
 
 import av
@@ -11,12 +12,14 @@ import torch
 import folder_paths
 from server import PromptServer
 
+from .share_encode import start_share_encode
+
 logger = logging.getLogger(__name__)
 
 # 拡張子にロスレスかどうかとコーデック名も含めて、
 # メタデータを確認しなくてもファイル名だけで中身が分かるようにする。
 # このノードは常に10-bit SVT-AV1 losslessのWebMを書き出す。
-video_suffix = "lossless.av1.webm"
+video_suffix = ".lossless.av1.webm"
 
 
 def warn_video_only(error: object) -> None:
@@ -77,10 +80,10 @@ class SaveSvtAv1:
             width,
             height,
         )
-        output_name = f"{filename}_{counter:05}_.{video_suffix}"
+        output_name = f"{filename}_{counter:05}_{video_suffix}"
         output_path = os.path.join(output_dir, output_name)
         partial_path = os.path.join(
-            output_dir, f"{filename}_{counter:05}_.partial.{video_suffix}"
+            output_dir, f"{filename}_{counter:05}_.partial{video_suffix}"
         )
         frame_rate = Fraction(fps).limit_denominator(1001)
 
@@ -199,6 +202,8 @@ class SaveSvtAv1:
                     warn_video_only(error)
 
         os.replace(partial_path, output_path)
+        # ロスレスのままでは公開用には大きすぎるので、配布用の圧縮版も裏で作る。
+        start_share_encode(Path(output_path), video_suffix)
 
         return {
             "ui": {

--- a/nixos/host/bullet/comfyui/custom-node/seedvr2-streaming/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/seedvr2-streaming/__init__.py
@@ -26,6 +26,8 @@ from typing import Any
 import folder_paths
 from comfy.model_management import throw_exception_if_processing_interrupted
 
+from .share_encode import start_share_encode
+
 logger = logging.getLogger(__name__)
 
 # custom_nodes配下のsymlinkのままのパスを保つため実体解決はしない。
@@ -195,11 +197,11 @@ class SeedVR2StreamingVideoUpscaler:
         # 拡張子にロスレスかどうかとコーデック名も含めて、
         # メタデータを確認しなくてもファイル名だけで中身が分かるようにする。
         # CLIへは常に`--10bit`を渡すのでコーデックはlibx265で固定される。
-        video_suffix = f"{'lossless.' if lossless else ''}hevc.mp4"
-        output_name = f"{filename}_{counter:05}_.{video_suffix}"
+        video_suffix = f".{'lossless.' if lossless else ''}hevc.mp4"
+        output_name = f"{filename}_{counter:05}_{video_suffix}"
         output_path = Path(output_dir) / output_name
         partial_path = (
-            Path(output_dir) / f"{filename}_{counter:05}_.partial.{video_suffix}"
+            Path(output_dir) / f"{filename}_{counter:05}_.partial{video_suffix}"
         )
         model_dir = get_model_dir(dit["model"], cli_fixed_vae)
 
@@ -319,6 +321,9 @@ class SeedVR2StreamingVideoUpscaler:
                     process.wait()
             partial_path.unlink(missing_ok=True)
             raise
+        # アップスケール結果はそのままでは公開用には大きすぎるので、
+        # 配布用の圧縮版も裏で作る。
+        start_share_encode(output_path, video_suffix)
 
         return {
             "ui": {

--- a/nixos/host/bullet/comfyui/custom-node/share_encode.py
+++ b/nixos/host/bullet/comfyui/custom-node/share_encode.py
@@ -1,0 +1,132 @@
+# ロスレスで保存した動画の隣へ、配布向けに圧縮した動画を作るモジュール。
+#
+# ロスレス動画は公開したり人へ渡したりするには大きすぎるので、
+# そのまま出せる大きさの版も一緒に欲しい。
+# 元のロスレスも残したいため、同じディレクトリへ拡張子だけ変えて並べる。
+#
+# 保存が終わった後にバックグラウンドのスレッドでffmpegを回す。
+# 生成自体は既に成功しているので、
+# 圧縮に失敗してもワークフローは成功のままにしてログだけ残す。
+# 完成前のファイルをSamba越しに掴まないよう、
+# `.partial`付きの名前へ書いてから`os.replace`で確定させる。
+#
+# 各カスタムノードのパッケージへsymlinkJoinで同じファイルを配り、
+# `from .share_encode import start_share_encode`と相対importで使う。
+import logging
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# 配布用動画の拡張子。
+# ロスレス側から`lossless.`が落ちただけの対になる名前にして、
+# ファイル名を見ただけでどちらがどちらか分かるようにする。
+share_suffix = ".av1.webm"
+# 配布用の品質。
+# 1104x848の5秒のロスレス出力で測ったところ、
+# CRF 24で1.51MB(PSNR-Y 45.4dB)、30で0.97MB(43.6dB)、40で0.48MB(40.4dB)だった。
+# 30ならロスレスの1/46でPSNR-Yは40dB台を保つので、配布する品質として十分。
+share_crf = 30
+# SVT-AV1のpreset。
+# 2134x3840の5秒(104MB)をCRF 30で圧縮した時の実測。
+#
+#   preset 6:   5.5秒  3.73MB
+#   preset 4:   7.8秒  3.37MB
+#   preset 3:  14.2秒  3.28MB
+#   preset 2:  25.0秒  3.06MB
+#   preset 1:  48.3秒  2.99MB
+#   preset 0: 103.3秒  2.96MB
+#
+# 1段下げるたびに時間はほぼ倍になるが、サイズの減りは2→1で2.2%、1→0で0.9%と潰れる。
+# preset 2はpreset 0まで詰めた場合の圧縮の87%を4分の1の時間で得られる。
+#
+# 動画生成やアップスケール自体が数十分から数時間かかるのに対して、
+# ここでの数十秒は誤差なので、速度より圧縮率を優先して選んでいる。
+#
+# なおここで作る版はそのまま公開に使っても困らない程度ではある。
+# 画質を真剣に詰めたい時だけ、ロスレスからCRFを30より下げて画質を優先し、
+# preset 0で時間をかけてエンコードし直せばよい。
+share_preset = 2
+
+# 圧縮を直列化するロック。
+# 続けて生成すると複数のffmpegが並ぶが、
+# コンテナのCPUQuotaは共有なので並べても総時間は縮まず、生成の邪魔になるだけ。
+encode_lock = threading.Lock()
+
+
+def start_share_encode(source: Path, video_suffix: str) -> None:
+    """`source`から配布用の圧縮動画を作る作業を開始する。
+
+    `video_suffix`は`source`が持つ拡張子で、
+    これを`share_suffix`へ置き換えた名前が出力先になる。
+    """
+    destination = source.with_name(
+        f"{source.name.removesuffix(video_suffix)}{share_suffix}"
+    )
+    threading.Thread(
+        target=encode_for_share,
+        args=(source, destination),
+        name=f"share-encode-{destination.name}",
+        daemon=True,
+    ).start()
+
+
+def encode_for_share(source: Path, destination: Path) -> None:
+    # niceはLinuxではスレッド単位の属性で、子プロセスは生成元スレッドの値を継ぐ。
+    # このスレッドだけを譲る側へ回して、ffmpegが生成のCPUを奪わないようにする。
+    os.nice(19)
+    partial = destination.with_name(
+        f"{destination.name.removesuffix(share_suffix)}.partial{share_suffix}"
+    )
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        # サービスから起動するので端末は無く、入力待ちで止まらないようにする。
+        "-nostdin",
+        # 中断した過去の実行が残した`.partial`をそのまま上書きする。
+        "-y",
+        "-i",
+        os.fspath(source),
+        "-c:v",
+        "libsvtav1",
+        "-crf",
+        str(share_crf),
+        "-preset",
+        str(share_preset),
+        # 入力が10-bitなので、8-bitへ落とすと単に情報が減るだけになる。
+        # AV1はMain profileが10-bitを含むので再生互換の心配もない。
+        "-pix_fmt",
+        "yuv420p10le",
+        # tuneは`0 = VQ, 1 = PSNR, 2 = SSIM`で既定は1。
+        # 人が見るための動画なので、指標ではなく視覚品質を狙う0を選ぶ。
+        # ただし視覚品質は主観なので、PSNRやSSIMでの裏付けは取っていない。
+        "-svtav1-params",
+        "tune=0",
+        # 音声は雑に決めた値で、特に比較検討はしていない。
+        # そもそも音声を持つ出力が少なく、容量はほぼ映像で決まるので、
+        # Opusで十分とよく言われる128kbpsをそのまま使っている。
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "128k",
+        os.fspath(partial),
+    ]
+    try:
+        with encode_lock:
+            if destination.exists():
+                logger.info(
+                    "Skipping share encode because it already exists: %s", destination
+                )
+                return
+            logger.info("Encoding video for sharing: %s", " ".join(command))
+            subprocess.run(command, check=True)
+            os.replace(partial, destination)
+        logger.info("Encoded video for sharing: %s", destination)
+    except Exception as error:
+        # ロスレス側の保存は終わっているので、ここで失敗しても生成はやり直させない。
+        logger.warning("Failed to encode video for sharing: %s: %s", destination, error)
+        partial.unlink(missing_ok=True)


### PR DESCRIPTION
ロスレス出力は公開したり人へ渡したりするには大きすぎます。
かといってロスレスを消したくはないので、
保存の直後に同じディレクトリへ配布用の圧縮版を並べます。
拡張子は`lossless.`が落ちただけの`.av1.webm`にして、
対であることが分かるようにします。

対象は`SaveSvtAv1`と、
`AnimeVideoQuick`の結合後の完成品と、
`SeedVR2StreamingVideoUpscaler`の出力です。
`AnimeVideoQuick`の区間は途中経過であって配布物ではないので圧縮しません。

生成そのものは既に成功しているため、
圧縮の失敗でワークフローまで失敗させたくはありません。
バックグラウンドのスレッドでffmpegを回して、
失敗してもログだけ残します。
書き込み途中のファイルを共有越しに掴まないよう、
`.partial`付きの名前へ書いてから`os.replace`で確定させます。

ロックで直列化するのは、
コンテナの`CPUQuota`を生成と共有しているからです。
同時に何本も回しても総時間は縮まらず、
生成を邪魔するだけです。
同じ理由でワーカースレッドを`os.nice(19)`します。
niceはLinuxではスレッド単位の属性で子プロセスへ継承されるため、
ffmpegだけが譲る側になります。

パラメータのCRF 30とpreset 2は実際の出力で測って決めました。
1104x848の5秒で測ったCRFは以下の通りです。

- CRF 24は1.51MBでPSNR-Y 45.4dB
- CRF 30は0.97MBでPSNR-Y 43.6dB
- CRF 40は0.48MBでPSNR-Y 40.4dB

2134x3840の5秒で測ったpresetは以下の通りです。

- preset 6は5.5秒で3.73MB
- preset 4は7.8秒で3.37MB
- preset 3は14.2秒で3.28MB
- preset 2は25.0秒で3.06MB
- preset 1は48.3秒で2.99MB
- preset 0は103.3秒で2.96MB

presetを1段下げるたびに時間は倍になるのに、
サイズの減りは2から1で2.2%しかなく、
1から0では0.9%まで潰れます。
preset 2なら0まで詰めた場合の圧縮の87%を4分の1の時間で得られます。
生成やアップスケール自体が数十分から数時間かかるので、
ここでの数十秒は誤差です。

共有モジュールは`writeCheckedModulePy`で構文検査してから、
`symlinkJoin`で3つのノードのパッケージへ配って相対importで読ませます。
ComfyUIは`__init__.py`を`spec_from_file_location`で読み込むため、
パッケージとして扱われて`from .share_encode import`が解決されます。

bulletへ適用して、
モデルを使わない最小のワークフローをAPIから流して確認しました。
`EmptyImage`の16フレームを`SaveSvtAv1`へ渡すだけのものです。
ロスレス出力の隣に`.av1.webm`が生成されて、
中身は10-bit AV1の1.001秒で`.partial`の残骸もなく、
ログにもpreset 2とtune VQとCRF 30が出ていました。
