### PR TITLE
feat(comfyui): 保存したPNGを裏でoxipngにかけて縮めます

### DIFF
--- a/nixos/host/bullet/comfyui/container.nix
+++ b/nixos/host/bullet/comfyui/container.nix
@@ -140,7 +140,10 @@ in
         systemd.services.comfyui.environment.PYTHONPATH = lib.makeSearchPath comfyuiPython.sitePackages [
           sageattention
         ];
-        systemd.services.comfyui.path = with pkgs; [ ffmpeg ];
+        systemd.services.comfyui.path = with pkgs; [
+          ffmpeg
+          oxipng
+        ];
       };
   };
   networking = {

--- a/nixos/host/bullet/comfyui/custom-node.nix
+++ b/nixos/host/bullet/comfyui/custom-node.nix
@@ -63,6 +63,10 @@ in
       shareEncode =
         writeCheckedModulePy "comfyui-share-encode" "share_encode.py"
           ./custom-node/share_encode.py;
+      # 保存したPNGを可逆再圧縮で縮める共有モジュール。
+      optimizePng =
+        writeCheckedModulePy "comfyui-optimize-png-module" "optimize_png.py"
+          ./custom-node/optimize_png.py;
       loraManager = pkgs.fetchFromGitHub {
         owner = "willmiao";
         repo = "ComfyUI-Lora-Manager";
@@ -193,6 +197,16 @@ in
             paths = [
               (writeCheckedInitPy "comfyui-anime-video-quick-init" ./custom-node/anime-video-quick/__init__.py)
               shareEncode
+              optimizePng
+            ];
+          };
+          # 本体のSaveImageが書き出したPNGを保存後に縮める自作ノード。
+          # ノードは提供せず、保存処理を包む副作用だけを持つ。
+          "ComfyUI-Optimize-Png" = pkgs.symlinkJoin {
+            name = "comfyui-optimize-png";
+            paths = [
+              (writeCheckedInitPy "comfyui-optimize-png-init" ./custom-node/optimize-png/__init__.py)
+              optimizePng
             ];
           };
           # danbooruタグのオートコンプリート。

--- a/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
@@ -414,9 +414,14 @@ def sanitize_job_id(job_id: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "-", job_id.strip()).strip(".-")
 
 
-def file_fingerprint(path: Path, base: Path) -> tuple[str, int, int]:
+def file_fingerprint(path: Path, base: Path) -> tuple[str, int]:
+    # ファイルサイズは見ない。
+    # キーフレームは保存後にoxipngが縮めるため、
+    # 内容が同じままサイズだけ後から変わる。
+    # oxipngへは`--preserve`を渡していて更新日時は動かないので、
+    # 更新日時だけを見れば作り直しを検出できる。
     status = path.stat()
-    return path.relative_to(base).as_posix(), status.st_mtime_ns, status.st_size
+    return path.relative_to(base).as_posix(), status.st_mtime_ns
 
 
 class AnimeVideoQuick:

--- a/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/anime-video-quick/__init__.py
@@ -22,6 +22,7 @@ import torch
 from comfy_extras.nodes_model_advanced import ModelSamplingSD3
 from PIL import Image
 
+from .optimize_png import start_optimize_png
 from .share_encode import start_share_encode
 
 
@@ -119,6 +120,9 @@ def save_image(image: torch.Tensor, path: Path) -> None:
     temporary = path.with_suffix(".partial.png")
     Image.fromarray(array, "RGB").save(temporary)
     os.replace(temporary, path)
+    # キーフレームは配布物ではないが、
+    # 縮めても画素は変わらないので動画の区間と違って除外する理由がない。
+    start_optimize_png(path)
 
 
 def load_image(path: Path) -> torch.Tensor:

--- a/nixos/host/bullet/comfyui/custom-node/optimize-png/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/optimize-png/__init__.py
@@ -37,7 +37,13 @@ def save_images(self: nodes.SaveImage, *args: Any, **kwargs: Any) -> dict[str, A
     return result
 
 
-nodes.SaveImage.save_images = save_images
+setattr(save_images, "optimize_png_wrapped", True)
+
+# ComfyUI-Managerによる再読み込みなどでこのモジュールが二度読まれると、
+# 何もしなければ包んだ関数を更に包んで1枚のPNGへoxipngを二重に走らせてしまう。
+# 目印を見て、既に包んであれば差し替えない。
+if not getattr(nodes.SaveImage.save_images, "optimize_png_wrapped", False):
+    nodes.SaveImage.save_images = save_images
 
 # ノードを提供しないが、これがないとComfyUIが読み込み失敗として扱う。
 NODE_CLASS_MAPPINGS: dict[str, type] = {}

--- a/nixos/host/bullet/comfyui/custom-node/optimize-png/__init__.py
+++ b/nixos/host/bullet/comfyui/custom-node/optimize-png/__init__.py
@@ -1,0 +1,43 @@
+# ComfyUI標準のSaveImageが書き出したPNGを、保存後にoxipngで縮めるだけのカスタムノード。
+#
+# ノードは足さず、`save_images`を包む副作用だけを持つ。
+# PNGを出す経路のほとんどは本体側のSaveImageなので、
+# 自作ノードを増やしてもワークフローを書き換えなければ効果がない。
+#
+# 本体へパッチを当てる方法もあるが、
+# 包むだけなら保存処理の中身が変わっても追随が要らず、
+# 万一戻り値の形が変わってもPNGが縮まなくなるだけで生成には影響しない。
+import logging
+from pathlib import Path
+from typing import Any
+
+import nodes
+
+from .optimize_png import start_optimize_png
+
+logger = logging.getLogger(__name__)
+
+original_save_images = nodes.SaveImage.save_images
+
+
+def save_images(self: nodes.SaveImage, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    result = original_save_images(self, *args, **kwargs)
+    # PreviewImageもSaveImageを継承していて、こちらは一時ディレクトリへ書く。
+    # すぐ消える画像を縮めても仕方がないので、出力ディレクトリの分だけ扱う。
+    if getattr(self, "type", None) != "output":
+        return result
+    try:
+        for image in result["ui"]["images"]:
+            start_optimize_png(
+                Path(self.output_dir) / image["subfolder"] / image["filename"]
+            )
+    except Exception as error:
+        # 保存自体は終わっているので、ここで失敗しても生成はやり直させない。
+        logger.warning("Failed to start PNG optimization: %s", error)
+    return result
+
+
+nodes.SaveImage.save_images = save_images
+
+# ノードを提供しないが、これがないとComfyUIが読み込み失敗として扱う。
+NODE_CLASS_MAPPINGS: dict[str, type] = {}

--- a/nixos/host/bullet/comfyui/custom-node/optimize_png.py
+++ b/nixos/host/bullet/comfyui/custom-node/optimize_png.py
@@ -1,0 +1,105 @@
+# 保存したPNGを、画素を変えずに小さくし直すモジュール。
+#
+# ComfyUIのPNG保存はPillowの`compress_level=4`で、
+# 生成の待ち時間を延ばさないよう圧縮を軽く済ませている。
+# 画像は消さずに増えていく一方なので、
+# 生成時間に比べれば無視できる時間で1割縮むなら縮めておきたい。
+#
+# oxipngは行フィルタの選び直しと再圧縮を試すだけで画素は変えないため、
+# 差し替えても画像の中身は同じになる。
+# 既定ではチャンクも落とさないので、
+# ComfyUIがtEXtへ書くpromptとworkflowも残り、
+# 画像をComfyUIへ投げ込んでワークフローを復元する使い方も壊れない。
+#
+# 保存が終わった後にバックグラウンドのスレッドでoxipngを回す。
+# 保存自体は既に成功しているので、
+# 縮めるのに失敗してもワークフローは成功のままにしてログだけ残す。
+# 書き込み途中のファイルを掴まれないよう、
+# `--out`で`.partial`付きの名前へ書いてから`os.replace`で差し替える。
+#
+# 動画の配布用エンコードと違って直列化はしない。
+# oxipngが1枚に使うCPUは`-o max`でも5コア程度で、
+# 生成中に遊んでいる32スレッドのごく一部で済むため、
+# 何枚か並んでも取り合いにはならない。
+#
+# 各カスタムノードのパッケージへsymlinkJoinで同じファイルを配り、
+# `from .optimize_png import start_optimize_png`と相対importで使う。
+import logging
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# oxipngの最適化レベル。
+# ComfyUIが出力した4枚(1392x752から1536x1536、合計9.76MiB)での実測。
+#
+#   -o 2(既定):              11.66%減    4.8秒
+#   -o 5:                    12.30%減    8.2秒
+#   -o max:                  12.34%減   12.0秒
+#   -o max --fast --zopfli:  12.63%減  151.3秒
+#   -o max --zopfli:         12.63%減  163.9秒
+#
+# 削減率はレベルを上げてもほとんど伸びず、12%台で頭打ちになる。
+# zopfliは`-o max`から更に0.3ポイント縮むだけで13倍の時間がかかり、
+# `--fast`の有無でも結果が変わらなかったので使わない。
+# それでも`-o max`を選ぶのは、
+# 1枚3秒程度と生成にかかる数十秒から数分に対しては誤差だからで、
+# 頭打ちの範囲で一番縮む設定を取っておく。
+#
+# なお`--interlace`の既定は`off`なので明示していない。
+optimize_level = "max"
+
+
+def start_optimize_png(path: Path) -> None:
+    """`path`のPNGを可逆に縮めて置き換える作業を開始する。"""
+    threading.Thread(
+        target=optimize_png,
+        args=(path,),
+        name=f"optimize-png-{path.name}",
+        daemon=True,
+    ).start()
+
+
+def optimize_png(path: Path) -> None:
+    # niceはLinuxではスレッド単位の属性で、子プロセスは生成元スレッドの値を継ぐ。
+    # このスレッドだけを譲る側へ回して、oxipngが生成のCPUを奪わないようにする。
+    os.nice(19)
+    partial = path.with_suffix(".partial.png")
+    command = [
+        "oxipng",
+        "--opt",
+        optimize_level,
+        # 差し替えは自分で行うので、oxipngには別名で書かせる。
+        "--out",
+        os.fspath(partial),
+        # 生成日時としての意味があるので、縮めた時刻で更新日時を上書きしない。
+        "--preserve",
+        os.fspath(path),
+    ]
+    try:
+        before = path.stat().st_size
+        # 成功時に出る統計は自前のログと重複するので捨てる。
+        # `--quiet`だと失敗の理由まで消えてしまうため、
+        # 黙らせるのではなく出力を受け取っておく。
+        subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        after = partial.stat().st_size
+        os.replace(partial, path)
+        logger.info("Optimized PNG: %s: %d -> %d bytes", path, before, after)
+    # 元のPNGは既に保存されているので、ここで失敗しても生成はやり直させない。
+    except subprocess.CalledProcessError as error:
+        logger.warning(
+            "Failed to optimize PNG: %s: %s: %s", path, error, error.stderr.strip()
+        )
+    except Exception as error:
+        logger.warning("Failed to optimize PNG: %s: %s", path, error)
+    finally:
+        # 失敗した時に書きかけを残さない。成功していれば既に消えている。
+        partial.unlink(missing_ok=True)

--- a/nixos/host/bullet/comfyui/custom-node/optimize_png.py
+++ b/nixos/host/bullet/comfyui/custom-node/optimize_png.py
@@ -15,7 +15,10 @@
 # 保存自体は既に成功しているので、
 # 縮めるのに失敗してもワークフローは成功のままにしてログだけ残す。
 # 書き込み途中のファイルを掴まれないよう、
-# `--out`で`.partial`付きの名前へ書いてから`os.replace`で差し替える。
+# `--out`で仮の名前へ書いてから`os.replace`で差し替える。
+# 仮の名前を`.oxipng-partial`にしているのは、
+# 保存側が使う`.partial`と名前空間を分けるためで、
+# 同じパスへの保存が最適化の最中に走っても互いの一時ファイルを奪わない。
 #
 # 動画の配布用エンコードと違って直列化はしない。
 # oxipngが1枚に使うCPUは`-o max`でも5コア程度で、
@@ -66,7 +69,10 @@ def optimize_png(path: Path) -> None:
     # niceはLinuxではスレッド単位の属性で、子プロセスは生成元スレッドの値を継ぐ。
     # このスレッドだけを譲る側へ回して、oxipngが生成のCPUを奪わないようにする。
     os.nice(19)
-    partial = path.with_suffix(".partial.png")
+    # 保存側の`.partial.png`とぶつからない名前にする。
+    # 同じパスへの保存がこのスレッドの生存中に走った場合、
+    # 名前を共有していると互いの一時ファイルを消し合ってしまう。
+    partial = path.with_suffix(".oxipng-partial.png")
     command = [
         "oxipng",
         "--opt",


### PR DESCRIPTION
ComfyUIのPNG保存はPillowの`compress_level=4`で、
生成の待ち時間を延ばさないよう圧縮を軽く済ませています。
画像は消さずに増えていく一方なので、
生成時間に比べれば無視できる時間で1割縮むなら縮めておきたいです。

oxipngは行フィルタの選び直しと再圧縮を試すだけで画素は変えないため、
差し替えても画像の中身は同じです。
既定ではチャンクも落とさないので、
ComfyUIがtEXtへ書くpromptとworkflowも残り、
画像を投げ込んでワークフローを復元する使い方も壊れません。

PNGを出す経路のほとんどは本体の`SaveImage`なので、
ノードを提供しない`ComfyUI-Optimize-Png`を足して`save_images`を包みます。
本体へパッチを当てる手もありますが、
包むだけなら保存処理の中身が変わっても追随が要らず、
万一戻り値の形が変わってもPNGが縮まなくなるだけで生成には影響しません。
`PreviewImage`も同じクラスを継承していますが、
一時ディレクトリへ書くので`type`を見て対象から外します。
`AnimeVideoQuick`のキーフレームは配布物ではありませんが、
縮めても画素は変わらず動画の区間と違って除外する理由がないので、
こちらは`save_image`から直接呼びます。

オプションはComfyUIが出力した4枚の合計9.76MiBで測って決めました。

- `-o 2`は既定で11.66%減の4.8秒
- `-o 5`は12.30%減の8.2秒
- `-o max`は12.34%減の12.0秒
- `-o max --fast --zopfli`は12.63%減の151.3秒
- `-o max --zopfli`は12.63%減の163.9秒

zopfliは`-o max`から更に0.3ポイント縮むだけで13倍の時間がかかり、
`--fast`の有無でも結果のバイト数が変わらなかったので使いません。
`-o max`は`-o 5`ともほとんど差がありませんが、
1枚3秒は生成にかかる数十秒から数分に対しては誤差なので、
頭打ちの範囲で一番縮む設定にしておきます。
`--interlace`は既定が`off`なので指定していません。

書き込み途中のファイルを掴まれないよう、
`--out`で`.partial`付きの名前へ書いてから`os.replace`で差し替えます。
更新日時は生成日時としての意味があるので`--preserve`で保ちます。
`--quiet`は失敗の理由まで消してしまうので使わず、
標準エラー出力を受け取ってログへ回します。

動画の配布用エンコードと違って直列化はしません。
1枚に使うCPUは`-o max`でも541%と5コア程度で、
生成中に遊んでいる32スレッドのごく一部で済むからです。
ワーカースレッドは`os.nice(19)`して生成のCPUを奪わないようにします。

bulletへ適用して、
`LoadImage`から`SaveImage`へ実画像を通して確認しました。
3275565バイトが2721169バイトへ減り、
tEXtのpromptチャンクも残っていました。
oxipngの前後の画素はImageMagickの`compare -metric AE`で差分0でした。
