### PR TITLE
feat(claude-code): セッションごとにメモリ制限を付けて起動します

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -371,10 +371,47 @@ in
     };
   };
 
+  # 制限は持たせず、`systemd-cgls`や`systemctl --user status`で
+  # Claude Codeのセッション群をまとめて観察するためだけのsliceです。
+  # Termuxなどsystemdの無い環境では単にスキップされます。
+  systemd.user.slices.claude-code = {
+    Unit.Description = "Claude Code sessions";
+  };
+
   home = {
     # Claude Codeがnativeインストール時に`~/.local/bin/claude`が存在していないと警告を出すため、
     # シンボリックリンクを作成して警告を抑制します。
-    file.".local/bin/claude".source = "${config.programs.claude-code.finalPackage}/bin/claude";
+    # またその際に、暴走したセッションが他のアプリをOOM Killerに殺させないように、
+    # セッションごとのメモリ制限を付けて起動するラッパーを挟みます。
+    file.".local/bin/claude".source = lib.getExe (
+      pkgs.writeShellApplication {
+        name = "claude";
+        # `systemd-run`をPATH経由の偶然に頼らずNixの依存として明示します。
+        runtimeInputs = [ pkgs.systemd ];
+        text = ''
+          claude=${config.programs.claude-code.finalPackage}/bin/claude
+          # systemdがPID 1ではない環境(Termuxなど)ではそのまま起動します。
+          if [ -d /run/systemd/system ]; then
+            # `--scope`はサービスと違いsystemd-run自身の子プロセスとして実行されるため、
+            # TTY・環境変数・カレントディレクトリがそのまま使えて対話TUIも問題ありません。
+            # メモリ制限はセッション(scope)ごとに独立して付けます。
+            # 暴走した1セッションだけがcgroup内のOOM Killerで殺され、
+            # 他の正常なセッションや他のアプリは巻き添えを食いません。
+            # systemdの`%`は全て物理メモリに対する割合です。
+            # MemorySwapMaxはswap容量比ではないことに注意。
+            # zram(物理メモリの20%、16GiB上限)の約半分を意図して10%としています。
+            exec systemd-run --user --scope --quiet --collect \
+              --slice=claude-code.slice \
+              --same-dir \
+              -p MemoryHigh=75% \
+              -p MemoryMax=80% \
+              -p MemorySwapMax=10% \
+              -- "$claude" "$@"
+          fi
+          exec "$claude" "$@"
+        '';
+      }
+    );
 
     activation = {
       # `~/.claude.json`に書き込まれる設定をインストール時に設定。


### PR DESCRIPTION
Claude Codeがメモリを大量に消費する処理を不用意に起動した時に、
グローバルなOOM Killerが他のアプリを殺してしまうのを防ぎます。

`~/.local/bin/claude`を`writeShellApplication`製のラッパーに差し替えて、
systemd環境では`systemd-run --user --scope`でcgroupの制限を付けて起動します。

- `MemoryHigh=75%`: ソフトリミット。超えると積極的なreclaimとスロットリングで
  ハードリミット到達を遅らせます
- `MemoryMax=80%`: ハードリミット。超えるとそのcgroupの内側だけで
  OOM Killerが発動し、殺されるのはClaude Code配下のプロセスだけになります
- `MemorySwapMax=10%`: 実メモリを食い潰した時に他のアプリを
  swapへ押し込め続けないようにします。systemdの`%`はswap容量ではなく
  物理メモリ比なので、zram(物理メモリの20%、16GiB上限)の約半分を
  意図して10%としています

制限は全セッション合算のsliceではなく、
起動ごとに作られるscopeへ個別に付けます。
目的は暴走したセッションを止めることなので、
暴走した1セッションだけが死んで、
tmux上の他の正常なセッションが巻き添えを食わない方を選びました。
`claude-code.slice`は制限を持たせず、
セッション群をまとめて観察するためだけに定義します。

CPUは制限しません。
スケジューラが割り当てを調停するので取り合っても問題が少なく、
ビルドなどの作業は速い方が良いためです。

Termux(nix-on-droid)にはsystemdが無いので、
`/run/systemd/system`の有無で判定してそのままexecへフォールバックします。
`runtimeInputs`のsystemdパッケージはTermuxのclosureにも入りますが、
層配置は厳密さより単純さを優先してhome/coreに置いたままにします。

なお`nix build`類はシステムサービスのnix-daemon側で実行されるため、
この制限の対象外です。

Claude-Session: https://claude.ai/code/session_01Kb4W5jY8ukFVFZKmCyEVsA
