### PR TITLE
feat(bullet): 物理swapを32GBで復活させます

### DIFF
--- a/nixos/host/bullet/disk.nix
+++ b/nixos/host/bullet/disk.nix
@@ -41,6 +41,12 @@
                       "compress=zstd"
                     ];
                   };
+                  "@swap" = {
+                    mountpoint = "/swap";
+                    mountOptions = [
+                      "noatime"
+                    ];
+                  };
                   "@var-log" = {
                     mountpoint = "/var/log";
                     mountOptions = [
@@ -63,4 +69,10 @@
       };
     };
   };
+  swapDevices = [
+    {
+      device = "/swap/swapfile";
+      size = 32 * 1024;
+    }
+  ];
 }


### PR DESCRIPTION
最近OOM Killerに殺されることが増えてきたため、
6caab22eで削除した`@swap`サブボリュームとswapfileを復活させます。

zram(16GB上限)だけではメモリが溢れた時の退避先が足りず、
日常的なプロセスが巻き添えで殺される方が困る状況になっています。
書き方は引き続き物理swapを持っているseminarに合わせます。

優先度はzramが5、
swapfileが-2なので、
まずzramが使われて溢れた分だけがディスクへ退避されます。

現在のSN8100は削除コミットより後にdiskoで構築されていて、
実ディスクに`@swap`サブボリュームが存在しなかったため、
btrfsトップレベルをマウントして手動で作成してから適用しました。
swapfile本体はNixOSのmkswapサービスが自動生成します。

適用後に`swapon --show`で32GBのswapfileが有効なことを確認しました。
