### PR TITLE
build(deps): comfyui-nixを更新してcacheサーバを追加します

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -16,6 +16,7 @@ runs:
           https://nix-community.cachix.org/
           https://nix-on-droid.cachix.org/
           https://microvm.cachix.org/
+          https://comfyui.cachix.org/
 
           trusted-public-keys =
           cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
@@ -24,3 +25,4 @@ runs:
           nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
           nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU=
           microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys=
+          comfyui.cachix.org-1:33mf9VzoIjzVbp0zwj+fT51HG0y31ZTK3nzYZAX0rec=

--- a/flake.lock
+++ b/flake.lock
@@ -706,11 +706,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1786584996,
-        "narHash": "sha256-2Zgg5vYChHvTE2bHIyTIST3omPdH01+WZ/gsl5Y+4Z4=",
+        "lastModified": 1786714237,
+        "narHash": "sha256-XnXKBpaidykfCegAqBGI7/F61IFtMSKUibQct/dP2Zw=",
         "owner": "utensils",
         "repo": "comfyui-nix",
-        "rev": "bbedf70a08ef2395da0a4b905e35a32e39bfd143",
+        "rev": "4501c5fe8dd93530d856866ba8bc4b585b508d41",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -455,6 +455,7 @@
       "https://nix-community.cachix.org/"
       "https://nix-on-droid.cachix.org/"
       "https://microvm.cachix.org/"
+      "https://comfyui.cachix.org/"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
@@ -463,6 +464,7 @@
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "nix-on-droid.cachix.org-1:56snoMJTXmDRC1Ei24CmKoUqvHJ9XCp+nidK7qkMQrU="
       "microvm.cachix.org-1:oXnBc6hRE3eX5rSYdRyMYXnfzcCxC7yKPTbZXALsqys="
+      "comfyui.cachix.org-1:33mf9VzoIjzVbp0zwj+fT51HG0y31ZTK3nzYZAX0rec="
     ];
   };
 }


### PR DESCRIPTION
utensils/comfyui-nixを最新のrevへ更新します。
今回の更新の中身は上流のPR 2つで、
新しいnixpkgsが`pythonRuntimeDepsCheckHook`を既定で有効にした時に露見する、
Pythonパッケージのメタデータ問題の修復と、
その修復をbackendごとのtorch wheelで検証するCIチェックの追加です。

- https://github.com/utensils/comfyui-nix/pull/88
- https://github.com/utensils/comfyui-nix/pull/89

`services.comfyui`モジュールのオプションに変更はなく、
ComfyUI本体のバージョンも0.32.0のまま変わらないため、
dotfiles側の設定変更は必要ありませんでした。
上流修正と重複するワークアラウンドも元々存在しないため、
剥がすものもありません。

あわせて上流READMEが案内しているcomfyui.cachix.orgをsubstituterへ追加します。
CUDA版torchなどの巨大なビルドを上流CIの成果物から取得できるようにするためです。
公開鍵はREADMEの記載と一致することを確認済みです。

`nix-fast-build`の統合チェックが通ることと、
`nixosConfigurations.bullet`のシステム閉包が新しいrevで実ビルドできることを確認しました。
bulletへの適用はまだです。

https://claude.ai/code/session_01SJWHSTBNHQSovF17XtGx5M