### PR TITLE
build(deps): konokaを更新してhome-managerモジュール経由の接続へ移行します

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -278,6 +278,9 @@
         "flake-parts": [
           "flake-parts"
         ],
+        "home-manager": [
+          "home-manager"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -286,11 +289,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786496021,
-        "narHash": "sha256-I7oH2sXUr2g3On5OqzDzqeLNdBTwfCPEd5Flf5CifNc=",
+        "lastModified": 1786791162,
+        "narHash": "sha256-yGl/gE8fLWJGeAFR0VtYxzCsHh6hG06JIluZCBMjkBk=",
         "owner": "ncaq",
         "repo": "konoka",
-        "rev": "5d696b26e90ad5a3ec56f5e0bf8293bbdbf523ad",
+        "rev": "9c46138e7f8f75795e0d21118f1d7012309cba20",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,7 @@
       url = "github:ncaq/konoka";
       inputs = {
         nixpkgs.follows = "nixpkgs";
+        home-manager.follows = "home-manager";
         flake-parts.follows = "flake-parts";
         treefmt-nix.follows = "treefmt-nix";
       };

--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -4,7 +4,6 @@
   pkgs-unstable,
   config,
   codingAgentWorkDirFullPath,
-  konoka,
   ...
 }:
 let
@@ -20,9 +19,6 @@ in
 
     # `mcp.nix`と連携します。
     enableMcpIntegration = true;
-
-    # ビルド済みのプラグインパッケージを直接リンクします。
-    plugins = map (n: konoka.plugins.${n}) konoka.allPluginNames;
 
     settings = {
       # 応答に使う自然言語です。

--- a/home/core/konoka.nix
+++ b/home/core/konoka.nix
@@ -1,70 +1,15 @@
+{ inputs, ... }:
 {
-  lib,
-  pkgs,
-  inputs,
-  ...
-}:
-let
-  # flake input経由でkonokaプラグインを取得します。
+  # konoka側が提供するhome-managerモジュールでプラグイン一式を接続します。
   # marketplace経由ではなくビルド済みプラグインを直接読み込むことで、
   # ヘルパースクリプトまでnixで管理できます。
-  konokaPlugins = inputs.konoka.packages.${pkgs.stdenv.hostPlatform.system};
+  imports = [ inputs.konoka.homeModules.default ];
 
-  # konokaリポジトリの`plugins/`直下のディレクトリ名をそのままプラグイン名として使います。
-  # konoka側のflake.nixがpluginsディレクトリの走査でパッケージ集合を導出しているのと同じ方針で、
-  # プラグインの追加削除にこちら側の一覧を手動追随させる必要をなくします。
-  # Claude Codeはこのリスト全てを`programs.claude-code.plugins`にリンクします。
-  allPluginNames = lib.attrNames (
-    lib.filterAttrs (_: type: type == "directory") (builtins.readDir "${inputs.konoka.outPath}/plugins")
-  );
-
-  # skillsを持つkonokaプラグインの名前リストです。
-  # `skills/`ディレクトリの有無で判定するため、
-  # hookのみで構成されるプラグイン(例: `rm-to-trash`)は自動的に除外されます。
-  skillPluginNames = lib.filter (
-    pluginName: builtins.pathExists "${inputs.konoka.outPath}/plugins/${pluginName}/skills"
-  ) allPluginNames;
-
-  # 各konokaプラグイン内のskillsサブディレクトリをフラットに展開します。
-  # ソース側のskillsディレクトリで一覧を取り、
-  # 実際のパスにはbin/やhooks/のビルド生成物まで揃ったパッケージ側を参照します。
-  skillEntries = builtins.concatMap (
-    pluginName:
-    let
-      pluginPkg = konokaPlugins.${pluginName};
-      skillsSrcDir = "${inputs.konoka.outPath}/plugins/${pluginName}/skills";
-      skillNames = builtins.attrNames (builtins.readDir skillsSrcDir);
-    in
-    map (skillName: {
-      inherit pluginName skillName;
-      path = "${pluginPkg}/skills/${skillName}";
-    }) skillNames
-  ) skillPluginNames;
-
-  # スキル名からそれを提供するプラグイン名のリストへの辞書。
-  # 複数プラグインが同名のスキルを持つとフラット展開時に片方が消えるため、
-  # 検出できるようにここで所有者一覧を組み立てます。
-  skillOwners = lib.foldl' (
-    acc: entry:
-    acc
-    // {
-      ${entry.skillName} = (acc.${entry.skillName} or [ ]) ++ [ entry.pluginName ];
-    }
-  ) { } skillEntries;
-
-  skillNameConflicts = lib.filterAttrs (_: owners: lib.length owners > 1) skillOwners;
-
-  skills =
-    assert lib.assertMsg (
-      skillNameConflicts == { }
-    ) "konokaプラグイン間でスキル名が衝突しています: ${builtins.toJSON skillNameConflicts}";
-    lib.listToAttrs (map (entry: lib.nameValuePair entry.skillName entry.path) skillEntries);
-in
-{
-  # konoka関連の情報を他のhome-managerモジュールに公開します。
-  # `konoka`引数として`programs.claude-code`や`programs.opencode`の設定モジュールから参照できます。
-  _module.args.konoka = {
-    plugins = konokaPlugins;
-    inherit allPluginNames skillPluginNames skills;
+  konoka = {
+    # 全プラグインを`programs.claude-code.plugins`へ追加します。
+    claude-code.enable = true;
+    # 各プラグインのスキルを`programs.opencode.skills`へ展開して、
+    # スキルの埋め込みコマンド用にプラグインの`bin/`を`extraPackages`へ追加します。
+    opencode.enable = true;
   };
 }

--- a/home/core/opencode.nix
+++ b/home/core/opencode.nix
@@ -2,7 +2,6 @@
   pkgs-unstable,
   config,
   codingAgentWorkDirFullPath,
-  konoka,
   ...
 }:
 {
@@ -15,16 +14,6 @@
     context = config.prompt.codingAgent;
     # `mcp.nix`と連携します。
     enableMcpIntegration = true;
-    # konokaのスキルをflake input経由で読み込みます。
-    # `~/.config/opencode/skills/<skill>/`にそれぞれsymlinkされます。
-    inherit (konoka) skills;
-    # OpenCodeプロセスのPATHにkonokaプラグインの`bin/`を追加します。
-    # スキルの埋め込みコマンド(`commit-prepare`など)を呼び出せるようにします。
-    # `home.packages`と違いユーザ全体のPATHは汚さず、
-    # `opencode`実行時のみに限定できます。
-    # `bin/`を持たないプラグインが混ざっても`makeBinPath`が単に空を返すだけで害はないため、
-    # 対象を絞らず全プラグインをまとめて渡します。
-    extraPackages = map (n: konoka.plugins.${n}) konoka.allPluginNames;
     # `~/.config/opencode/opencode.json`に配置されます。
     settings = {
       # パッケージはNixで管理しているため自己アップデートは無効にします。


### PR DESCRIPTION
konokaを更新して、
新しく提供されるようになった`homeModules.default`でプラグイン一式を接続します。

これまではdotfiles側で、
konokaの`plugins/`を走査してプラグイン名を導出し、
`skills/`の有無でスキルを持つプラグインを判定し、
スキルをフラットに展開して名前の衝突を検出していました。
どれもkonokaのリポジトリの構造を前提とした処理で、
プラグイン構成が変わるたびに利用側が追随する必要がありました。

この実装をkonokaへ移してモジュールとして提供させたので、
こちら側はimportと`konoka.claude-code.enable`と`konoka.opencode.enable`だけになります。
`_module.args.konoka`の公開もやめて、
`programs.claude-code.plugins`と、
`programs.opencode`の`skills`と`extraPackages`はモジュールが設定します。

スキルのパスはビルド済みパッケージ側からkonokaのソース側へ変わります。
これはkonokaのモジュールが、
home-managerのopencodeモジュールが評価時にパスを読む都合で、
別システム向けの構成をビルドなしに評価できるように選んでいる形です。
スキルの埋め込みコマンドは`extraPackages`のPATH経由で解決されるため機能は変わりません。

bulletの構成で、
`programs.claude-code.plugins`に従来通り全プラグインが並ぶことと、
`programs.opencode.skills`のスキル名の一覧が変わらないことを確認しました。
`nix-fast-build`も通りました。
