### PR TITLE
build: nixf-diagnoseをtreefmtへ追加します

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -324,6 +324,7 @@
             programs = {
               actionlint.enable = true;
               deadnix.enable = true;
+              nixf-diagnose.enable = true;
               nixfmt.enable = true;
               prettier.enable = true;
               ruff-check.enable = true;
@@ -425,6 +426,7 @@
               actionlint
               deadnix
               editorconfig-checker
+              nixf-diagnose
               nixfmt
               prettier
               ruff

--- a/lib/convert-safetensors-fp16.nix
+++ b/lib/convert-safetensors-fp16.nix
@@ -48,7 +48,7 @@ let
   # storeパスを見ただけで変換済みだと分かるようにする。
   # ComfyUIから見えるファイル名はlinkFarmがmodel.nixの属性名で決めるので、
   # ここでの名前は配置されるファイル名には影響しない。
-  baseName = builtins.baseNameOf (src.name or src);
+  baseName = baseNameOf (src.name or src);
   name = "${pkgs.lib.removeSuffix ".safetensors" baseName}-fp16.safetensors";
 in
 pkgs.runCommand name

--- a/lib/fetch-hugging-face.nix
+++ b/lib/fetch-hugging-face.nix
@@ -23,7 +23,7 @@ in
   file,
   hash,
 }:
-pkgs.runCommand (builtins.baseNameOf file)
+pkgs.runCommand (baseNameOf file)
   {
     nativeBuildInputs = with pkgs; [ python3Packages.huggingface-hub ];
 

--- a/lib/systemd-hardening.nix
+++ b/lib/systemd-hardening.nix
@@ -11,7 +11,7 @@
   };
   ```
 
-  設定を外す必要がある場合は`builtins.removeAttrs`で属性ごと外し、
+  設定を外す必要がある場合は`removeAttrs`で属性ごと外し、
   理由をコメントに残す。
 
   NixOSモジュールへは`flake.nix`の`specialArgs`経由で、

--- a/nixos/core/trash.nix
+++ b/nixos/core/trash.nix
@@ -3,7 +3,7 @@ let
   trashHardening =
     # 全ユーザーのホーム、全マウント先、ホストの/tmpにあるゴミ箱を掃除するため、
     # それらを不可視またはread-onlyにする隔離は適用できない。
-    builtins.removeAttrs hardening.isolated [
+    removeAttrs hardening.isolated [
       "PrivateTmp"
       "ProtectHome"
       "ProtectSystem"

--- a/nixos/host/seminar/mcp-nixos.nix
+++ b/nixos/host/seminar/mcp-nixos.nix
@@ -130,7 +130,7 @@ in
           wantedBy = [ "multi-user.target" ];
           # PythonはlibffiがW^X違反のメモリを使うことがあるため、
           # MemoryDenyWriteExecuteは設定しません。
-          serviceConfig = builtins.removeAttrs hardening.network [ "MemoryDenyWriteExecute" ] // {
+          serviceConfig = removeAttrs hardening.network [ "MemoryDenyWriteExecute" ] // {
             # mcp-nixosはHTTPトランスポートをネイティブにサポートしているので、
             # 環境変数で設定して直接起動します。
             # パスは未指定だとデフォルトの`/mcp`になり、前段Caddyの転送先と一致します。

--- a/nixos/host/seminar/opentelemetry-collector.nix
+++ b/nixos/host/seminar/opentelemetry-collector.nix
@@ -93,7 +93,7 @@ in
     # 上流モジュールがDynamicUser/ProtectSystem/DevicePolicy/NoNewPrivilegesを設定済みなので、
     # 上流と重複・衝突する属性は外してその上に締めます。
     serviceConfig =
-      builtins.removeAttrs hardening.network [
+      removeAttrs hardening.network [
         "NoNewPrivileges"
         "PrivateDevices"
         "PrivateTmp"

--- a/nixos/native-linux/boot.nix
+++ b/nixos/native-linux/boot.nix
@@ -75,7 +75,7 @@
       };
       # efivarfsの変数を削除するだけでソケットは使わない。
       # /sysへの書き込みが必要なのでProtectKernelTunablesは設定できない。
-      serviceConfig = builtins.removeAttrs hardening.isolated [ "ProtectKernelTunables" ] // {
+      serviceConfig = removeAttrs hardening.isolated [ "ProtectKernelTunables" ] // {
         Type = "oneshot";
         # chattrによるimmutable属性の解除にCAP_LINUX_IMMUTABLEが必要。
         CapabilityBoundingSet = [ "CAP_LINUX_IMMUTABLE" ];


### PR DESCRIPTION
エディタで使っているnixdの診断は、
実装上すべてlibnixfの`nixf::Diagnostic`をLSPの形へ詰め替えたもので、
評価ベースの独自診断は持っていません。
nixd自身のCLIはLSPサーバの起動専用でバッチ検査の口がありませんが、
`nixf-diagnose`が同じlibnixfの`nixf-tidy`を包んでファイル単位で走るので、
エディタで見えている指摘をそのままCIでも拾えます。

`checks.treefmt`は既にあるため、
`nix fmt`と`nix-fast-build`の両方が検査するようになります。
devShellにも他のformatterと同じく単体版を置きます。

既存の294個の`.nix`に対する指摘は`sema-primop-removed-prefix`の6件だけでした。
`autoFix`は既定の`true`のままにしたので、
`builtins.baseNameOf`と`builtins.removeAttrs`の`builtins.`が落ちています。
どちらもプレリュードの組み込みで、
変数の解決も`--variable-lookup`が見ているため意味は変わりません。

全ホストのNixOS構成とhome-managerの構成の評価が通ること、
再度の`nix fmt`で差分が出ないことを確認しました。
