### PR TITLE
feat(creep): 物理swapを32GBで復活させます

### DIFF
--- a/docs/install/nixos-manual.md
+++ b/docs/install/nixos-manual.md
@@ -64,6 +64,7 @@ sudo mkfs.btrfs /dev/mapper/nixos-root
 sudo mount /dev/mapper/nixos-root /mnt
 sudo btrfs subvolume create /mnt/@
 sudo btrfs subvolume create /mnt/@nix-store
+sudo btrfs subvolume create /mnt/@swap
 sudo btrfs subvolume create /mnt/@var-log
 sudo btrfs subvolume create /mnt/@snapshots
 sudo umount /mnt
@@ -76,11 +77,13 @@ sudo mount -o noatime,compress=zstd,subvol=@ /dev/mapper/nixos-root /mnt
 
 sudo mkdir -p /mnt/efi
 sudo mkdir -p /mnt/nix/store
+sudo mkdir -p /mnt/swap
 sudo mkdir -p /mnt/var/log
 sudo mkdir -p /mnt/.snapshots
 
 sudo mount -o noatime,fmask=0077,dmask=0077 /dev/disk/by-label/nixos-esp /mnt/efi
 sudo mount -o noatime,compress=zstd,subvol=@nix-store /dev/mapper/nixos-root /mnt/nix/store
+sudo mount -o noatime,subvol=@swap /dev/mapper/nixos-root /mnt/swap
 sudo mount -o noatime,compress=zstd,subvol=@var-log /dev/mapper/nixos-root /mnt/var/log
 sudo mount -o noatime,compress=zstd,subvol=@snapshots /dev/mapper/nixos-root /mnt/.snapshots
 ```

--- a/nixos/host/creep/disk.nix
+++ b/nixos/host/creep/disk.nix
@@ -29,6 +29,14 @@ _: {
         "subvol=@nix-store"
       ];
     };
+    "/swap" = {
+      device = "/dev/mapper/nixos-root";
+      fsType = "btrfs";
+      options = [
+        "noatime"
+        "subvol=@swap"
+      ];
+    };
     "/var/log" = {
       device = "/dev/mapper/nixos-root";
       fsType = "btrfs";
@@ -48,4 +56,10 @@ _: {
       ];
     };
   };
+  swapDevices = [
+    {
+      device = "/swap/swapfile";
+      size = 32 * 1024;
+    }
+  ];
 }


### PR DESCRIPTION
6caab22eで削除した`@swap`サブボリュームとswapfileを復活させます。
bulletを7b7253d7で復活させたのと同じ判断で、
zramだけではメモリが溢れた時の退避先が足りず、
OOM Killerに日常的なプロセスを巻き添えで殺される方が困るためです。

内容は削除前の設定の復元ですが、
サイズは4GBではなく物理メモリに合わせて32GBにします。

優先度はzramが5、
swapfileが-2なので、
まずzramが使われて溢れた分だけがディスクへ退避されます。

実ディスクには`@swap`サブボリュームが存在しなかったため、
btrfsトップレベルをマウントして手動で作成してから適用しました。
swapfile本体はNixOSのmkswapサービスが自動生成します。

手動インストール手順のドキュメントは現在creepのようなデュアルブート環境向けなので、
6caab22eで削除した`@swap`の作成とマウントの手順も戻します。

適用後に`swapon --show`で32GBのswapfileが有効なことを確認しました。

https://claude.ai/code/session_016vKxvnaPNRbSUBXCaLBAuq