### PR TITLE
feat(ollama): freedomModelsのQwen勢をabliterated版へ入れ替えます

### DIFF
--- a/nixos/ollama/freedom-model-loader.nix
+++ b/nixos/ollama/freedom-model-loader.nix
@@ -1,4 +1,14 @@
 # Nix storeのGGUFをOllamaへ登録する。
+#
+# 1つのモデルは複数のGGUFからなることがあります。
+# visionを持つモデルは言語モデル本体とclipの投影器(mmproj)に分かれており、
+# `FROM`を並べて書くと`ollama create`が両方を取り込み、
+# GGUFのメタデータからどちらが投影器かを判別してレイヤーを分けます。
+# 投影器を指定する専用のディレクティブはありません。
+#
+# ollamaはディレクトリを`FROM`に渡す形も受け付けますが、
+# 中身がディレクトリの外を指すsymlinkだと`insecure path`で弾かれるため、
+# Nix storeのファイルを`linkFarm`で束ねる形は使えません。
 {
   lib,
   pkgs,
@@ -9,10 +19,10 @@ let
   freedomModels = config.local.ollama.freedomModels;
   markerDir = "${config.local.ollama.dataDir}/freedom-models";
   modelfiles = lib.mapAttrs (
-    name: gguf:
-    pkgs.writeText "ollama-${lib.replaceStrings [ ":" ] [ "-" ] name}-Modelfile" ''
-      FROM ${gguf}
-    ''
+    name: sources:
+    pkgs.writeText "ollama-${lib.replaceStrings [ ":" ] [ "-" ] name}-Modelfile" (
+      lib.concatMapStrings (source: "FROM ${source}\n") sources
+    )
   ) freedomModels;
 in
 {
@@ -30,18 +40,22 @@ in
           mkdir -p ${lib.escapeShellArg markerDir}
           ${lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
-              name: gguf:
+              name: _sources:
               let
                 marker = "${markerDir}/${lib.replaceStrings [ ":" ] [ "-" ] name}";
+                # マーカーにはGGUFではなくModelfileのパスを記録します。
+                # Modelfileの内容は全てのGGUFのパスを含むので、
+                # 構成ファイルが1つでも入れ替われば必ず値が変わります。
+                modelfile = toString modelfiles.${name};
               in
               ''
                 if [[ ! -f ${lib.escapeShellArg marker} ]] \
-                  || [[ $(< ${lib.escapeShellArg marker}) != ${lib.escapeShellArg (toString gguf)} ]] \
+                  || [[ $(< ${lib.escapeShellArg marker}) != ${lib.escapeShellArg modelfile} ]] \
                   || ! ollama show ${lib.escapeShellArg name} > /dev/null 2>&1; then
                   ollama create ${lib.escapeShellArg name} --file ${
                     lib.escapeShellArg (toString modelfiles.${name})
                   }
-                  printf '%s\n' ${lib.escapeShellArg (toString gguf)} > ${lib.escapeShellArg marker}
+                  printf '%s\n' ${lib.escapeShellArg modelfile} > ${lib.escapeShellArg marker}
                 fi
               ''
             ) freedomModels

--- a/nixos/ollama/model.nix
+++ b/nixos/ollama/model.nix
@@ -79,19 +79,32 @@ let
   # 対話を待っていられる速度ではないため、
   # ディスクとロード時間を消費するだけになる。
   freedomModels = lib.optionalAttrs enableCuda {
+    # Qwen3.8-27Bをheretic(ARA: Arbitrary-Rank Ablation)で拒否挙動だけ除去したもの。
+    # 単一の拒否方向を引き算する従来のabliterationと違い重み行列を直接最適化するため、
+    # 配布元の計測ではKL divergenceが基のQwen3.8-27Bに対して0.0085と小さく、
+    # 拒否率は99/100から0-1/100まで落ちている。
+    # 素の知能を保ったまま規制だけ外れるので、
+    # 創作用に別途finetuneされたモデルとは性格が違い、
+    # 汎用の受け答えの延長で自由度が欲しい場合に効く。
+    # mtp版を選ぶのはgeneralModelsと同じ理由で、
+    # MTPのドラフトヘッドを埋め込んだGGUFはGPUの投機的デコーディングで速度が上がる。
+    # 量子化は他のfreedomModelsのq4_k_mより上のq6_kにする。
+    # 配布元の計測ではmtpを付けるとQ6_Kは126トークン/秒、
+    # Q4_K_Mは122トークン/秒でほぼ同速なので、
+    # 22.5GBが32GiBのVRAMに収まる以上q4_k_mを選ぶ理由がない。
+    "qwen3.8-27b-heretic-rvn:q6_k" = fetchHuggingFace {
+      owner = "0bserverx";
+      repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
+      rev = "2aff31a04896ab1f3716dde35f73d099ed0c08c5";
+      file = "RVN-Q6_K-mtp.gguf";
+      hash = "sha256-Z9nzqWLSVIn93JCnwMmU+F4WNunpiw+dnRJneg2Uc8k=";
+    };
     "mistralprism-24b:q4_k_m" = fetchHuggingFace {
       owner = "Aratako";
       repo = "MistralPrism-24B-GGUF";
       rev = "ef08191bef153caaa70e0720a8fcfa1cf11fb10b";
       file = "MistralPrism-24B-Q4_K_M.gguf";
       hash = "sha256-Tm9H9IXyhqSnPhzA0KZhwU8fNYWyK1XcdRKFGfB0Fdw=";
-    };
-    "qwen3-30b-a3b-erp-v0.1:q4_k_m" = fetchHuggingFace {
-      owner = "Aratako";
-      repo = "Qwen3-30B-A3B-ERP-v0.1-GGUF";
-      rev = "78221ae35684a78dec965c1041c0bf10e0ff16d9";
-      file = "Qwen3-30B-A3B-ERP-v0.1-Q4_K_M.gguf";
-      hash = "sha256-Tzvnhjb74SOYzBIGvG4XqcYUelcaDLb5dTH0UrGpSAM=";
     };
     "ms3.2-24b-magnum-diamond:q4_k_m" = fetchHuggingFace {
       owner = "Doctor-Shotgun";

--- a/nixos/ollama/model.nix
+++ b/nixos/ollama/model.nix
@@ -96,27 +96,52 @@ let
     # bulletでの実測ではq4_k_mが100%GPUで80.3トークン/秒、
     # VRAMの空きも5.6GiB残るのに対し、
     # 本体が5.2GiB大きいq6_kは6%がCPUへ溢れて34.8トークン/秒まで落ちた。
-    "qwen3.8-27b-heretic-rvn:q4_k_m" = fetchHuggingFace {
-      owner = "0bserverx";
-      repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
-      rev = "2aff31a04896ab1f3716dde35f73d099ed0c08c5";
-      file = "RVN-Q4_K_M-mtp.gguf";
-      hash = "sha256-N5dNFvyF66qh6v/ZIr+jAtGm1YccapLtBh5Hj7hKX1c=";
-    };
-    "mistralprism-24b:q4_k_m" = fetchHuggingFace {
-      owner = "Aratako";
-      repo = "MistralPrism-24B-GGUF";
-      rev = "ef08191bef153caaa70e0720a8fcfa1cf11fb10b";
-      file = "MistralPrism-24B-Q4_K_M.gguf";
-      hash = "sha256-Tm9H9IXyhqSnPhzA0KZhwU8fNYWyK1XcdRKFGfB0Fdw=";
-    };
-    "ms3.2-24b-magnum-diamond:q4_k_m" = fetchHuggingFace {
-      owner = "Doctor-Shotgun";
-      repo = "MS3.2-24B-Magnum-Diamond-GGUF";
-      rev = "7422a3599b749c9efa003c53f3165adc71e1f2aa";
-      file = "MS3.2-24B-Magnum-Diamond-Q4_K_M.gguf";
-      hash = "sha256-MLwAq6iPY52EsZwZ2bxVaHHQBGbDJuyc9U7F+Y6PVsQ=";
-    };
+    # 言語モデル本体だけではvisionが付かないので、
+    # clipの投影器であるmmprojも一緒に渡す。
+    # registryの`qwen3.8:27b-mtp-q4_K_M`がpullしただけでvisionを持つのは、
+    # 同じ投影器をマニフェストの別レイヤーとして同梱しているからで、
+    # Hugging Faceから本体のGGUFを1ファイル取るだけでは付いてこない。
+    # 配布元は本体の量子化を変えた`-vision`付きのファイルも置いているが、
+    # あれは画像の埋め込みを受ける層をq8_0で保護しただけの言語モデルで、
+    # 使うにはどのみち投影器が要る上にmtp版が存在しない。
+    # 投影器は`ggml-org/Qwen3.8-27B-GGUF`にある公式のものと同一で、
+    # ARAは言語モデル側の層しか触っていないため素の投影器がそのまま噛み合う。
+    # bulletでの実測でも`ollama show`の`Projector`はregistry版と同じ、
+    # clipの460.73Mパラメータとして認識される。
+    "qwen3.8-27b-heretic-rvn:q4_k_m" = [
+      (fetchHuggingFace {
+        owner = "0bserverx";
+        repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
+        rev = "2aff31a04896ab1f3716dde35f73d099ed0c08c5";
+        file = "RVN-Q4_K_M-mtp.gguf";
+        hash = "sha256-N5dNFvyF66qh6v/ZIr+jAtGm1YccapLtBh5Hj7hKX1c=";
+      })
+      (fetchHuggingFace {
+        owner = "0bserverx";
+        repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
+        rev = "2aff31a04896ab1f3716dde35f73d099ed0c08c5";
+        file = "mmproj-Qwen3.8-27B-Q8_0.gguf";
+        hash = "sha256-LpaKavl8412JcYkLJXubftq/IK2RRQUB+lMWKhnuM+s=";
+      })
+    ];
+    "mistralprism-24b:q4_k_m" = [
+      (fetchHuggingFace {
+        owner = "Aratako";
+        repo = "MistralPrism-24B-GGUF";
+        rev = "ef08191bef153caaa70e0720a8fcfa1cf11fb10b";
+        file = "MistralPrism-24B-Q4_K_M.gguf";
+        hash = "sha256-Tm9H9IXyhqSnPhzA0KZhwU8fNYWyK1XcdRKFGfB0Fdw=";
+      })
+    ];
+    "ms3.2-24b-magnum-diamond:q4_k_m" = [
+      (fetchHuggingFace {
+        owner = "Doctor-Shotgun";
+        repo = "MS3.2-24B-Magnum-Diamond-GGUF";
+        rev = "7422a3599b749c9efa003c53f3165adc71e1f2aa";
+        file = "MS3.2-24B-Magnum-Diamond-Q4_K_M.gguf";
+        hash = "sha256-MLwAq6iPY52EsZwZ2bxVaHHQBGbDJuyc9U7F+Y6PVsQ=";
+      })
+    ];
   };
 in
 {

--- a/nixos/ollama/model.nix
+++ b/nixos/ollama/model.nix
@@ -88,16 +88,20 @@ let
     # 汎用の受け答えの延長で自由度が欲しい場合に効く。
     # mtp版を選ぶのはgeneralModelsと同じ理由で、
     # MTPのドラフトヘッドを埋め込んだGGUFはGPUの投機的デコーディングで速度が上がる。
-    # 量子化は他のfreedomModelsのq4_k_mより上のq6_kにする。
-    # 配布元の計測ではmtpを付けるとQ6_Kは126トークン/秒、
-    # Q4_K_Mは122トークン/秒でほぼ同速なので、
-    # 22.5GBが32GiBのVRAMに収まる以上q4_k_mを選ぶ理由がない。
-    "qwen3.8-27b-heretic-rvn:q6_k" = fetchHuggingFace {
+    # 量子化は他のfreedomModelsと同じくq4_k_mにする。
+    # 配布元のREADMEは32GBのGPUにq6_kやq8_0を勧めているが、
+    # あれは実効contextを24Kから64K程度と想定した表で、
+    # bulletの`OLLAMA_CONTEXT_LENGTH`である131072では成立しない。
+    # このcontextではKV cacheと計算バッファだけで10GiB以上要る。
+    # bulletでの実測ではq4_k_mが100%GPUで80.3トークン/秒、
+    # VRAMの空きも5.6GiB残るのに対し、
+    # 本体が5.2GiB大きいq6_kは6%がCPUへ溢れて34.8トークン/秒まで落ちた。
+    "qwen3.8-27b-heretic-rvn:q4_k_m" = fetchHuggingFace {
       owner = "0bserverx";
       repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
       rev = "2aff31a04896ab1f3716dde35f73d099ed0c08c5";
-      file = "RVN-Q6_K-mtp.gguf";
-      hash = "sha256-Z9nzqWLSVIn93JCnwMmU+F4WNunpiw+dnRJneg2Uc8k=";
+      file = "RVN-Q4_K_M-mtp.gguf";
+      hash = "sha256-N5dNFvyF66qh6v/ZIr+jAtGm1YccapLtBh5Hj7hKX1c=";
     };
     "mistralprism-24b:q4_k_m" = fetchHuggingFace {
       owner = "Aratako";

--- a/nixos/ollama/option.nix
+++ b/nixos/ollama/option.nix
@@ -57,9 +57,14 @@
     };
 
     freedomModels = lib.mkOption {
-      type = lib.types.attrsOf lib.types.package;
+      type = lib.types.attrsOf (lib.types.listOf lib.types.package);
       readOnly = true;
-      description = "GGUFから`ollama create`で登録する表現自由度重視モデル。";
+      description = ''
+        GGUFから`ollama create`で登録する表現自由度重視モデル。
+        値は1つのモデルを構成するGGUFのリストです。
+        visionを持つモデルは言語モデル本体とclipの投影器に分かれるため、
+        要素が2つになります。
+      '';
     };
   };
 }


### PR DESCRIPTION
`qwen3-30b-a3b-erp-v0.1`を外して、
generalModelsと同じQwen3.8-27Bのabliterated版を入れます。

選んだのは、
heretic(ARA: Arbitrary-Rank Ablation)で拒否挙動を除去したRVNです。

https://huggingface.co/0bserverx/Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF

単一の拒否方向を引き算する従来のabliterationと違い、
重み行列そのものを最適化するため元の挙動への影響が小さく、
配布元の計測ではKL divergenceが0.0085で、
拒否率は基のQwen3.8-27Bの99/100に対し0-1/100です。

残るfreedomModelsはどちらもMistral Small系の創作向けfinetuneなので、
素の知能を保ったまま規制だけ外れるこのモデルとは性格が違います。
創作の文体ではなく、
汎用の受け答えの延長で自由度が欲しい場合に効きます。

同じくQwen3.8-27Bのabliterated版である、
`huihui-ai/Huihui-Qwen3.8-27B-abliterated-GGUF`も候補にしましたが、
拒否率やKLの計測値が公開されておらず、
MTPのドラフトヘッドを埋め込んだGGUFも無いため見送ります。

ファイルはmtp版を選びます。
generalModelsで`qwen3.8:27b-mtp-q4_K_M`を選んだのと同じ理由で、
GPUでは投機的デコーディングで生成速度が上がるためです。

量子化は他のfreedomModelsのq4_k_mより上のq6_kにします。
配布元の計測ではmtpを付けるとQ6_Kが126トークン/秒、
Q4_K_Mが122トークン/秒でほぼ同速なので、
22.5GBが32GiBのVRAMに収まる以上q4_k_mを選ぶ理由がありません。

`nix eval`でbulletのfreedomModelsの中身を確認しました。
hashはHugging FaceのAPIが返すLFSのoidから導出したもので、
実ファイルとの照合は`./install.sh`でのダウンロード時になります。
