### PR TITLE
feat(open-webui): blue-promptのスキルをModelとして登録します

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787231070,
-        "narHash": "sha256-fMCsOk9ZJMj0+YO0gw/vMNtdc4lEJHAH6B8PtezEPng=",
+        "lastModified": 1787234086,
+        "narHash": "sha256-XMJuXcTRb1+dPo+dguvvBeumMuR1/sNEenojfMcngfM=",
         "owner": "ncaq",
         "repo": "blue-prompt",
-        "rev": "122e8be7054d1dddf1cef7b1dd2460a03e145e85",
+        "rev": "12770344de8cdab257f7ced94f29eb7f9c6e6930",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787221904,
-        "narHash": "sha256-00HdM/57UdXP55cgBWPQyJ18Hh/OkEruI5mN3w277Qc=",
+        "lastModified": 1787231070,
+        "narHash": "sha256-fMCsOk9ZJMj0+YO0gw/vMNtdc4lEJHAH6B8PtezEPng=",
         "owner": "ncaq",
         "repo": "blue-prompt",
-        "rev": "5b69667a25cc1f9a51245522f8623694ee84876d",
+        "rev": "122e8be7054d1dddf1cef7b1dd2460a03e145e85",
         "type": "github"
       },
       "original": {

--- a/nixos/host/seminar/open-webui/blue-prompt-model.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt-model.nix
@@ -1,0 +1,42 @@
+# blue-promptのスキルから生成したワークスペースModelをOpen WebUIへ登録する。
+#
+# Open WebUIにはスキルのオンデマンド読み込みが無いため、
+# スキルの内容をシステムプロンプトへ焼き込んだModelとして事前に登録しておく。
+# Modelは他のチャット履歴と同じくOpen WebUIのDBに持つ状態なので、
+# Nixで宣言できるのは同期を行うサービスの側だけになる。
+{
+  lib,
+  config,
+  inputs,
+  ...
+}:
+let
+  serve = config.local.tailscaleServe.services.open-webui;
+  # `tailscale-serve.nix`が公開しているのと同じ、人がブラウザで開くURL。
+  # Tailscale Serveの転送先はホスト側のsocket proxyなので、
+  # loopbackを直接叩くのと最終的な到達先もコンテナから見える送信元も変わらない。
+  # 同じホストからの接続でも経路はtailscaledの中で完結する。
+  url = "https://${lib.removePrefix "svc:" serve.service}.${config.local.tailscale.tailnet}";
+in
+{
+  imports = [ inputs.blue-prompt.nixosModules.default ];
+
+  blue-prompt.open-webui = {
+    enable = true;
+    inherit url;
+    # 推論に使う上流モデル。
+    # 拒否挙動を除去してあるので、
+    # キャラクターの人格を演じるスキルが安全側へ倒れて崩れることが少ない。
+    baseModelId = "qwen3.8-27b-heretic-rvn:q4_k_m";
+    # コンテナのOpen WebUIは`WEBUI_AUTH = "False"`で動いているため、
+    # APIキーを渡さなくても書き込みできる。
+  };
+
+  # Serviceがadvertiseされる前に同期が走ると名前を引けても接続先が居ない。
+  # Serveの登録はRemainAfterExitのoneshotなので、
+  # afterで完了まで待てば初回アクセスでコンテナのsocket activationも発火する。
+  systemd.services.blue-prompt-open-webui-model-sync = {
+    requires = [ "tailscale-serve-open-webui.service" ];
+    after = [ "tailscale-serve-open-webui.service" ];
+  };
+}


### PR DESCRIPTION
seminarのOpen WebUIへ、
blue-promptのスキルをワークスペースModelとして宣言的に登録します。

Open WebUIにはClaude Codeのようなスキルのオンデマンド読み込みが無いため、
SKILL.mdと参照ファイルをシステムプロンプトへ焼き込んだModelを事前に登録する形になります。
Model自体はチャット履歴と同じくDBに持つ状態なので、
Nixで宣言できるのは同期を行うoneshotのサービスまでです。
ユニットにモデル定義のstoreパスが焼き込まれているため、
スキルを改良すればユニットが変わって同期が再実行されます。

推論に使う上流モデルにはbulletで動かしているheretic版のQwen3.8-27Bを指定します。
拒否挙動を除去してあるので、
キャラクターの人格を演じるスキルが安全側へ倒れて崩れることが少ないためです。

同期先のURLはloopbackではなく、
Tailscale Serviceとして公開しているホスト名にします。
Serveの転送先はホスト側のsocket proxyなので、
loopbackを直接叩くのと最終的な到達先もコンテナから見える送信元も変わらず、
同じホストからの接続でも経路はtailscaledの中で完結します。
それなら人がブラウザで開くURLと同じものが書いてある方が対応を追いやすいです。
その代わりServiceがadvertiseされてから同期が走るように順序を付けています。

blue-prompt自体も更新します。
Open WebUIは`WEBUI_AUTH`を無効にしてもAPIにはBearerトークンを要求するため、
最初の実装は`401 Not authenticated`で失敗していました。
更新後はAPIキーを渡さない場合に、
UIが裏で行っているのと同じサインインでトークンを取ってから同期します。

実機で簡単に動くことを確認済みです。
7件のModelが作成され、
再実行では全件が変更なしになり、
登録された`base_model_id`も指定した上流モデルになっています。

ref https://github.com/ncaq/blue-prompt/pull/156
