### PR TITLE
feat(shell): yqを導入してClaude Codeへ包括的に許可します

### DIFF
--- a/home/core/claude-code.nix
+++ b/home/core/claude-code.nix
@@ -269,6 +269,7 @@ in
           "Bash(true)"
           "Bash(update-nix-fetchgit:*)"
           "Bash(wc:*)"
+          "Bash(yq:*)"
           "WebFetch"
           "WebSearch"
           "mcp__plugin_claude-code-home-manager_backlog__count_issues"

--- a/home/core/shell.nix
+++ b/home/core/shell.nix
@@ -7,5 +7,6 @@
     parallel
     shellcheck
     xxd
+    yq-go
   ];
 }

--- a/lib/github-actions-runner-packages.nix
+++ b/lib/github-actions-runner-packages.nix
@@ -128,7 +128,7 @@ let
 
     # Data Processing
     jq
-    yq
+    yq-go
 
     # Compression
     brotli


### PR DESCRIPTION
konokaの`programming-tasuke`プラグインに、
YAMLやXMLやTOMLの処理でPythonなどの汎用スクリプト言語ではなくyqを使わせる、
`programming-tasuke:prefer-yq`スキルを追加しました。
しかしこの環境にyqが入っていないため、
スキルが指示する道具を使えない状態でした。

nixpkgsには`yq`という名前のコマンドを提供するパッケージが2つあります。
Python製のjqラッパーである`yq`ではなく、
Go製の単体バイナリであるmikefarah版の`yq-go`を入れます。
Python依存がなく、
コメントを保ったままin-place編集できるためです。
スキル側もmikefarah版を前提に書いています。

あわせてClaude Codeの許可リストに`Bash(yq:*)`を足します。
既に`Bash(jq:*)`を許可しているのと同じ理由で、
yqの出来ることはデータの変換にほぼ限られていて副作用が少ないため、
包括的な許可を出しても危なくありません。
許可しなければ結局は毎回承認を求められて、
承認疲れを減らすというスキルの目的が達成できません。

`nix eval`でhome-managerのactivationPackageが評価できることを確認しました。

ref https://github.com/ncaq/konoka/issues/27
ref https://github.com/ncaq/konoka/pull/484
