### PR TITLE
feat(open-webui): blue-promptのKnowledge同期へ移行します

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787234086,
-        "narHash": "sha256-XMJuXcTRb1+dPo+dguvvBeumMuR1/sNEenojfMcngfM=",
+        "lastModified": 1787282135,
+        "narHash": "sha256-3M900RGjnryeAYcRedJy5medSDsWyKBfjtyQiegSx90=",
         "owner": "ncaq",
         "repo": "blue-prompt",
-        "rev": "12770344de8cdab257f7ced94f29eb7f9c6e6930",
+        "rev": "912374da55ac5eccf3aed74423062793f3ea7de7",
         "type": "github"
       },
       "original": {

--- a/nixos/host/seminar/open-webui/blue-prompt.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt.nix
@@ -40,6 +40,7 @@ in
     requires = [ "tailscale-serve-open-webui.service" ];
     after = [
       "tailscale-serve-open-webui.service"
+      # コンテナへの追従は後述。
       "container@open-webui.service"
     ];
     # RAGのプロンプトテンプレートはインスタンス全体の設定としてAPIで書き込まれる。
@@ -50,11 +51,22 @@ in
     # 人格側のModelの話し方が壊れたまま気付かれずに残る。
     # コンテナの起動と停止に追従させて、その度に同期をやり直す。
     #
-    # コンテナは`autoStart = false`でsocket activationから起動するため、
-    # boot時のトランザクションにはコンテナのジョブが無く`after`は効かない。
-    # 従来どおり同期自身のアクセスがsocket activationを発火させる。
+    # `partOf`ではなく`bindsTo`にするのは、
+    # `partOf`がsystemdの明示的なstopやrestartのジョブでしか伝播しないため。
+    # コンテナが異常終了した場合や、
+    # ephemeralなコンテナが落ちた後にsocket activationから起動し直された場合には、
+    # 同期は`active (exited)`のまま残り、
+    # `wantedBy`のWantsは既にactiveなユニットを再実行しない。
+    # `bindsTo`なら予期しない停止でも同期がinactiveへ落ちて、
+    # 次のコンテナ起動で確実に引き込み直される。
+    # `mcp-nixos.nix`の`mcp-nixos-traffic-control`も同じ形で追従させている。
+    #
+    # `bindsTo`は起動側では`requires`と同じなので、
+    # コンテナは同期の依存として先に起動するようになる。
+    # 元々この同期自身のアクセスがsocket activationを発火させていて、
+    # boot毎にコンテナは起き上がっていたので実質の差は無い。
     wantedBy = [ "container@open-webui.service" ];
-    partOf = [ "container@open-webui.service" ];
+    bindsTo = [ "container@open-webui.service" ];
     # Knowledgeのアップロードでは1ファイルごとに埋め込みがコンテナ内で走る。
     # 断片の数だけ時間が積み上がるため、
     # oneshotの既定のタイムアウトで中断されて中途半端な状態が残るのを念のため避ける。

--- a/nixos/host/seminar/open-webui/blue-prompt.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt.nix
@@ -38,7 +38,23 @@ in
     # Serveの登録はRemainAfterExitのoneshotなので、
     # afterで完了まで待てば初回アクセスでコンテナのsocket activationも発火する。
     requires = [ "tailscale-serve-open-webui.service" ];
-    after = [ "tailscale-serve-open-webui.service" ];
+    after = [
+      "tailscale-serve-open-webui.service"
+      "container@open-webui.service"
+    ];
+    # RAGのプロンプトテンプレートはインスタンス全体の設定としてAPIで書き込まれる。
+    # コンテナは`ENABLE_PERSISTENT_CONFIG = "False"`で動いていて、
+    # この種の設定はDBへ残らずプロセス内にしか無いため、
+    # コンテナが再起動するとOpen WebUI標準の英語のテンプレートへ戻ってしまう。
+    # 同期はRemainAfterExitのoneshotなので放っておくと再実行されず、
+    # 人格側のModelの話し方が壊れたまま気付かれずに残る。
+    # コンテナの起動と停止に追従させて、その度に同期をやり直す。
+    #
+    # コンテナは`autoStart = false`でsocket activationから起動するため、
+    # boot時のトランザクションにはコンテナのジョブが無く`after`は効かない。
+    # 従来どおり同期自身のアクセスがsocket activationを発火させる。
+    wantedBy = [ "container@open-webui.service" ];
+    partOf = [ "container@open-webui.service" ];
     # Knowledgeのアップロードでは1ファイルごとに埋め込みがコンテナ内で走る。
     # 断片の数だけ時間が積み上がるため、
     # oneshotの既定のタイムアウトで中断されて中途半端な状態が残るのを念のため避ける。

--- a/nixos/host/seminar/open-webui/blue-prompt.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt.nix
@@ -1,8 +1,9 @@
-# blue-promptのスキルから生成したワークスペースModelをOpen WebUIへ登録する。
+# blue-promptのスキルから生成したワークスペースModelとKnowledgeをOpen WebUIへ登録する。
 #
 # Open WebUIにはスキルのオンデマンド読み込みが無いため、
-# スキルの内容をシステムプロンプトへ焼き込んだModelとして事前に登録しておく。
-# Modelは他のチャット履歴と同じくOpen WebUIのDBに持つ状態なので、
+# 人格を与えるスキルは内容をシステムプロンプトへ焼き込んだModelとして事前に登録し、
+# 事実を引くだけのスキルはModelから参照できるKnowledgeとして登録しておく。
+# どちらも他のチャット履歴と同じくOpen WebUIのDBに持つ状態なので、
 # Nixで宣言できるのは同期を行うサービスの側だけになる。
 {
   lib,
@@ -32,11 +33,16 @@ in
     # APIキーを渡さなくても書き込みできる。
   };
 
-  # Serviceがadvertiseされる前に同期が走ると名前を引けても接続先が居ない。
-  # Serveの登録はRemainAfterExitのoneshotなので、
-  # afterで完了まで待てば初回アクセスでコンテナのsocket activationも発火する。
-  systemd.services.blue-prompt-open-webui-model-sync = {
+  systemd.services.blue-prompt-open-webui-sync = {
+    # Serviceがadvertiseされる前に同期が走ると名前を引けても接続先が居ない。
+    # Serveの登録はRemainAfterExitのoneshotなので、
+    # afterで完了まで待てば初回アクセスでコンテナのsocket activationも発火する。
     requires = [ "tailscale-serve-open-webui.service" ];
     after = [ "tailscale-serve-open-webui.service" ];
+    # Knowledgeのアップロードでは1ファイルごとに埋め込みがコンテナ内で走る。
+    # 断片の数だけ時間が積み上がるため、
+    # oneshotの既定のタイムアウトで中断されて中途半端な状態が残るのを念のため避ける。
+    # 同期側はリクエストごとに打ち切りを持つので、待ち続けても止まらなくなることはない。
+    serviceConfig.TimeoutStartSec = "infinity";
   };
 }

--- a/nixos/host/seminar/open-webui/blue-prompt.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt.nix
@@ -42,7 +42,14 @@ in
     # Knowledgeのアップロードでは1ファイルごとに埋め込みがコンテナ内で走る。
     # 断片の数だけ時間が積み上がるため、
     # oneshotの既定のタイムアウトで中断されて中途半端な状態が残るのを念のため避ける。
-    # 同期側はリクエストごとに打ち切りを持つので、待ち続けても止まらなくなることはない。
-    serviceConfig.TimeoutStartSec = "infinity";
+    #
+    # 上限を外さないのは、
+    # このユニットがoneshotでmulti-user.targetに紐付いているためで、
+    # 同期が詰まるとboot時のtarget到達と`./install.sh`のactivationが待ち続けてしまう。
+    # 同期側はリクエストごとに.NETの既定の100秒で打ち切るので、
+    # 断片の数から全体の上限も見積もれる。
+    # 余裕を持った有限値にしておけば、
+    # 想定を超えた時はfailとしてジャーナルに残って気付ける。
+    serviceConfig.TimeoutStartSec = "1h";
   };
 }

--- a/nixos/host/seminar/open-webui/blue-prompt.nix
+++ b/nixos/host/seminar/open-webui/blue-prompt.nix
@@ -78,6 +78,21 @@ in
     # 断片の数から全体の上限も見積もれる。
     # 余裕を持った有限値にしておけば、
     # 想定を超えた時はfailとしてジャーナルに残って気付ける。
-    serviceConfig.TimeoutStartSec = "1h";
+    serviceConfig = {
+      TimeoutStartSec = "1h";
+      # コンテナの起動が終わった時点では、
+      # nspawnがbootしただけで中のOpen WebUIはまだlistenしていない。
+      # `container-socket-activation.nix`のproxyが疎通待ちに5分を見込むのに対して、
+      # 上流のヘルス待ちは5秒の試行と2秒の待機を30回で3分半しか無いため、
+      # 埋め込みモデルの取得やDB migrationを伴う寒い起動では同期の方が先に諦める。
+      # コンテナの起動ごとにこの経路を通るようになった分、露出も増えている。
+      #
+      # 恒久的に起動できない状態で短い間隔の再試行を繰り返さないよう、
+      # そのproxyと同じ指数バックオフを使う。
+      Restart = "on-failure";
+      RestartSec = "1s";
+      RestartMaxDelaySec = "2h";
+      RestartSteps = 10;
+    };
   };
 }


### PR DESCRIPTION
blue-promptがOpen WebUIのKnowledgeコレクションも同期するようになったので、
seminar側の設定を新しい形へ合わせます。

Open WebUIのModelは会話の入口を選ぶだけで、
Claude Codeのスキルのように会話の途中で他のスキルを読み込むことはできません。
そのため人格を与える`role-play`のスキルはModelにする意味がありますが、
参照して事実を引くだけの`jp-wikiru-bluearchive`のスキルは、
Modelにしても選ばれず読まれませんでした。
更新後はこの種のスキルがKnowledgeとして登録され、
人格側のModelから参照したりチャットで`#`を打って引いたりできます。

`knowledge`と`ragTemplate`のオプションは既定で有効なので、
こちら側で書くことはありません。

同期を行うユニットの名前が、
Model専用ではなくなったことに合わせて、
`blue-prompt-open-webui-model-sync`から`blue-prompt-open-webui-sync`へ変わったため、
順序の指定を新しい名前へ付け替えます。
ファイル名も同じ理由で`blue-prompt-model.nix`から`blue-prompt.nix`にします。

あわせて念のためこのユニットのタイムアウトを解除します。
Knowledgeのアップロードでは1ファイルごとに埋め込みがコンテナ内で走り、
生成される断片は現時点で130ファイルあります。
所詮はテキストなので既定の90秒に収まる可能性も十分ありますが、
超えた場合は同期が中断されて中途半端な状態が残ります。
同期側はリクエストごとに打ち切りを持つので、
待ち続けても止まらなくなることはありません。

`nix-fast-build`のチェックが通ることと、
生成されたユニットのExecStartに、
ナレッジとRAGテンプレートのstoreパスが載ることを確認しました。

ref https://github.com/ncaq/blue-prompt/pull/158