### PR TITLE
feat(comfyui): アイドル中のComfyUIにメモリを解放させます

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -304,6 +304,9 @@
           # ComfyUIの自作カスタムノードのうち、
           # ComfyUI本体に触れない部分のpytest。
           comfyui-custom-node-test = import ./lib/comfyui-custom-node-test.nix { inherit pkgs; };
+          # アイドル解放の常駐プロセスのうち、
+          # 応答の解釈とアイドルの判定のpytest。
+          comfyui-idle-free-memory-test = import ./lib/comfyui-idle-free-memory-test.nix { inherit pkgs; };
           # Open WebUIの利用者ごとの設定を合成するjqのフィルタが、
           # 意図した通りに合成することを検査するderivation。
           open-webui-user-settings-merge-test =
@@ -432,6 +435,7 @@
               inherit
                 comfyui-api-workflow-test
                 comfyui-custom-node-test
+                comfyui-idle-free-memory-test
                 git-repo-subscribe
                 open-webui-user-settings-merge-test
                 safetensors-fp16

--- a/lib/comfyui-idle-free-memory-test.nix
+++ b/lib/comfyui-idle-free-memory-test.nix
@@ -1,0 +1,71 @@
+/**
+  comfyuiIdleFreeMemoryTest: アイドル解放の常駐プロセスのpytestを走らせるderivation。
+
+  型: { pkgs } -> derivation
+
+  引数:
+    pkgs - pytestを走らせるPythonと`runCommand`を取るためのnixpkgs
+
+  何を検査するか:
+    `response.py`のComfyUIの応答の解釈と、
+    `state.py`のアイドルの判定だけを対象にする。
+    `main.py`は環境変数とHTTPと`while True`を持つので、
+    ここからは触らない。
+
+    解釈の方は正常系より異常系が本体である。
+    ComfyUIのAPIには型が無く、
+    バージョンが上がって形が変わった時に、
+    例外ではなく静かに違う値が返る形で壊れる。
+    実機で1回動かしても通るのは1本の経路だけなので、
+    壊れた形を並べて分岐を固定する。
+
+    判定の方は順序と境界が本体である。
+    「確認の隙間に終わった生成を拾い直す」
+    「解放済みなら投げ直さない」
+    「しきい値を跨いだ最初の周回でだけ解放する」
+    が同時に成り立つ必要があり、
+    どれか1つを崩しても1周回が数分かかる実機では滅多に表面化しない。
+
+  なぜComfyUIのPython環境を使わないか:
+    `lib/comfyui-custom-node-test.nix`と同じ理由による。
+    対象が標準ライブラリしか使わないので、
+    素の`python3`で足りるなら、
+    CUDA版torchを含む閉包を持たないaarch64でもそのまま走らせられる。
+
+  なぜ`main.py`を入力へ入れないか:
+    テストが読まないファイルの変更でこのcheckが作り直されるのを避ける。
+    `main.py`の側は`checks.pyright`が見る。
+*/
+{ pkgs }:
+let
+  inherit (pkgs) lib;
+
+  idleFreeMemory = ../nixos/host/bullet/comfyui/idle-free-memory;
+
+  source = lib.fileset.toSource {
+    root = idleFreeMemory;
+    fileset = lib.fileset.unions [
+      (idleFreeMemory + "/tests")
+      (idleFreeMemory + "/response.py")
+      (idleFreeMemory + "/state.py")
+    ];
+  };
+
+  python = pkgs.python3.withPackages (pythonPkgs: [ pythonPkgs.pytest ]);
+in
+pkgs.runCommand "comfyui-idle-free-memory-test"
+  {
+    nativeBuildInputs = [ python ];
+  }
+  ''
+    # pytestはキャッシュを書くので、読み取り専用のstoreから作業領域へ複製する。
+    cp -r ${source} work
+    chmod -R u+w work
+    cd work
+
+    # 実機では`main.py`と同じディレクトリに置かれた素のモジュールとして解決される。
+    # `tests/conftest.py`がその並びをsys.pathで再現する。
+    pytest tests
+
+    touch $out
+  ''

--- a/lib/comfyui-idle-free-memory-test.nix
+++ b/lib/comfyui-idle-free-memory-test.nix
@@ -8,9 +8,14 @@
 
   何を検査するか:
     `response.py`のComfyUIの応答の解釈と、
-    `state.py`のアイドルの判定だけを対象にする。
-    `main.py`は環境変数とHTTPと`while True`を持つので、
-    ここからは触らない。
+    `state.py`のアイドルの判定と、
+    `main.py`の`free_if_needed`を対象にする。
+
+    `main.py`は環境変数とHTTPと`while True`を持つが、
+    それらを実行するのは`main()`の中だけで、
+    importしただけでは何も起きない。
+    `free_if_needed`は解放の要求をcallableで受け取るので、
+    HTTPを踏まずにダブルで固定できる。
 
     解釈の方は正常系より異常系が本体である。
     ComfyUIのAPIには型が無く、
@@ -32,9 +37,10 @@
     素の`python3`で足りるなら、
     CUDA版torchを含む閉包を持たないaarch64でもそのまま走らせられる。
 
-  なぜ`main.py`を入力へ入れないか:
-    テストが読まないファイルの変更でこのcheckが作り直されるのを避ける。
-    `main.py`の側は`checks.pyright`が見る。
+  なぜ`main.py`も入力へ入れるか:
+    `free_if_needed`がテストの対象になったためである。
+    以前はここに入れず「テストが読まないファイルの変更で作り直さない」と書いていたが、
+    読むようになった以上その理由は当てはまらない。
 */
 { pkgs }:
 let
@@ -46,6 +52,7 @@ let
     root = idleFreeMemory;
     fileset = lib.fileset.unions [
       (idleFreeMemory + "/tests")
+      (idleFreeMemory + "/main.py")
       (idleFreeMemory + "/response.py")
       (idleFreeMemory + "/state.py")
     ];

--- a/nixos/host/bullet/comfyui/idle-free-memory.nix
+++ b/nixos/host/bullet/comfyui/idle-free-memory.nix
@@ -53,7 +53,7 @@ in
           # `http://`をこちらで足して完全なURLにすると、
           # Python側で`urlopen`へ渡るのが変数になり、
           # ruffがS310でスキームを確定できないと警告する。
-          # 理由の詳細は`idle-free-memory.py`の冒頭にある。
+          # 理由の詳細は`idle-free-memory/main.py`の冒頭にある。
           COMFYUI_AUTHORITY = "127.0.0.1:${toString config.services.comfyui.port}";
           # 確認の間隔。
           # 活動時刻はComfyUI自身の記録から取るので、

--- a/nixos/host/bullet/comfyui/idle-free-memory.nix
+++ b/nixos/host/bullet/comfyui/idle-free-memory.nix
@@ -1,0 +1,66 @@
+# アイドル中のComfyUIにメモリを解放させる常駐プロセスを、コンテナの中で動かす。
+#
+# 何をどう判断して解放するかは`idle-free-memory.py`の先頭に書いてある。
+#
+# ホスト側のサービスにしない理由は寿命の管理である。
+# ComfyUIのコンテナはソケットアクティベーションで起きるので、
+# ホストに置くと`container@comfyui.service`への`bindsTo`と`after`と`wantedBy`で、
+# 起動と停止を追従させる配線が要る。
+# コンテナの中のサービスなら、コンテナが消える時に一緒に消える。
+#
+# 隔離の観点でも中に置いて構わない。
+# 外部由来のコードと同じ空間へ自分のコードを入れることになるが、
+# このプロセスが持つ権限はComfyUIのAPIを叩けることだけで、
+# それは同じ空間にいるComfyUI自身が最初からできることである。
+#
+# 宛先がループバックになるので、
+# vethのアドレスもコンテナのfirewallも関係しなくなる。
+{
+  containers.comfyui.config =
+    {
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      systemd.services.comfyui-idle-free-memory = {
+        description = "Free ComfyUI memory while idle";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "comfyui.service" ];
+        # 依存関係で縛らない。
+        # ComfyUIが落ちている間はHTTPが失敗するだけで、
+        # スクリプトはそれを記録して次の周回へ進む。
+        # 縛って止めるより、動いていない相手を叩き続けて勝手に復帰する方が単純である。
+        environment = {
+          # 渡すのはホストとポートだけにする。
+          # `http://`をこちらで足して完全なURLにすると、
+          # Python側で`urlopen`へ渡るのが変数になり、
+          # ruffがS310でスキームを確定できないと警告する。
+          # 理由の詳細は`idle-free-memory.py`の冒頭にある。
+          COMFYUI_AUTHORITY = "127.0.0.1:${toString config.services.comfyui.port}";
+          # 確認の間隔。
+          # 活動時刻はComfyUI自身の記録から取るので、
+          # 間隔を詰めても取りこぼしは減らない。
+          # 解放が実際に走るのが最後の活動から`IDLE_SECONDS`後ちょうどではなく、
+          # そこから最大でこの秒数だけ遅れる、という意味しか持たない。
+          POLL_INTERVAL_SECONDS = "300";
+          # これだけ何もしていなければ解放する。
+          # 短くすると、少し考えてから次の生成を回す間に降ろされて載せ直しになる。
+          IDLE_SECONDS = "600";
+        };
+        serviceConfig =
+          # `hardening`は`flake.nix`のspecialArgs経由でホストのモジュールへ配られるが、
+          # コンテナの中のモジュールへは伝播しない。
+          # 引数を取らない素のimportなので、ここで直接読む。
+          (import ../../../../lib/systemd-hardening.nix).network // {
+            # ループバックへHTTPを投げるだけなので、
+            # 標準ライブラリしか使わないPythonをそのまま動かせる。
+            ExecStart = "${pkgs.python3}/bin/python3 ${./idle-free-memory.py}";
+            DynamicUser = true;
+            # 待ち続けるのが仕事なので、終了は全て異常である。
+            Restart = "always";
+            RestartSec = "10s";
+          };
+      };
+    };
+}

--- a/nixos/host/bullet/comfyui/idle-free-memory.nix
+++ b/nixos/host/bullet/comfyui/idle-free-memory.nix
@@ -15,6 +15,7 @@
 #
 # 宛先がループバックになるので、
 # vethのアドレスもコンテナのfirewallも関係しなくなる。
+{ hardening, ... }:
 {
   containers.comfyui.config =
     {
@@ -48,19 +49,18 @@
           # 短くすると、少し考えてから次の生成を回す間に降ろされて載せ直しになる。
           IDLE_SECONDS = "600";
         };
-        serviceConfig =
-          # `hardening`は`flake.nix`のspecialArgs経由でホストのモジュールへ配られるが、
-          # コンテナの中のモジュールへは伝播しない。
-          # 引数を取らない素のimportなので、ここで直接読む。
-          (import ../../../../lib/systemd-hardening.nix).network // {
-            # ループバックへHTTPを投げるだけなので、
-            # 標準ライブラリしか使わないPythonをそのまま動かせる。
-            ExecStart = "${pkgs.python3}/bin/python3 ${./idle-free-memory.py}";
-            DynamicUser = true;
-            # 待ち続けるのが仕事なので、終了は全て異常である。
-            Restart = "always";
-            RestartSec = "10s";
-          };
+        # `hardening`はこのファイル自身がホスト側のモジュールとして受け取ったものである。
+        # コンテナの中のモジュールへはモジュール引数としては渡らないが、
+        # ここはクロージャの内側なのでそのまま参照できる。
+        serviceConfig = hardening.network // {
+          # ループバックへHTTPを投げるだけなので、
+          # 標準ライブラリしか使わないPythonをそのまま動かせる。
+          ExecStart = "${pkgs.python3}/bin/python3 ${./idle-free-memory.py}";
+          DynamicUser = true;
+          # 待ち続けるのが仕事なので、終了は全て異常である。
+          Restart = "always";
+          RestartSec = "10s";
+        };
       };
     };
 }

--- a/nixos/host/bullet/comfyui/idle-free-memory.nix
+++ b/nixos/host/bullet/comfyui/idle-free-memory.nix
@@ -58,8 +58,20 @@
           ExecStart = "${pkgs.python3}/bin/python3 ${./idle-free-memory.py}";
           DynamicUser = true;
           # 待ち続けるのが仕事なので、終了は全て異常である。
+          #
+          # HTTPの失敗はPython側が周回の中で吸収するので、
+          # ここまで来る終了は環境変数の欠落やスクリプト自体の不具合など、
+          # 待っても直らないものが基本になる。
+          # 10秒固定のままだと、
+          # systemdの既定の起動レート制限(10秒に5回)に掛からないため、
+          # 直らない状態で10秒間隔の再起動を永久に繰り返す。
+          #
+          # `lib/container-socket-activation.nix`が`comfyui-proxy`へ入れているものと同じ、
+          # nixpkgsの`ollama-model-loader`由来の指数バックオフで抑える。
           Restart = "always";
           RestartSec = "10s";
+          RestartMaxDelaySec = "2h";
+          RestartSteps = 10;
         };
       };
     };

--- a/nixos/host/bullet/comfyui/idle-free-memory.nix
+++ b/nixos/host/bullet/comfyui/idle-free-memory.nix
@@ -1,6 +1,6 @@
 # アイドル中のComfyUIにメモリを解放させる常駐プロセスを、コンテナの中で動かす。
 #
-# 何をどう判断して解放するかは`idle-free-memory.py`の先頭に書いてある。
+# 何をどう判断して解放するかは`idle-free-memory/main.py`の先頭に書いてある。
 #
 # ホスト側のサービスにしない理由は寿命の管理である。
 # ComfyUIのコンテナはソケットアクティベーションで起きるので、
@@ -15,7 +15,23 @@
 #
 # 宛先がループバックになるので、
 # vethのアドレスもコンテナのfirewallも関係しなくなる。
-{ hardening, ... }:
+{
+  lib,
+  hardening,
+  ...
+}:
+let
+  # コンテナのstoreへ持ち込むのは動かすものだけにする。
+  # ディレクトリをそのまま渡すとテストまで付いてくる。
+  source = lib.fileset.toSource {
+    root = ./idle-free-memory;
+    fileset = lib.fileset.unions [
+      ./idle-free-memory/main.py
+      ./idle-free-memory/response.py
+      ./idle-free-memory/state.py
+    ];
+  };
+in
 {
   containers.comfyui.config =
     {
@@ -55,7 +71,11 @@
         serviceConfig = hardening.network // {
           # ループバックへHTTPを投げるだけなので、
           # 標準ライブラリしか使わないPythonをそのまま動かせる。
-          ExecStart = "${pkgs.python3}/bin/python3 ${./idle-free-memory.py}";
+          #
+          # `main.py`を直接指すと、
+          # Pythonが置かれたディレクトリをsys.pathの先頭へ入れるので、
+          # 隣の`response.py`と`state.py`が素のモジュールとして解決される。
+          ExecStart = "${pkgs.python3}/bin/python3 ${source}/main.py";
           DynamicUser = true;
           # 待ち続けるのが仕事なので、終了は全て異常である。
           #

--- a/nixos/host/bullet/comfyui/idle-free-memory.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory.py
@@ -1,0 +1,266 @@
+"""ComfyUIがアイドルになったらメモリを解放させる常駐プロセス。
+
+ComfyUIはsmart memoryで実行後も重みをVRAMへ保持し続ける。
+同じモデルを連続で使う分には正しい挙動だが、
+使い終わって放置している間も抱えたままになる。
+bulletではOllamaが同じGPUを使うので、
+抱えられたままだと汎用モデルがCUDAのOOMで載らない。
+
+ComfyUI本体にこれを時間で解く仕組みは無い。
+0.33.1の`comfy/cli_args.py`には該当する引数が無く、
+`--disable-smart-memory`は実行のたびに降ろす別物である。
+上流でも「作業セッションの後にVRAMが解放されない」という要望が挙がったまま実装されていない。
+https://github.com/Comfy-Org/ComfyUI/issues/3192
+
+コンテナごと止めれば全て解決するが、それはできない。
+ComfyUIはSQLiteへ保存した状態の一部をローカル版では復元できず、
+アイドルだからと落とすと利用者が困る。
+そのため`lib/container-socket-activation.nix`はアイドル停止を持たない。
+プロセスは生かしたまま、メモリだけを返させる。
+
+# アイドルの測り方
+
+`/prompt`の`queue_remaining`が0でないなら、実行中か待機中のものがあるので動いている。
+
+0の時に「いつから空か」を自分の観測だけで決めてはいけない。
+確認は数分おきなので、その隙間に始まって終わった生成を丸ごと見落とす。
+生成の直後に「ずっと空だった」と誤って判断して降ろすのが、一番やってはいけない挙動である。
+
+代わりにComfyUI自身が記録した時刻を読む。
+`execution_start`と`execution_success`には`add_message`がミリ秒の実時刻を打っていて、
+`/history`の各件の`status.messages`から取れる。
+これを使えば確認の間隔と無関係に最後の活動が分かる。
+
+# 何を解放するか
+
+`/free`へ`unload_models`と`free_memory`を立てて投げる。
+前者がVRAMの重みを降ろし、後者が実行結果のキャッシュを捨ててRAMを返す。
+`main.py`の`prompt_worker`はキューが空でもフラグを読みに行くので、
+何も実行していない待機中でもこの要求は効く。
+降ろした後の`gc.collect`と`soft_empty_cache`も本体がやる。
+
+ただしRSSが起動直後の水準まで戻ることは期待できない。
+Pythonのアロケータが確保済みの領域をOSへ返しきるとは限らないためである。
+完全に返すにはプロセスの終了が要るが、それは上に書いた理由で採らない。
+
+# 接続先の組み立て
+
+環境変数から受け取るのはホストとポートだけにして、
+`http://`はこのファイルの中で固定する。
+
+完全なURLを渡してもらう方が`idle-free-memory.nix`の側は素直になるが、
+そうすると`urlopen`へ渡るのが変数になり、
+`file:`や独自スキームも開ける形だとしてruffがS310で警告する。
+スキームが1つに定まっていることをソースの上で示せるなら、
+抑制のコメントを置くよりそちらの方が正しい。
+リテラルで始まるf-stringをその場で渡せば、ruffは警告しない。
+
+# なぜ常駐するか
+
+タイマーで起こす形だと、
+最後に動いていた時刻をプロセスの外、
+つまり`/run`のファイルへ置き直す必要がある。
+起動しっぱなしなら変数で済む。
+インタプリタの起動を数分おきに繰り返さずに済むという利点もある。
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from typing import cast
+
+# HTTPの待ち時間の上限。
+# 相手は同じコンテナの中のlocalhostなので、
+# 返らないのは相手が詰まっているか落ちている時だけである。
+# 短く切っても得るものは無いが、
+# 無指定だとsocketの既定でぶら下がり続けるので上限自体は置く。
+REQUEST_TIMEOUT_SECONDS = 30
+
+# 解放を指示する本文。
+# `main.py`は`free_memory`が立っていれば`unload_models`も立っているとみなすので、
+# 後者だけでも同じ結果になるが、
+# どちらを意図したのかが読めなくなるので両方書く。
+FREE_PAYLOAD = {"unload_models": True, "free_memory": True}
+
+
+def log(message: str) -> None:
+    """journalへ残す。
+
+    systemdはstderrをそのままjournaldへ流すので、
+    ロギングの設定を持たずに`journalctl -M comfyui -u`で読める。
+    バッファに溜めたまま次の確認まで出てこないと追いにくいので毎回流す。
+    """
+    print(f"[idle-free-memory] {message}", file=sys.stderr, flush=True)
+
+
+def get_json(authority: str, path: str) -> object:
+    """GETしてJSONを読む。
+
+    ComfyUIのAPIには型が無いので`object`のまま返して、
+    必要な形かどうかは呼び出し側で確かめる。
+
+    組み立て済みのURLを受け取らずにここで繋ぐ理由はモジュールの冒頭にある。
+    """
+    with urllib.request.urlopen(
+        f"http://{authority}{path}", timeout=REQUEST_TIMEOUT_SECONDS
+    ) as response:
+        body: bytes = response.read()
+    parsed: object = json.loads(body)
+    return parsed
+
+
+def post_json(authority: str, path: str, payload: dict[str, bool]) -> None:
+    """JSONをPOSTする。
+
+    `Request`を変数へ置かずにその場で組むのも`get_json`と同じ理由による。
+    """
+    with urllib.request.urlopen(
+        urllib.request.Request(
+            f"http://{authority}{path}",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        ),
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    ) as response:
+        # 本文は空なので捨てる。
+        # それでも読むのは、応答を受け取りきってから接続を閉じるためである。
+        response.read()
+
+
+def queue_remaining(authority: str) -> int:
+    """キューに残っている数を返す。
+
+    実行中のものも含まれるので、0でなければ何かしら動いている。
+    """
+    parsed = get_json(authority, "/prompt")
+    if not isinstance(parsed, dict):
+        raise ValueError("/promptがオブジェクトを返しませんでした")
+    # `isinstance`だけでは要素の型が不明なままなので、
+    # JSONのオブジェクトとして値を`object`へ寄せる。
+    exec_info = cast(dict[str, object], parsed).get("exec_info")
+    if not isinstance(exec_info, dict):
+        raise ValueError("/promptの応答にexec_infoがありませんでした")
+    remaining = cast(dict[str, object], exec_info).get("queue_remaining")
+    if not isinstance(remaining, int):
+        raise ValueError("/promptのqueue_remainingが整数ではありませんでした")
+    return remaining
+
+
+def _message_timestamps(entry: object) -> list[int]:
+    """履歴1件が持つ状態メッセージの時刻をミリ秒で集める。
+
+    要素は`("execution_start", {...})`のタプルがJSONの配列になったものである。
+    形が違うものは黙って飛ばす。
+    ここで欲しいのは最後の活動時刻だけで、
+    1件読めなくても他の件と次の周回で足りるためである。
+    """
+    if not isinstance(entry, dict):
+        return []
+    status = cast(dict[str, object], entry).get("status")
+    if not isinstance(status, dict):
+        return []
+    messages = cast(dict[str, object], status).get("messages")
+    if not isinstance(messages, list):
+        return []
+    timestamps: list[int] = []
+    for message in cast(list[object], messages):
+        if not isinstance(message, list):
+            continue
+        pair = cast(list[object], message)
+        if len(pair) < 2:
+            continue
+        data = pair[1]
+        if not isinstance(data, dict):
+            continue
+        timestamp = cast(dict[str, object], data).get("timestamp")
+        if isinstance(timestamp, int):
+            timestamps.append(timestamp)
+    return timestamps
+
+
+def latest_activity(authority: str) -> float | None:
+    """ComfyUIが記録した最後の実行時刻をUNIX時刻の秒で返す。
+
+    一度も実行していない場合はNoneを返す。
+
+    `max_items=1`は`offset`の既定値の-1と組み合わさって、
+    `len(history) - max_items`がoffsetになるため新しい方の1件を返す。
+    """
+    parsed = get_json(authority, "/history?max_items=1")
+    if not isinstance(parsed, dict):
+        raise ValueError("/historyがオブジェクトを返しませんでした")
+    timestamps = [
+        timestamp
+        for entry in cast(dict[str, object], parsed).values()
+        for timestamp in _message_timestamps(entry)
+    ]
+    if not timestamps:
+        return None
+    return max(timestamps) / 1000
+
+
+def main() -> None:
+    # 受け取るのはホストとポートだけで、スキームはこのファイルが決める。
+    authority = os.environ["COMFYUI_AUTHORITY"]
+    interval_seconds = float(os.environ["POLL_INTERVAL_SECONDS"])
+    idle_seconds = float(os.environ["IDLE_SECONDS"])
+
+    # 最後に動いていた時刻。
+    # ComfyUIが記録する時刻と比べるので実時刻で持つ。
+    last_activity = time.time()
+    # 解放済みかどうか。
+    # 解放してから次の活動があるまでの間、同じ要求を投げ続けないために持つ。
+    #
+    # 起動直後は未解放から始める。
+    # 通常はコンテナが起きた直後で何も載っていないので、
+    # 最初の1回だけ何も降ろさない要求が飛ぶことになるが、
+    # 載っていなければ`unload_all_models`は何もしないので害は無い。
+    # そのかわり、このプロセスだけが再起動した場合に、
+    # 載ったままのモデルを取りこぼさずに済む。
+    freed = False
+
+    log(
+        f"{interval_seconds:.0f}秒ごとに確認し、{idle_seconds:.0f}秒のアイドルで解放します"
+    )
+
+    while True:
+        # 確認より先に待つ。
+        # ComfyUIの起動を待つ経路をここに書かずに済む。
+        time.sleep(interval_seconds)
+        try:
+            busy = 0 < queue_remaining(authority)
+            latest = latest_activity(authority)
+        except (OSError, ValueError) as error:
+            # ComfyUIの再起動中や、モデルの読み込みで応答が詰まっている間は届かない。
+            # 次の周回で回復するので、記録だけ残して続ける。
+            # `urllib`の投げる`URLError`はOSErrorの、
+            # `json`の投げる`JSONDecodeError`はValueErrorの下位にある。
+            log(f"状態を取得できませんでした: {error}")
+            continue
+        now = time.time()
+        if busy:
+            last_activity = now
+            freed = False
+            continue
+        if latest is not None and last_activity < latest:
+            # 確認と確認の間に終わった生成をここで拾う。
+            last_activity = latest
+            freed = False
+        if freed:
+            continue
+        if now - last_activity < idle_seconds:
+            continue
+        try:
+            post_json(authority, "/free", FREE_PAYLOAD)
+        except OSError as error:
+            log(f"メモリの解放を要求できませんでした: {error}")
+            continue
+        freed = True
+        log("アイドルが続いているのでメモリの解放を要求しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/nixos/host/bullet/comfyui/idle-free-memory.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory.py
@@ -90,7 +90,8 @@ def log(message: str) -> None:
     """journalへ残す。
 
     systemdはstderrをそのままjournaldへ流すので、
-    ロギングの設定を持たずに`journalctl -M comfyui -u`で読める。
+    ロギングの設定を持たずに、
+    `journalctl -M comfyui -u comfyui-idle-free-memory`でそのまま読める。
     バッファに溜めたまま次の確認まで出てこないと追いにくいので毎回流す。
     """
     print(f"[idle-free-memory] {message}", file=sys.stderr, flush=True)

--- a/nixos/host/bullet/comfyui/idle-free-memory.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory.py
@@ -79,8 +79,9 @@ from typing import cast
 REQUEST_TIMEOUT_SECONDS = 30
 
 # 解放を指示する本文。
-# `main.py`は`free_memory`が立っていれば`unload_models`も立っているとみなすので、
-# 後者だけでも同じ結果になるが、
+# `main.py`は`flags.get("unload_models", free_memory)`の形で、
+# `free_memory`を`unload_models`の既定値として読む。
+# つまり`free_memory`だけでも同じ結果になるが、
 # どちらを意図したのかが読めなくなるので両方書く。
 FREE_PAYLOAD = {"unload_models": True, "free_memory": True}
 

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -72,6 +72,7 @@ Pythonのアロケータが確保済みの領域をOSへ返しきるとは限ら
 `while True`と`time.sleep`と同居していると回さずに試せないためである。
 """
 
+import http.client
 import json
 import os
 import sys
@@ -167,11 +168,19 @@ def main() -> None:
         try:
             busy = 0 < queue_remaining(get_json(authority, "/prompt"))
             latest = latest_activity(get_json(authority, "/history?max_items=1"))
-        except (OSError, ValueError) as error:
+        except (OSError, ValueError, http.client.HTTPException) as error:
             # ComfyUIの再起動中や、モデルの読み込みで応答が詰まっている間は届かない。
             # 次の周回で回復するので、記録だけ残して続ける。
+            #
             # `urllib`の投げる`URLError`はOSErrorの、
             # `json`の投げる`JSONDecodeError`はValueErrorの下位にある。
+            #
+            # `IncompleteRead`や`RemoteDisconnected`はそのどちらでもなく、
+            # `http.client.HTTPException`の下にいる。
+            # ComfyUIがモデルのロード中や再起動中に接続を途中で切ると起こりうる。
+            # `Restart = "always"`があるので恒久的な停止にはならないが、
+            # プロセスが落ちると`state`が起動時の値へ戻るので、
+            # 解放が最大で`IDLE_SECONDS`分だけ後ろへずれる。
             log(f"状態を取得できませんでした: {error}")
             continue
         now = time.time()
@@ -190,7 +199,8 @@ def main() -> None:
             continue
         try:
             post_json(authority, "/free", FREE_PAYLOAD)
-        except OSError as error:
+        except (OSError, http.client.HTTPException) as error:
+            # 捕捉する範囲を`get_json`側と揃える。理由はそちらのコメントにある。
             log(f"メモリの解放を要求できませんでした: {error}")
             continue
         # 要求が通ってから解放済みにする。

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -167,7 +167,16 @@ def main() -> None:
         time.sleep(interval_seconds)
         try:
             busy = 0 < queue_remaining(get_json(authority, "/prompt"))
-            latest = latest_activity(get_json(authority, "/history?max_items=1"))
+            # busyなら`next_state`は履歴を見ずに現在時刻で上書きするので、
+            # 引いても結果に影響しない。
+            # 300秒に1回のループバックHTTPで絶対量は小さいが、
+            # 相手はComfyUIのメインループと同じプロセスのハンドラなので、
+            # 生成中に余計な仕事をさせない。
+            latest = (
+                None
+                if busy
+                else latest_activity(get_json(authority, "/history?max_items=1"))
+            )
         except (OSError, ValueError, http.client.HTTPException) as error:
             # ComfyUIの再起動中や、モデルの読み込みで応答が詰まっている間は届かない。
             # 次の周回で回復するので、記録だけ残して続ける。

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -78,6 +78,8 @@ import os
 import sys
 import time
 import urllib.request
+from collections.abc import Callable
+from dataclasses import replace
 
 from response import latest_activity, queue_remaining
 from state import State, next_state
@@ -141,6 +143,35 @@ def post_json(authority: str, path: str, payload: dict[str, bool]) -> None:
         # 本文は空なので捨てる。
         # それでも読むのは、応答を受け取りきってから接続を閉じるためである。
         response.read()
+
+
+def free_if_needed(
+    state: State,
+    should_free: bool,
+    request_free: Callable[[], None],
+) -> State:
+    """必要なら解放を要求して、通った時だけ`freed`を立てる。
+
+    要求そのものをcallableで受け取るのは、
+    ここが`next_state`と対になる不変条件を持つからである。
+    あちらは`freed`を立てず、立てるのはこちらで、
+    しかも要求が実際に通った後に限る。
+    失敗した周回でフラグだけ進めると、
+    次の活動があるまで再試行できなくなる。
+
+    HTTPの失敗だけを吸収する。
+    それ以外の例外はこちらの不具合なので、握り潰さずに上へ通す。
+    """
+    if not should_free:
+        return state
+    try:
+        request_free()
+    except (OSError, http.client.HTTPException) as error:
+        # 捕捉する範囲を`get_json`側と揃える。理由はそちらのコメントにある。
+        log(f"メモリの解放を要求できませんでした: {error}")
+        return state
+    log("アイドルが続いているのでメモリの解放を要求しました")
+    return replace(state, freed=True)
 
 
 def initial_activity(authority: str) -> float:
@@ -232,19 +263,11 @@ def main() -> None:
             latest=latest,
             idle_seconds=idle_seconds,
         )
-        if not should_free:
-            continue
-        try:
-            post_json(authority, "/free", FREE_PAYLOAD)
-        except (OSError, http.client.HTTPException) as error:
-            # 捕捉する範囲を`get_json`側と揃える。理由はそちらのコメントにある。
-            log(f"メモリの解放を要求できませんでした: {error}")
-            continue
-        # 要求が通ってから解放済みにする。
-        # `next_state`がここを立てないのは、
-        # 失敗した周回でフラグだけ進めて再試行できなくならないようにするためである。
-        state = State(last_activity=state.last_activity, freed=True)
-        log("アイドルが続いているのでメモリの解放を要求しました")
+        state = free_if_needed(
+            state,
+            should_free=should_free,
+            request_free=lambda: post_json(authority, "/free", FREE_PAYLOAD),
+        )
 
 
 if __name__ == "__main__":

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -174,9 +174,14 @@ def main() -> None:
             # `json`の投げる`JSONDecodeError`はValueErrorの下位にある。
             log(f"状態を取得できませんでした: {error}")
             continue
+        now = time.time()
+        if latest is not None and now < latest:
+            # `next_state`が現在時刻へ倒すので判定は狂わないが、
+            # 倒したこと自体は時刻ずれの兆候なので記録しておく。
+            log(f"履歴の時刻が{latest - now:.0f}秒だけ未来を指しています")
         state, should_free = next_state(
             state,
-            now=time.time(),
+            now=now,
             busy=busy,
             latest=latest,
             idle_seconds=idle_seconds,

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -143,6 +143,34 @@ def post_json(authority: str, path: str, payload: dict[str, bool]) -> None:
         response.read()
 
 
+def initial_activity(authority: str) -> float:
+    """ループへ入る前の`last_activity`を決める。
+
+    現在時刻から始めると、
+    このプロセスだけが再起動した時に困る。
+    ComfyUIが何時間も前から放置されていても、
+    履歴の時刻は初期値より古いので拾い直されず、
+    解放まで改めて`IDLE_SECONDS`待つことになる。
+    載ったままのモデルを取りこぼさないという意図が半分しか効かない。
+
+    履歴が取れたらそれを使う。
+    一度も実行していない場合と、
+    ComfyUIがまだ起動しきっていない場合は現在時刻へ倒す。
+    その場合に待つ時間は、
+    どのみち何も載っていないか、これから載るところなので惜しくない。
+    """
+    now = time.time()
+    try:
+        latest = latest_activity(get_json(authority, "/history?max_items=1"))
+    except (OSError, ValueError, http.client.HTTPException) as error:
+        log(f"起動時の履歴を取得できませんでした: {error}")
+        return now
+    if latest is None:
+        return now
+    # 未来の時刻はループの中と同じく現在時刻へ倒す。
+    return min(latest, now)
+
+
 def main() -> None:
     # 受け取るのはホストとポートだけで、スキームはこのファイルが決める。
     authority = os.environ["COMFYUI_AUTHORITY"]
@@ -155,7 +183,7 @@ def main() -> None:
     # 載っていなければ`unload_all_models`は何もしないので害は無い。
     # そのかわり、このプロセスだけが再起動した場合に、
     # 載ったままのモデルを取りこぼさずに済む。
-    state = State(last_activity=time.time(), freed=False)
+    state = State(last_activity=initial_activity(authority), freed=False)
 
     log(
         f"{interval_seconds:.0f}秒ごとに確認し、{idle_seconds:.0f}秒のアイドルで解放します"

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -62,6 +62,14 @@ Pythonのアロケータが確保済みの領域をOSへ返しきるとは限ら
 つまり`/run`のファイルへ置き直す必要がある。
 起動しっぱなしなら変数で済む。
 インタプリタの起動を数分おきに繰り返さずに済むという利点もある。
+
+# なぜファイルを分けるか
+
+このファイルはHTTPと環境変数とループだけを持ち、
+応答の解釈は`response.py`へ、
+アイドルの判定は`state.py`へ置いてある。
+どちらもpytestで固定したい対象で、
+`while True`と`time.sleep`と同居していると回さずに試せないためである。
 """
 
 import json
@@ -69,7 +77,9 @@ import os
 import sys
 import time
 import urllib.request
-from typing import cast
+
+from response import latest_activity, queue_remaining
+from state import State, next_state
 
 # HTTPの待ち時間の上限。
 # 相手は同じコンテナの中のlocalhostなので、
@@ -101,7 +111,7 @@ def get_json(authority: str, path: str) -> object:
     """GETしてJSONを読む。
 
     ComfyUIのAPIには型が無いので`object`のまま返して、
-    必要な形かどうかは呼び出し側で確かめる。
+    必要な形かどうかは`response.py`側で確かめる。
 
     組み立て済みのURLを受け取らずにここで繋ぐ理由はモジュールの冒頭にある。
     """
@@ -132,97 +142,19 @@ def post_json(authority: str, path: str, payload: dict[str, bool]) -> None:
         response.read()
 
 
-def queue_remaining(authority: str) -> int:
-    """キューに残っている数を返す。
-
-    実行中のものも含まれるので、0でなければ何かしら動いている。
-    """
-    parsed = get_json(authority, "/prompt")
-    if not isinstance(parsed, dict):
-        raise ValueError("/promptがオブジェクトを返しませんでした")
-    # `isinstance`だけでは要素の型が不明なままなので、
-    # JSONのオブジェクトとして値を`object`へ寄せる。
-    exec_info = cast(dict[str, object], parsed).get("exec_info")
-    if not isinstance(exec_info, dict):
-        raise ValueError("/promptの応答にexec_infoがありませんでした")
-    remaining = cast(dict[str, object], exec_info).get("queue_remaining")
-    if not isinstance(remaining, int):
-        raise ValueError("/promptのqueue_remainingが整数ではありませんでした")
-    return remaining
-
-
-def _message_timestamps(entry: object) -> list[int]:
-    """履歴1件が持つ状態メッセージの時刻をミリ秒で集める。
-
-    要素は`("execution_start", {...})`のタプルがJSONの配列になったものである。
-    形が違うものは黙って飛ばす。
-    ここで欲しいのは最後の活動時刻だけで、
-    1件読めなくても他の件と次の周回で足りるためである。
-    """
-    if not isinstance(entry, dict):
-        return []
-    status = cast(dict[str, object], entry).get("status")
-    if not isinstance(status, dict):
-        return []
-    messages = cast(dict[str, object], status).get("messages")
-    if not isinstance(messages, list):
-        return []
-    timestamps: list[int] = []
-    for message in cast(list[object], messages):
-        if not isinstance(message, list):
-            continue
-        pair = cast(list[object], message)
-        if len(pair) < 2:
-            continue
-        data = pair[1]
-        if not isinstance(data, dict):
-            continue
-        timestamp = cast(dict[str, object], data).get("timestamp")
-        if isinstance(timestamp, int):
-            timestamps.append(timestamp)
-    return timestamps
-
-
-def latest_activity(authority: str) -> float | None:
-    """ComfyUIが記録した最後の実行時刻をUNIX時刻の秒で返す。
-
-    一度も実行していない場合はNoneを返す。
-
-    `max_items=1`は`offset`の既定値の-1と組み合わさって、
-    `len(history) - max_items`がoffsetになるため新しい方の1件を返す。
-    """
-    parsed = get_json(authority, "/history?max_items=1")
-    if not isinstance(parsed, dict):
-        raise ValueError("/historyがオブジェクトを返しませんでした")
-    timestamps = [
-        timestamp
-        for entry in cast(dict[str, object], parsed).values()
-        for timestamp in _message_timestamps(entry)
-    ]
-    if not timestamps:
-        return None
-    return max(timestamps) / 1000
-
-
 def main() -> None:
     # 受け取るのはホストとポートだけで、スキームはこのファイルが決める。
     authority = os.environ["COMFYUI_AUTHORITY"]
     interval_seconds = float(os.environ["POLL_INTERVAL_SECONDS"])
     idle_seconds = float(os.environ["IDLE_SECONDS"])
 
-    # 最後に動いていた時刻。
-    # ComfyUIが記録する時刻と比べるので実時刻で持つ。
-    last_activity = time.time()
-    # 解放済みかどうか。
-    # 解放してから次の活動があるまでの間、同じ要求を投げ続けないために持つ。
-    #
     # 起動直後は未解放から始める。
     # 通常はコンテナが起きた直後で何も載っていないので、
     # 最初の1回だけ何も降ろさない要求が飛ぶことになるが、
     # 載っていなければ`unload_all_models`は何もしないので害は無い。
     # そのかわり、このプロセスだけが再起動した場合に、
     # 載ったままのモデルを取りこぼさずに済む。
-    freed = False
+    state = State(last_activity=time.time(), freed=False)
 
     log(
         f"{interval_seconds:.0f}秒ごとに確認し、{idle_seconds:.0f}秒のアイドルで解放します"
@@ -233,8 +165,8 @@ def main() -> None:
         # ComfyUIの起動を待つ経路をここに書かずに済む。
         time.sleep(interval_seconds)
         try:
-            busy = 0 < queue_remaining(authority)
-            latest = latest_activity(authority)
+            busy = 0 < queue_remaining(get_json(authority, "/prompt"))
+            latest = latest_activity(get_json(authority, "/history?max_items=1"))
         except (OSError, ValueError) as error:
             # ComfyUIの再起動中や、モデルの読み込みで応答が詰まっている間は届かない。
             # 次の周回で回復するので、記録だけ残して続ける。
@@ -242,25 +174,24 @@ def main() -> None:
             # `json`の投げる`JSONDecodeError`はValueErrorの下位にある。
             log(f"状態を取得できませんでした: {error}")
             continue
-        now = time.time()
-        if busy:
-            last_activity = now
-            freed = False
-            continue
-        if latest is not None and last_activity < latest:
-            # 確認と確認の間に終わった生成をここで拾う。
-            last_activity = latest
-            freed = False
-        if freed:
-            continue
-        if now - last_activity < idle_seconds:
+        state, should_free = next_state(
+            state,
+            now=time.time(),
+            busy=busy,
+            latest=latest,
+            idle_seconds=idle_seconds,
+        )
+        if not should_free:
             continue
         try:
             post_json(authority, "/free", FREE_PAYLOAD)
         except OSError as error:
             log(f"メモリの解放を要求できませんでした: {error}")
             continue
-        freed = True
+        # 要求が通ってから解放済みにする。
+        # `next_state`がここを立てないのは、
+        # 失敗した周回でフラグだけ進めて再試行できなくならないようにするためである。
+        state = State(last_activity=state.last_activity, freed=True)
         log("アイドルが続いているのでメモリの解放を要求しました")
 
 

--- a/nixos/host/bullet/comfyui/idle-free-memory/main.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/main.py
@@ -35,7 +35,7 @@ ComfyUIはSQLiteへ保存した状態の一部をローカル版では復元で�
 
 `/free`へ`unload_models`と`free_memory`を立てて投げる。
 前者がVRAMの重みを降ろし、後者が実行結果のキャッシュを捨ててRAMを返す。
-`main.py`の`prompt_worker`はキューが空でもフラグを読みに行くので、
+ComfyUI本体の`main.py`の`prompt_worker`はキューが空でもフラグを読みに行くので、
 何も実行していない待機中でもこの要求は効く。
 降ろした後の`gc.collect`と`soft_empty_cache`も本体がやる。
 
@@ -90,7 +90,7 @@ from state import State, next_state
 REQUEST_TIMEOUT_SECONDS = 30
 
 # 解放を指示する本文。
-# `main.py`は`flags.get("unload_models", free_memory)`の形で、
+# ComfyUI本体の`main.py`は`flags.get("unload_models", free_memory)`の形で、
 # `free_memory`を`unload_models`の既定値として読む。
 # つまり`free_memory`だけでも同じ結果になるが、
 # どちらを意図したのかが読めなくなるので両方書く。

--- a/nixos/host/bullet/comfyui/idle-free-memory/response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/response.py
@@ -35,6 +35,12 @@ def queue_remaining(parsed: object) -> int:
     """`/prompt`の応答からキューに残っている数を取り出す。
 
     実行中のものも含まれるので、0でなければ何かしら動いている。
+
+    形が合わない場合はValueErrorを投げる。
+    応答がオブジェクトでない、
+    `exec_info`が無いかオブジェクトでない、
+    `queue_remaining`が数値でない、の3経路がある。
+    呼び出し側はこれを捕まえてその周回を飛ばす。
     """
     if not isinstance(parsed, dict):
         raise ValueError("/promptがオブジェクトを返しませんでした")

--- a/nixos/host/bullet/comfyui/idle-free-memory/response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/response.py
@@ -1,0 +1,86 @@
+"""ComfyUIの応答を解釈する。
+
+HTTPには触れず、
+`json.loads`が返したものを受け取って必要な値だけを取り出す。
+ComfyUIのAPIには型が無いので、
+引数は`object`で受けて形をその場で確かめる。
+
+`main.py`から分けてあるのは、
+ここがComfyUIのバージョンが上がると壊れる側だからである。
+しかも壊れ方は「例外が出る」ではなく、
+「形が変わって静かに違う値を返す」になりやすい。
+`while True`も`time.sleep`も`os.environ`も持たない形にしておけば、
+壊れた入力を並べたpytestで分岐を固定できる。
+"""
+
+from typing import cast
+
+
+def queue_remaining(parsed: object) -> int:
+    """`/prompt`の応答からキューに残っている数を取り出す。
+
+    実行中のものも含まれるので、0でなければ何かしら動いている。
+    """
+    if not isinstance(parsed, dict):
+        raise ValueError("/promptがオブジェクトを返しませんでした")
+    # `isinstance`だけでは要素の型が不明なままなので、
+    # JSONのオブジェクトとして値を`object`へ寄せる。
+    exec_info = cast(dict[str, object], parsed).get("exec_info")
+    if not isinstance(exec_info, dict):
+        raise ValueError("/promptの応答にexec_infoがありませんでした")
+    remaining = cast(dict[str, object], exec_info).get("queue_remaining")
+    if not isinstance(remaining, int):
+        raise ValueError("/promptのqueue_remainingが整数ではありませんでした")
+    return remaining
+
+
+def message_timestamps(entry: object) -> list[int]:
+    """履歴1件が持つ状態メッセージの時刻をミリ秒で集める。
+
+    要素は`("execution_start", {...})`のタプルがJSONの配列になったものである。
+    形が違うものは黙って飛ばす。
+    ここで欲しいのは最後の活動時刻だけで、
+    1件読めなくても他の件と次の周回で足りるためである。
+    """
+    if not isinstance(entry, dict):
+        return []
+    status = cast(dict[str, object], entry).get("status")
+    if not isinstance(status, dict):
+        return []
+    messages = cast(dict[str, object], status).get("messages")
+    if not isinstance(messages, list):
+        return []
+    timestamps: list[int] = []
+    for message in cast(list[object], messages):
+        if not isinstance(message, list):
+            continue
+        pair = cast(list[object], message)
+        if len(pair) < 2:
+            continue
+        data = pair[1]
+        if not isinstance(data, dict):
+            continue
+        timestamp = cast(dict[str, object], data).get("timestamp")
+        if isinstance(timestamp, int):
+            timestamps.append(timestamp)
+    return timestamps
+
+
+def latest_activity(parsed: object) -> float | None:
+    """`/history`の応答から最後の実行時刻をUNIX時刻の秒で取り出す。
+
+    一度も実行していない場合はNoneを返す。
+
+    `/history?max_items=1`は`offset`の既定値の-1と組み合わさって、
+    `len(history) - max_items`がoffsetになるため新しい方の1件を返す。
+    """
+    if not isinstance(parsed, dict):
+        raise ValueError("/historyがオブジェクトを返しませんでした")
+    timestamps = [
+        timestamp
+        for entry in cast(dict[str, object], parsed).values()
+        for timestamp in message_timestamps(entry)
+    ]
+    if not timestamps:
+        return None
+    return max(timestamps) / 1000

--- a/nixos/host/bullet/comfyui/idle-free-memory/response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/response.py
@@ -16,6 +16,21 @@ ComfyUIのAPIには型が無いので、
 from typing import cast
 
 
+def _as_int(value: object) -> int | None:
+    """JSONの整数として読める場合だけ返す。
+
+    `isinstance(value, int)`だけでは`bool`も通る。
+    `bool`が`int`の派生だからである。
+    この関数群の存在意義は壊れた形を弾くことなので、
+    `true`が0や1として流れ込む経路を先に塞ぐ。
+    """
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int):
+        return None
+    return value
+
+
 def queue_remaining(parsed: object) -> int:
     """`/prompt`の応答からキューに残っている数を取り出す。
 
@@ -28,8 +43,8 @@ def queue_remaining(parsed: object) -> int:
     exec_info = cast(dict[str, object], parsed).get("exec_info")
     if not isinstance(exec_info, dict):
         raise ValueError("/promptの応答にexec_infoがありませんでした")
-    remaining = cast(dict[str, object], exec_info).get("queue_remaining")
-    if not isinstance(remaining, int):
+    remaining = _as_int(cast(dict[str, object], exec_info).get("queue_remaining"))
+    if remaining is None:
         raise ValueError("/promptのqueue_remainingが整数ではありませんでした")
     return remaining
 
@@ -60,8 +75,8 @@ def message_timestamps(entry: object) -> list[int]:
         data = pair[1]
         if not isinstance(data, dict):
             continue
-        timestamp = cast(dict[str, object], data).get("timestamp")
-        if isinstance(timestamp, int):
+        timestamp = _as_int(cast(dict[str, object], data).get("timestamp"))
+        if timestamp is not None:
             timestamps.append(timestamp)
     return timestamps
 

--- a/nixos/host/bullet/comfyui/idle-free-memory/response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/response.py
@@ -13,20 +13,37 @@ ComfyUIのAPIには型が無いので、
 壊れた入力を並べたpytestで分岐を固定できる。
 """
 
+import math
 from typing import cast
 
 
-def _as_int(value: object) -> int | None:
-    """JSONの整数として読める場合だけ返す。
+def _as_number(value: object) -> float | None:
+    """JSONの数値として読める場合だけ返す。
 
-    `isinstance(value, int)`だけでは`bool`も通る。
-    `bool`が`int`の派生だからである。
+    `bool`は弾く。
+    `isinstance(value, int)`だけでは`bool`も通ってしまうためである。
+    `bool`が`int`の派生だからで、
     この関数群の存在意義は壊れた形を弾くことなので、
     `true`が0や1として流れ込む経路を先に塞ぐ。
+
+    `float`は受け入れる。
+    上流が浮動小数点数で返すようになった時に、
+    弾くと全件が飛んで`latest_activity`がValueErrorを投げ、
+    呼び出し側が周回を飛ばし続けて解放が二度と走らなくなる。
+    このプロセスが防ごうとしているOOMがそのまま再発するので、
+    厳格に弾くより受け入れて動き続ける方が結果として良い。
+    値はどのみち`/ 1000`して秒にするだけで、
+    キューの残数も`0 <`で比べるだけなので、浮動小数点数でも壊れない。
+
+    有限でない値は弾く。
+    `nan`は比較が常に偽になり、
+    `inf`は`max`を占有してしまうので、どちらも判定の意味を失わせる。
     """
     if isinstance(value, bool):
         return None
-    if not isinstance(value, int):
+    if not isinstance(value, int | float):
+        return None
+    if not math.isfinite(value):
         return None
     return value
 
@@ -49,13 +66,14 @@ def queue_remaining(parsed: object) -> int:
     exec_info = cast(dict[str, object], parsed).get("exec_info")
     if not isinstance(exec_info, dict):
         raise ValueError("/promptの応答にexec_infoがありませんでした")
-    remaining = _as_int(cast(dict[str, object], exec_info).get("queue_remaining"))
+    remaining = _as_number(cast(dict[str, object], exec_info).get("queue_remaining"))
     if remaining is None:
-        raise ValueError("/promptのqueue_remainingが整数ではありませんでした")
-    return remaining
+        raise ValueError("/promptのqueue_remainingが数値ではありませんでした")
+    # 件数なので整数へ落とす。呼び出し側は`0 <`で比べるだけである。
+    return int(remaining)
 
 
-def message_timestamps(entry: object) -> list[int]:
+def message_timestamps(entry: object) -> list[float]:
     """履歴1件が持つ状態メッセージの時刻をミリ秒で集める。
 
     要素は`("execution_start", {...})`のタプルがJSONの配列になったものである。
@@ -71,7 +89,7 @@ def message_timestamps(entry: object) -> list[int]:
     messages = cast(dict[str, object], status).get("messages")
     if not isinstance(messages, list):
         return []
-    timestamps: list[int] = []
+    timestamps: list[float] = []
     for message in cast(list[object], messages):
         if not isinstance(message, list):
             continue
@@ -81,7 +99,7 @@ def message_timestamps(entry: object) -> list[int]:
         data = pair[1]
         if not isinstance(data, dict):
             continue
-        timestamp = _as_int(cast(dict[str, object], data).get("timestamp"))
+        timestamp = _as_number(cast(dict[str, object], data).get("timestamp"))
         if timestamp is not None:
             timestamps.append(timestamp)
     return timestamps

--- a/nixos/host/bullet/comfyui/idle-free-memory/response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/response.py
@@ -86,16 +86,28 @@ def latest_activity(parsed: object) -> float | None:
 
     一度も実行していない場合はNoneを返す。
 
+    件はあるのに時刻が1つも取れなかった場合はValueErrorを投げる。
+    `message_timestamps`は形の合わないものを黙って飛ばすので、
+    ComfyUIが`status.messages`の形やキー名を変えると全件が飛ばされる。
+    ここでNoneを返すと呼び出し側は「一度も実行していない」とみなし、
+    自分の観測だけでアイドルを判定する状態へ静かに退行する。
+    それはこのプロセスが避けようとしている、
+    生成の直後に降ろす動作そのものである。
+    件が0件の場合と区別して、上流の変化に気付けるようにする。
+
     `/history?max_items=1`は`offset`の既定値の-1と組み合わさって、
     `len(history) - max_items`がoffsetになるため新しい方の1件を返す。
     """
     if not isinstance(parsed, dict):
         raise ValueError("/historyがオブジェクトを返しませんでした")
+    entries = cast(dict[str, object], parsed)
     timestamps = [
         timestamp
-        for entry in cast(dict[str, object], parsed).values()
+        for entry in entries.values()
         for timestamp in message_timestamps(entry)
     ]
-    if not timestamps:
-        return None
-    return max(timestamps) / 1000
+    if timestamps:
+        return max(timestamps) / 1000
+    if entries:
+        raise ValueError(f"/historyの{len(entries)}件から時刻を1つも取れませんでした")
+    return None

--- a/nixos/host/bullet/comfyui/idle-free-memory/state.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/state.py
@@ -1,0 +1,60 @@
+"""アイドルかどうかの判定と、解放を要求するかどうかの決定。
+
+時刻は引数で受け取り、
+`time`にも`os.environ`にもHTTPにも触れない。
+1周回分の遷移を1つの関数にまとめてあるので、
+`main.py`のループを回さずに順序と境界をpytestで固定できる。
+
+ここが一番壊れやすい。
+「確認と確認の隙間に終わった生成を拾い直す」
+「解放済みなら同じ要求を投げ直さない」
+「しきい値を跨いだ最初の周回でだけ解放する」
+の3つが同時に成り立っている必要があり、
+どれか1つを崩しても実機では滅多に表面化しないためである。
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class State:
+    """周回をまたいで持ち越す状態。
+
+    `last_activity`はComfyUIが最後に動いていた実時刻の秒。
+    `freed`は解放を要求済みかどうかで、
+    次の活動があるまで同じ要求を投げ続けないために持つ。
+    """
+
+    last_activity: float
+    freed: bool
+
+
+def next_state(
+    state: State,
+    now: float,
+    busy: bool,
+    latest: float | None,
+    idle_seconds: float,
+) -> tuple[State, bool]:
+    """1周回分の遷移を行い、更新後の状態と解放を要求すべきかを返す。
+
+    `busy`はキューに残りがあるかどうか、
+    `latest`はComfyUI自身が記録した最後の活動時刻で、
+    取れなかった場合はNoneを渡す。
+
+    解放が成功したかどうかはHTTPの結果次第なので、
+    ここでは`freed`を立てない。
+    立てるのは実際に要求が通った後の呼び出し側である。
+    要求に失敗した周回でフラグだけ進めてしまうと、
+    次の活動があるまで再試行できなくなる。
+    """
+    if busy:
+        return (State(last_activity=now, freed=False), False)
+    if latest is not None and state.last_activity < latest:
+        # 確認と確認の間に始まって終わった生成をここで拾う。
+        state = State(last_activity=latest, freed=False)
+    if state.freed:
+        return (state, False)
+    if now - state.last_activity < idle_seconds:
+        return (state, False)
+    return (state, True)

--- a/nixos/host/bullet/comfyui/idle-free-memory/state.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/state.py
@@ -50,9 +50,20 @@ def next_state(
     """
     if busy:
         return (State(last_activity=now, freed=False), False)
-    if latest is not None and state.last_activity < latest:
-        # 確認と確認の間に始まって終わった生成をここで拾う。
-        state = State(last_activity=latest, freed=False)
+    if latest is not None:
+        # 未来の時刻は現在時刻へ倒す。
+        # コンテナ内の時刻ずれや、
+        # 履歴を書ける立場が未来のタイムスタンプを1件でも記録した場合に、
+        # そのまま代入すると`now - last_activity`が負のままになる。
+        # しきい値を二度と超えられなくなって解放が永久に止まり、
+        # GPUを共有する他のサービスへ直接効いてしまう。
+        #
+        # 無視せず倒すのは、
+        # 未来を指していても「新しい活動があった」ことは事実だからである。
+        activity = min(latest, now)
+        if state.last_activity < activity:
+            # 確認と確認の間に始まって終わった生成をここで拾う。
+            state = State(last_activity=activity, freed=False)
     if state.freed:
         return (state, False)
     if now - state.last_activity < idle_seconds:

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/conftest.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/conftest.py
@@ -1,0 +1,11 @@
+"""`response`と`state`をテストからimportできるようにする。
+
+`main.py`はスクリプトとして起動されるので、
+Pythonが自分の置かれたディレクトリをsys.pathの先頭へ入れる。
+その並びをここで再現して、実機と同じ名前で解決させる。
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_free.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_free.py
@@ -1,0 +1,68 @@
+"""`main.py`の`free_if_needed`のテスト。
+
+`state.py`のdocstringは「`freed`を立てるのは要求が通った後の呼び出し側である」と書き、
+`test_freed_is_not_set_by_the_transition`が遷移の側を固定している。
+その対になる呼び出し側がここである。
+
+片側だけを固定していると、
+要求を`try`の外へ出しても、
+`except`節で状態を進めてしまっても、テストは緑のまま通る。
+実機では解放が次の活動まで再試行されなくなるだけなので気付けない。
+"""
+
+import http.client
+
+import pytest
+from main import free_if_needed
+from state import State
+
+IDLE_STATE = State(last_activity=1000.0, freed=False)
+
+
+def test_does_nothing_when_not_requested() -> None:
+    calls: list[int] = []
+
+    def request_free() -> None:
+        calls.append(1)
+
+    assert free_if_needed(IDLE_STATE, should_free=False, request_free=request_free) == (
+        IDLE_STATE
+    )
+    assert calls == []
+
+
+def test_marks_freed_after_a_successful_request() -> None:
+    calls: list[int] = []
+
+    def request_free() -> None:
+        calls.append(1)
+
+    state = free_if_needed(IDLE_STATE, should_free=True, request_free=request_free)
+    assert calls == [1]
+    assert state == State(last_activity=1000.0, freed=True)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OSError("接続できませんでした"),
+        http.client.RemoteDisconnected("切断されました"),
+    ],
+)
+def test_keeps_freed_false_when_the_request_fails(error: Exception) -> None:
+    # 失敗した周回でフラグだけ進めると、次の活動まで再試行できなくなる。
+    def request_free() -> None:
+        raise error
+
+    state = free_if_needed(IDLE_STATE, should_free=True, request_free=request_free)
+    assert state == IDLE_STATE
+
+
+def test_does_not_swallow_unexpected_errors() -> None:
+    # HTTPの失敗だけを吸収する。
+    # それ以外はこちらの不具合なので、握り潰さずにユニットごと落とす。
+    def request_free() -> None:
+        raise ValueError("想定していない失敗")
+
+    with pytest.raises(ValueError):
+        free_if_needed(IDLE_STATE, should_free=True, request_free=request_free)

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
@@ -111,3 +111,13 @@ def test_latest_activity_returns_none_for_empty_history() -> None:
 def test_latest_activity_rejects_non_object() -> None:
     with pytest.raises(ValueError):
         latest_activity([])
+
+
+def test_latest_activity_reports_entries_without_timestamps() -> None:
+    # 件はあるのに時刻が1つも取れないのは、上流が形を変えた時の症状である。
+    # ここで黙ってNoneを返すと、
+    # 呼び出し側は「一度も実行していない」とみなして、
+    # 自分の観測だけでアイドルを判定する状態へ静かに退行する。
+    # それは生成の直後に降ろす動作そのものなので、例外にして気付けるようにする。
+    with pytest.raises(ValueError):
+        latest_activity(history("1000"))

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
@@ -49,6 +49,10 @@ BROKEN_QUEUE_RESPONSES: list[object] = [
     # `queue_remaining`が整数ではない。
     {"exec_info": {"queue_remaining": "3"}},
     {"exec_info": {"queue_remaining": None}},
+    # `bool`は`int`の派生なので素の`isinstance`を通ってしまう。
+    # 通すと`0 < True`が成立して常時busy扱いになり、解放が永久に止まる。
+    {"exec_info": {"queue_remaining": True}},
+    {"exec_info": {"queue_remaining": False}},
 ]
 
 
@@ -84,6 +88,9 @@ BROKEN_HISTORY_ENTRIES: list[object] = [
     {"status": {"messages": [["execution_start", {}]]}},
     # `timestamp`が整数ではない。
     {"status": {"messages": [["execution_start", {"timestamp": "1000"}]]}},
+    # `bool`は`int`の派生なので素の`isinstance`を通ってしまう。
+    # 通すと`True`が1ミリ秒の時刻として扱われる。
+    {"status": {"messages": [["execution_start", {"timestamp": True}]]}},
 ]
 
 

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
@@ -36,6 +36,12 @@ def test_queue_remaining_accepts_zero() -> None:
     assert queue_remaining({"exec_info": {"queue_remaining": 0}}) == 0
 
 
+def test_queue_remaining_accepts_float() -> None:
+    # 上流が数値を浮動小数点数で返すようになっても止まらないようにする。
+    # 弾くと`0 <`の比較ができずに毎周回が例外になり、解放が二度と走らない。
+    assert queue_remaining({"exec_info": {"queue_remaining": 3.0}}) == 3
+
+
 # 型を明示しないと、`{}`の要素の型が不明なまま`parametrize`へ渡ることになる。
 BROKEN_QUEUE_RESPONSES: list[object] = [
     # オブジェクトですらない。
@@ -96,6 +102,20 @@ BROKEN_HISTORY_ENTRIES: list[object] = [
 
 @pytest.mark.parametrize("entry", BROKEN_HISTORY_ENTRIES)
 def test_message_timestamps_skips_broken_shape(entry: object) -> None:
+    assert message_timestamps(entry) == []
+
+
+def test_message_timestamps_accepts_float() -> None:
+    # 時刻も同じ。弾くと全件が飛んで`latest_activity`がValueErrorを投げ続ける。
+    # 症状は5分おきのログ1行だけで、防ごうとしていたOOMがそのまま再発する。
+    entry = history(1000.5)["8f0e"]
+    assert message_timestamps(entry) == [1000.5]
+
+
+@pytest.mark.parametrize("timestamp", [float("nan"), float("inf"), float("-inf")])
+def test_message_timestamps_skips_non_finite(timestamp: float) -> None:
+    # 有限でない値は比較も`max`も意味を持たないので受け入れない。
+    entry = history(timestamp)["8f0e"]
     assert message_timestamps(entry) == []
 
 

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_response.py
@@ -1,0 +1,106 @@
+"""`response.py`の解釈のテスト。
+
+正常系より異常系が本体である。
+ComfyUIのAPIには型が無く、
+バージョンが上がって形が変わった時に、
+例外ではなく静かに違う値が返ることを防ぐために書いている。
+"""
+
+import pytest
+from response import latest_activity, message_timestamps, queue_remaining
+
+
+def history(*timestamps: object) -> dict[str, object]:
+    """`/history?max_items=1`の応答を、指定した時刻のメッセージ1件分で組み立てる。"""
+    return {
+        "8f0e": {
+            "prompt": [],
+            "outputs": {},
+            "status": {
+                "status_str": "success",
+                "completed": True,
+                "messages": [
+                    ["execution_start", {"prompt_id": "8f0e", "timestamp": timestamp}]
+                    for timestamp in timestamps
+                ],
+            },
+        }
+    }
+
+
+def test_queue_remaining_reads_exec_info() -> None:
+    assert queue_remaining({"exec_info": {"queue_remaining": 3}}) == 3
+
+
+def test_queue_remaining_accepts_zero() -> None:
+    assert queue_remaining({"exec_info": {"queue_remaining": 0}}) == 0
+
+
+# 型を明示しないと、`{}`の要素の型が不明なまま`parametrize`へ渡ることになる。
+BROKEN_QUEUE_RESPONSES: list[object] = [
+    # オブジェクトですらない。
+    [],
+    # `exec_info`が無い。
+    {},
+    # `exec_info`がオブジェクトではない。
+    {"exec_info": 1},
+    # `queue_remaining`が無い。
+    {"exec_info": {}},
+    # `queue_remaining`が整数ではない。
+    {"exec_info": {"queue_remaining": "3"}},
+    {"exec_info": {"queue_remaining": None}},
+]
+
+
+@pytest.mark.parametrize("parsed", BROKEN_QUEUE_RESPONSES)
+def test_queue_remaining_rejects_broken_shape(parsed: object) -> None:
+    with pytest.raises(ValueError):
+        queue_remaining(parsed)
+
+
+def test_message_timestamps_collects_every_message() -> None:
+    entry = history(1000, 2000)["8f0e"]
+    assert message_timestamps(entry) == [1000, 2000]
+
+
+BROKEN_HISTORY_ENTRIES: list[object] = [
+    # 件がオブジェクトではない。
+    [],
+    # `status`が無い。
+    {},
+    # `status`がオブジェクトではない。
+    {"status": 1},
+    # `messages`が無い。
+    {"status": {}},
+    # `messages`が配列ではない。
+    {"status": {"messages": {}}},
+    # 要素が配列ではない。
+    {"status": {"messages": [1]}},
+    # 要素が1つしかなくデータが無い。
+    {"status": {"messages": [["execution_start"]]}},
+    # データがオブジェクトではない。
+    {"status": {"messages": [["execution_start", 1]]}},
+    # `timestamp`が無い。
+    {"status": {"messages": [["execution_start", {}]]}},
+    # `timestamp`が整数ではない。
+    {"status": {"messages": [["execution_start", {"timestamp": "1000"}]]}},
+]
+
+
+@pytest.mark.parametrize("entry", BROKEN_HISTORY_ENTRIES)
+def test_message_timestamps_skips_broken_shape(entry: object) -> None:
+    assert message_timestamps(entry) == []
+
+
+def test_latest_activity_takes_the_newest_in_seconds() -> None:
+    assert latest_activity(history(1000, 3000, 2000)) == 3.0
+
+
+def test_latest_activity_returns_none_for_empty_history() -> None:
+    # 一度も実行していない状態は異常ではない。
+    assert latest_activity({}) is None
+
+
+def test_latest_activity_rejects_non_object() -> None:
+    with pytest.raises(ValueError):
+        latest_activity([])

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
@@ -62,6 +62,36 @@ def test_missing_history_does_not_move_the_clock() -> None:
     assert should_free is False
 
 
+def test_future_history_is_clamped_to_now() -> None:
+    # 履歴に未来の時刻が1件でも入ると、
+    # 素直に代入したら`now - last_activity`が負のままになり、
+    # しきい値を二度と超えられなくなって解放が永久に止まる。
+    # このプロセスはOllamaのCUDA OOMを防ぐための緩和策なので、
+    # 静かな無効化はGPUを共有する他のサービスへ直接効く。
+    state, should_free = next_state(
+        State(last_activity=0.0, freed=False),
+        now=1000.0,
+        busy=False,
+        latest=99999.0,
+        idle_seconds=IDLE,
+    )
+    assert state.last_activity == 1000.0
+    assert should_free is False
+
+
+def test_future_history_still_clears_freed() -> None:
+    # クランプしても「新しい活動があった」ことは事実なので、
+    # 解放済みのフラグは戻す。
+    state, _ = next_state(
+        State(last_activity=0.0, freed=True),
+        now=1000.0,
+        busy=False,
+        latest=99999.0,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=1000.0, freed=False)
+
+
 def test_already_freed_does_not_request_again() -> None:
     # しきい値を超え続けている間、同じ要求を投げ続けないことを固定する。
     state, should_free = next_state(

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
@@ -1,0 +1,114 @@
+"""`state.py`の遷移のテスト。
+
+実機で確かめられるのは1周回に1本の経路だけで、
+しかも1周回は数分かかる。
+順序と境界はここで固定する。
+"""
+
+from state import State, next_state
+
+# しきい値。テストの中で意味を持つのは大小関係だけなので短くする。
+IDLE = 600.0
+
+
+def test_busy_resets_the_clock() -> None:
+    # 実行中なら、履歴を見るまでもなく現在時刻が最後の活動になる。
+    state, should_free = next_state(
+        State(last_activity=0.0, freed=True),
+        now=1000.0,
+        busy=True,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=1000.0, freed=False)
+    assert should_free is False
+
+
+def test_newer_history_is_picked_up() -> None:
+    # 確認と確認の間に始まって終わった生成を拾い直す経路。
+    # 拾ったら解放済みのフラグも戻す。
+    state, should_free = next_state(
+        State(last_activity=100.0, freed=True),
+        now=1000.0,
+        busy=False,
+        latest=900.0,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=900.0, freed=False)
+    assert should_free is False
+
+
+def test_older_history_does_not_move_the_clock() -> None:
+    state, should_free = next_state(
+        State(last_activity=900.0, freed=True),
+        now=2000.0,
+        busy=False,
+        latest=100.0,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=900.0, freed=True)
+    assert should_free is False
+
+
+def test_missing_history_does_not_move_the_clock() -> None:
+    state, should_free = next_state(
+        State(last_activity=900.0, freed=False),
+        now=1000.0,
+        busy=False,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=900.0, freed=False)
+    assert should_free is False
+
+
+def test_already_freed_does_not_request_again() -> None:
+    # しきい値を超え続けている間、同じ要求を投げ続けないことを固定する。
+    state, should_free = next_state(
+        State(last_activity=0.0, freed=True),
+        now=10000.0,
+        busy=False,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=0.0, freed=True)
+    assert should_free is False
+
+
+def test_below_threshold_waits() -> None:
+    state, should_free = next_state(
+        State(last_activity=1000.0, freed=False),
+        now=1000.0 + IDLE - 1,
+        busy=False,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=1000.0, freed=False)
+    assert should_free is False
+
+
+def test_at_threshold_frees() -> None:
+    # ちょうど到達した周回で解放する。
+    state, should_free = next_state(
+        State(last_activity=1000.0, freed=False),
+        now=1000.0 + IDLE,
+        busy=False,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert state == State(last_activity=1000.0, freed=False)
+    assert should_free is True
+
+
+def test_freed_is_not_set_by_the_transition() -> None:
+    # 解放が成功したかはHTTPの結果次第なので、ここでは立てない。
+    # 立ててしまうと、要求に失敗した周回で次の活動まで再試行できなくなる。
+    state, should_free = next_state(
+        State(last_activity=1000.0, freed=False),
+        now=10000.0,
+        busy=False,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert should_free is True
+    assert state.freed is False

--- a/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
+++ b/nixos/host/bullet/comfyui/idle-free-memory/tests/test_state.py
@@ -24,6 +24,26 @@ def test_busy_resets_the_clock() -> None:
     assert should_free is False
 
 
+def test_busy_ignores_history() -> None:
+    # busyなら履歴は結果に影響しない。
+    # 影響しないものを引かずに済ませられることを、呼び出し側の根拠として固定する。
+    with_history, _ = next_state(
+        State(last_activity=0.0, freed=True),
+        now=1000.0,
+        busy=True,
+        latest=500.0,
+        idle_seconds=IDLE,
+    )
+    without_history, _ = next_state(
+        State(last_activity=0.0, freed=True),
+        now=1000.0,
+        busy=True,
+        latest=None,
+        idle_seconds=IDLE,
+    )
+    assert with_history == without_history
+
+
 def test_newer_history_is_picked_up() -> None:
     # 確認と確認の間に始まって終わった生成を拾い直す経路。
     # 拾ったら解放済みのフラグも戻す。

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -16,6 +16,10 @@
       "extraPaths": ["pkgs/safetensors-fp16", "pkgs/safetensors-fp16/tests"]
     },
     {
+      "root": "nixos/host/bullet/comfyui/idle-free-memory",
+      "extraPaths": ["nixos/host/bullet/comfyui/idle-free-memory"]
+    },
+    {
       "root": "nixos/host/bullet/comfyui/custom-node/tests",
       "extraPaths": [
         "nixos/host/bullet/comfyui/custom-node",


### PR DESCRIPTION
ComfyUIはsmart memoryで実行後も重みをVRAMへ保持し続けます。
同じモデルを連続で使う分には正しい挙動ですが、
使い終わって放置している間も抱えたままになります。
bulletではOllamaが同じGPUを使うので、
抱えられたままだと汎用モデルがCUDAのOOMで載りません。

ComfyUI本体にこれを時間で解く仕組みはありませんでした。
0.33.1の`comfy/cli_args.py`には該当する引数が無く、
`--disable-smart-memory`は実行のたびに降ろす別物です。
上流でも要望が挙がったまま実装されていません。
https://github.com/Comfy-Org/ComfyUI/issues/3192

コンテナごと止める解決は採れません。
ComfyUIはSQLiteへ保存した状態の一部をローカル版では復元できず、
アイドルだからと落とすと利用者が困ります。
`lib/container-socket-activation.nix`がアイドル停止を持たないのもそのためです。
プロセスは生かしたまま、
メモリだけを返させます。

常駐プロセスはコンテナの中で動かします。
ホスト側へ置くと`container@comfyui.service`への依存で寿命を追従させる配線が要りますが、
中に置けばコンテナが消える時に一緒に消えます。
外部由来のコードと同じ空間へ入ることになりますが、
このプロセスが持つ権限はComfyUIのAPIを叩けることだけで、
それは同じ空間にいるComfyUI自身が最初からできることです。

アイドルの判定にはComfyUI自身が記録した時刻を使います。
`/prompt`の`queue_remaining`だけを数分おきに見る形では、
確認と確認の隙間に始まって終わった生成を丸ごと見落とします。
生成の直後に「ずっと空だった」と誤判定して降ろすのが最も困る挙動です。
`/history`の`status.messages`には`add_message`がミリ秒の実時刻を打っているので、
そちらを読めば確認の間隔と無関係に最後の活動が分かります。

接続先はホストとポートだけを環境変数で渡して、
`http://`はPython側で固定します。
組み立て済みのURLを渡すと`urlopen`へ渡るのが変数になり、
`file:`のようなスキームも開ける形としてruffがS310で警告します。
抑制のコメントを置くより、
スキームが1つに定まっていることをソースの上で示す方が正しいです。

bulletの実機で以下を確認しました。

- 生成の直後に6987MiBだったVRAMが、18時12分16秒の確認で1399MiBへ落ちること
- その時刻が最後の活動と確認の周期から事前に予測した時刻と秒まで一致すること
- 解放の要求が繰り返されず、journalにも本体側のログにも1回だけ現れること

close https://github.com/ncaq/dotfiles/issues/1536