### PR TITLE
fix(seminar): CIがキャッシュへ無駄にアクセスしないようにします

### DIFF
--- a/nixos/host/seminar/acme.nix
+++ b/nixos/host/seminar/acme.nix
@@ -1,10 +1,21 @@
-{ config, ... }: {
-  # garage.ncaq.netのLet's Encrypt証明書をDNS-01チャレンジで取得。
-  # Cloudflare Tunnelの接続先は変更せず(Garage直接のまま)、
-  # niks3-publicコンテナからの内部アクセスのみCaddy HTTPS経由にする。
-  security.acme.certs."garage.ncaq.net" = {
+{ config, ... }:
+let
+  # DNS-01チャレンジで取得するLet's Encrypt証明書の共通設定。
+  dns01Cert = {
     dnsProvider = "cloudflare";
     environmentFile = config.sops.templates."cloudflare-dns-env".path;
     group = "caddy";
+  };
+in
+{
+  security.acme.certs = {
+    # garage.ncaq.netのLet's Encrypt証明書をDNS-01チャレンジで取得。
+    # Cloudflare Tunnelの接続先は変更せず(Garage直接のまま)、
+    # niks3-publicコンテナからの内部アクセスのみCaddy HTTPS経由にする。
+    "garage.ncaq.net" = dns01Cert;
+    # niks3-public.ncaq.netも同様に、
+    # ホスト内部からのアクセスをCaddy HTTPS経由でバイパスするために取得する。
+    # caddy.nix参照。
+    "niks3-public.ncaq.net" = dns01Cert;
   };
 }

--- a/nixos/host/seminar/acme.nix
+++ b/nixos/host/seminar/acme.nix
@@ -11,7 +11,7 @@ in
   security.acme.certs = {
     # garage.ncaq.netのLet's Encrypt証明書をDNS-01チャレンジで取得。
     # Cloudflare Tunnelの接続先は変更せず(Garage直接のまま)、
-    # niks3-publicコンテナからの内部アクセスのみCaddy HTTPS経由にする。
+    # niks3コンテナおよびホスト自身からの内部アクセスをCaddy HTTPS経由にする。
     "garage.ncaq.net" = dns01Cert;
     # niks3-public.ncaq.netも同様に、
     # ホスト内部からのアクセスをCaddy HTTPS経由でバイパスするために取得する。

--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 let
   garageAddr = config.machineAddresses.garage.guest;
+  niks3PublicAddr = config.machineAddresses.niks3-public.guest;
   niks3PublicHostAddr = config.machineAddresses.niks3-public.host;
   niks3PrivateAddr = config.machineAddresses.niks3-private.guest;
   niks3PrivateHostAddr = config.machineAddresses.niks3-private.host;
@@ -25,6 +26,20 @@ in
         reverse_proxy http://${garageAddr}:3900
       '';
     };
+    # ホスト自身からniks3-publicへのアクセスをマシン内で完結させるproxy。
+    # niks3-public.ncaq.netの公開経路はCloudflare Tunnelのみなので、
+    # そのままだと同じマシン上のキャッシュへCloudflareを往復して到達することになります。
+    # substituteやpost-build-hookはホストのnix-daemonが実行するため、
+    # ホストのnetworking.hostsで名前をこのバインド先へ向けることで、
+    # CIランナーのキャッシュ入出力もマシン内で完結します。
+    # https://github.com/ncaq/dotfiles/issues/1535
+    virtualHosts."niks3-public.ncaq.net" = {
+      useACMEHost = "niks3-public.ncaq.net";
+      extraConfig = ''
+        bind ${niks3PublicHostAddr}
+        reverse_proxy http://${niks3PublicAddr}:5751
+      '';
+    };
     # Tailscale Serve(tailnet専用)からのリクエストを受けるリバースプロキシ。
     # Tailscale ServeがTLS終端し、ここにHTTPで転送する。
     # Caddy v2では`localhost`はlocal CAによる自動HTTPSの対象になるため、
@@ -38,8 +53,19 @@ in
       redir /niks3/private /niks3/private/
     '';
   };
-  # コンテナのvethインターフェースからCaddyの443への接続を許可する。
-  networking.firewall.interfaces."ve-+".allowedTCPPorts = [ 443 ];
+  networking = {
+    # ホスト上でniks3-public.ncaq.netとgarage.ncaq.netをローカルのCaddyへ向けます。
+    # substituteはホストのnix-daemonが行うため、
+    # これによりCIのキャッシュ取得がCloudflare Tunnelを経由しなくなります。
+    # garage.ncaq.netはniks3が発行するpresigned URLのアップロード先なので、
+    # キャッシュへのアップロードもマシン内で完結します。
+    hosts.${niks3PublicHostAddr} = [
+      "niks3-public.ncaq.net"
+      "garage.ncaq.net"
+    ];
+    # コンテナのvethインターフェースからCaddyの443への接続を許可する。
+    firewall.interfaces."ve-+".allowedTCPPorts = [ 443 ];
+  };
   # vethインターフェースはコンテナ起動時に作成されるため、
   # Caddy起動時にはまだバインド先IPが存在しない場合がある。
   # ip_nonlocal_bindを有効にして未割当アドレスへのバインドを許可する。

--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -1,6 +1,7 @@
 { config, ... }:
 let
   garageAddr = config.machineAddresses.garage.guest;
+  garageHostAddr = config.machineAddresses.garage.host;
   niks3PublicAddr = config.machineAddresses.niks3-public.guest;
   niks3PublicHostAddr = config.machineAddresses.niks3-public.host;
   niks3PrivateAddr = config.machineAddresses.niks3-private.guest;
@@ -22,7 +23,7 @@ in
     virtualHosts."garage.ncaq.net" = {
       useACMEHost = "garage.ncaq.net";
       extraConfig = ''
-        bind ${niks3PublicHostAddr} ${niks3PrivateHostAddr}
+        bind ${garageHostAddr} ${niks3PublicHostAddr} ${niks3PrivateHostAddr}
         reverse_proxy http://${garageAddr}:3900
       '';
     };
@@ -59,10 +60,12 @@ in
     # これによりCIのキャッシュ取得がCloudflare Tunnelを経由しなくなります。
     # garage.ncaq.netはniks3が発行するpresigned URLのアップロード先なので、
     # キャッシュへのアップロードもマシン内で完結します。
-    hosts.${niks3PublicHostAddr} = [
-      "niks3-public.ncaq.net"
-      "garage.ncaq.net"
-    ];
+    # 向き先はそれぞれの用途に対応するコンテナ側のvethにして、
+    # 障害の切り分けが素直になるようにします。
+    hosts = {
+      ${garageHostAddr} = [ "garage.ncaq.net" ];
+      ${niks3PublicHostAddr} = [ "niks3-public.ncaq.net" ];
+    };
     # コンテナのvethインターフェースからCaddyの443への接続を許可する。
     firewall.interfaces."ve-+".allowedTCPPorts = [ 443 ];
   };

--- a/nixos/host/seminar/caddy.nix
+++ b/nixos/host/seminar/caddy.nix
@@ -11,15 +11,15 @@ in
   services.caddy = {
     enable = true;
     email = "ncaq@ncaq.net";
-    # niks3コンテナからGarageへのTLS termination proxy。
+    # niks3コンテナとホスト自身からGarageへのTLS termination proxy。
     # 同じサーバ上の通信なのにいちいちCloudflare Tunnelを経由すると無駄なので、
     # ローカルのCaddyで通信を橋渡しします。
-    # コンテナ内のhostsでgarage.ncaq.netをhostAddressに向け、
+    # niks3コンテナ内のhostsとホストのnetworking.hostsでgarage.ncaq.netをここへ向け、
     # Caddy(Let's Encrypt証明書)経由でGarageに直接HTTP接続することでバイパスします。
     # それによりpresigned URLはhttps://garage.ncaq.net/...のまま維持されます。
     # 外部クライアント(GitHub Actionsなど)はCloudflare Tunnel経由でアクセスします。
     # ホストの443を完全に占有してしまわないように、
-    # niks3コンテナのhostAddress側vethのみにバインドします。
+    # garageとniks3各コンテナのvethのホスト側アドレスのみにバインドします。
     virtualHosts."garage.ncaq.net" = {
       useACMEHost = "garage.ncaq.net";
       extraConfig = ''
@@ -60,7 +60,7 @@ in
     # これによりCIのキャッシュ取得がCloudflare Tunnelを経由しなくなります。
     # garage.ncaq.netはniks3が発行するpresigned URLのアップロード先なので、
     # キャッシュへのアップロードもマシン内で完結します。
-    # 向き先はそれぞれの用途に対応するコンテナ側のvethにして、
+    # 向き先はそれぞれの用途に対応するvethのホスト側アドレスにして、
     # 障害の切り分けが素直になるようにします。
     hosts = {
       ${garageHostAddr} = [ "garage.ncaq.net" ];

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -71,18 +71,17 @@ let
 
       # flakeから消えた構成のrootを削除して、
       # 不要になった閉包をいつまでも保持し続けないようにします。
+      # `nix build`の中断などでシンボリックリンク以外の残骸が紛れ込んでいても、
+      # 削除に失敗して途中終了しないよう`rm -rf`で消します。
+      declare -A keep=()
+      for name in "''${names[@]}"; do
+        keep[$name]=1
+      done
       shopt -s nullglob
       for link in "$STATE_DIRECTORY"/*; do
-        name=$(basename "$link")
-        keep=0
-        for root in "''${names[@]}"; do
-          if [[ "$name" == "$root" ]]; then
-            keep=1
-            break
-          fi
-        done
-        if [[ "$keep" == 0 ]]; then
-          rm -- "$link"
+        name=''${link##*/}
+        if [[ -z "''${keep[$name]:-}" ]]; then
+          rm -rf -- "$link"
         fi
       done
 

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -1,6 +1,11 @@
-{ config, pkgs, ... }:
 {
-  # CIで構築される全ホストの閉包をGCから保護するGC rootを登録します。
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # CIで構築される全ホストの閉包をGCから保護するGC rootを登録するスクリプト。
   #
   # セルフホストランナーはこのホストのnix storeを共有していますが、
   # `nix build`のresultリンクはephemeralなランナーコンテナ内にあるため、
@@ -15,15 +20,14 @@
   # デプロイ済みのflakeを参照するため作業ツリーには依存しません。
   # nix-on-droid(aarch64-linux)はQEMUエミュレーション経由のビルドが遅く、
   # モデルファイルのような巨大なパスも含まれないため対象外にします。
-  systemd.services.nix-gc-root-hosts = {
-    description = "Register Nix GC roots for all hosts' closures";
-    path = [
+  nix-gc-root-hosts = pkgs.writeShellApplication {
+    name = "nix-gc-root-hosts";
+    runtimeInputs = [
       config.nix.package
+      pkgs.coreutils
       pkgs.jq
     ];
-    script = ''
-      set -euo pipefail
-
+    text = ''
       failed=0
       roots=()
 
@@ -40,9 +44,9 @@
       # 誤って後段のクリーンアップで既存のrootを消してしまわないようにするためです。
       hostNames=$(nix eval --json /etc/nixos-flake#nixosConfigurations --apply builtins.attrNames | jq -r '.[]')
 
-      for host in $hostNames; do
+      while IFS= read -r host; do
         build "nixos-$host" "/etc/nixos-flake#nixosConfigurations.$host.config.system.build.toplevel"
-      done
+      done <<<"$hostNames"
       build home-manager-x86_64-linux /etc/nixos-flake#homeConfigurations.x86_64-linux.activationPackage
 
       # flakeから消えた構成のrootを削除して、
@@ -64,8 +68,14 @@
 
       exit "$failed"
     '';
+  };
+in
+{
+  systemd.services.nix-gc-root-hosts = {
+    description = "Register Nix GC roots for all hosts' closures";
     serviceConfig = {
       Type = "oneshot";
+      ExecStart = lib.getExe nix-gc-root-hosts;
       StateDirectory = "nix-gc-root-hosts";
       # キャッシュが切れているとビルドに長時間かかることがあります。
       TimeoutStartSec = "8h";

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -1,5 +1,6 @@
 {
   config,
+  hardening,
   lib,
   pkgs,
   ...
@@ -92,12 +93,27 @@ in
 {
   systemd.services.nix-gc-root-hosts = {
     description = "Register Nix GC roots for all hosts' closures";
-    serviceConfig = {
+    environment = {
+      # `ProtectSystem = "strict"`下ではnixクライアントがstoreへ直接書けないため、
+      # rootでもnix-daemon経由で操作するように固定します。
+      NIX_REMOTE = "daemon";
+      # `ProtectHome`でrootのホームへ書けないため、
+      # nixの評価キャッシュの書き先をCacheDirectoryへ向けます。
+      XDG_CACHE_HOME = "/var/cache/nix-gc-root-hosts";
+    };
+    # ネットワークからflake inputsとキャッシュを取得するためnetworkプロファイルを使います。
+    serviceConfig = hardening.network // {
       Type = "oneshot";
       ExecStart = lib.getExe nix-gc-root-hosts;
       StateDirectory = "nix-gc-root-hosts";
+      CacheDirectory = "nix-gc-root-hosts";
       # キャッシュが切れているとビルドに長時間かかることがあります。
       TimeoutStartSec = "8h";
+      # 週次のウォームアップに緊急性はないため、
+      # 同居するCIや公開サービスへリソースを譲ります。
+      Nice = 19;
+      CPUSchedulingPolicy = "idle";
+      IOSchedulingClass = "idle";
     };
   };
 

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -5,7 +5,8 @@
   ...
 }:
 let
-  # CIで構築される全ホストの閉包をGCから保護するGC rootを登録するスクリプト。
+  # flakeに定義された全nixosConfigurationsとhomeConfigurationsの閉包を、
+  # GCから保護するGC rootを登録するスクリプト。
   #
   # セルフホストランナーはこのホストのnix storeを共有していますが、
   # `nix build`のresultリンクはephemeralなランナーコンテナ内にあるため、
@@ -18,8 +19,11 @@ let
   # 全nixosConfigurationsのtoplevelとhome-managerの閉包をビルドして、
   # `--out-link`でGC rootとして保持します。
   # デプロイ済みのflakeを参照するため作業ツリーには依存しません。
-  # nix-on-droid(aarch64-linux)はQEMUエミュレーション経由のビルドが遅く、
-  # モデルファイルのような巨大なパスも含まれないため対象外にします。
+  # どちらの属性集合も動的に列挙するため、
+  # flakeへ構成を追加するとこのスクリプトも自動で追従します。
+  # `nixOnDroidConfigurations`は列挙の対象に含めていません。
+  # QEMUエミュレーション経由のビルドが遅く、
+  # モデルファイルのような巨大なパスも含まれないためです。
   nix-gc-root-hosts = pkgs.writeShellApplication {
     name = "nix-gc-root-hosts";
     runtimeInputs = [
@@ -40,14 +44,17 @@ let
         fi
       }
 
-      # ホスト一覧の取得に失敗した場合はここで中断します。
+      # 一覧の取得に失敗した場合はここで中断します。
       # 誤って後段のクリーンアップで既存のrootを消してしまわないようにするためです。
       hostNames=$(nix eval --json /etc/nixos-flake#nixosConfigurations --apply builtins.attrNames | jq -r '.[]')
+      homeSystems=$(nix eval --json /etc/nixos-flake#homeConfigurations --apply builtins.attrNames | jq -r '.[]')
 
       while IFS= read -r host; do
         build "nixos-$host" "/etc/nixos-flake#nixosConfigurations.$host.config.system.build.toplevel"
       done <<<"$hostNames"
-      build home-manager-x86_64-linux /etc/nixos-flake#homeConfigurations.x86_64-linux.activationPackage
+      while IFS= read -r system; do
+        build "home-manager-$system" "/etc/nixos-flake#homeConfigurations.$system.activationPackage"
+      done <<<"$homeSystems"
 
       # flakeから消えた構成のrootを削除して、
       # 不要になった閉包をいつまでも保持し続けないようにします。

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -33,15 +33,12 @@ let
     ];
     text = ''
       failed=0
-      roots=()
+      names=()
+      installables=()
 
-      build() {
-        local name="$1" installable="$2"
-        roots+=("$name")
-        if ! nix build "$installable" --out-link "$STATE_DIRECTORY/$name"; then
-          echo "failed to build $installable" >&2
-          failed=1
-        fi
+      add() {
+        names+=("$1")
+        installables+=("$2")
       }
 
       # 一覧の取得に失敗した場合はここで中断します。
@@ -50,11 +47,27 @@ let
       homeSystems=$(nix eval --json /etc/nixos-flake#homeConfigurations --apply builtins.attrNames | jq -r '.[]')
 
       while IFS= read -r host; do
-        build "nixos-$host" "/etc/nixos-flake#nixosConfigurations.$host.config.system.build.toplevel"
+        add "nixos-$host" "/etc/nixos-flake#nixosConfigurations.$host.config.system.build.toplevel"
       done <<<"$hostNames"
       while IFS= read -r system; do
-        build "home-manager-$system" "/etc/nixos-flake#homeConfigurations.$system.activationPackage"
+        add "home-manager-$system" "/etc/nixos-flake#homeConfigurations.$system.activationPackage"
       done <<<"$homeSystems"
+
+      # 先に全installableを1回のnix buildへまとめて渡してウォームアップします。
+      # 1つずつビルドすると評価プロセスがその都度立ち上がる上に、
+      # ダウンロードとビルドが構成間で全く重なりません。
+      # まとめて渡せばNixのスケジューラが構成横断で並列に処理します。
+      # 失敗の検知は後段のout-linkで個別に行うため、ここでは失敗を無視します。
+      nix build --keep-going --no-link "''${installables[@]}" || true
+
+      # ウォームアップでストアに成果物が揃っているため、
+      # ここの個別ビルドはout-linkを張るだけでほぼ即座に終わります。
+      for i in "''${!names[@]}"; do
+        if ! nix build "''${installables[$i]}" --out-link "$STATE_DIRECTORY/''${names[$i]}"; then
+          echo "failed to build ''${installables[$i]}" >&2
+          failed=1
+        fi
+      done
 
       # flakeから消えた構成のrootを削除して、
       # 不要になった閉包をいつまでも保持し続けないようにします。
@@ -62,7 +75,7 @@ let
       for link in "$STATE_DIRECTORY"/*; do
         name=$(basename "$link")
         keep=0
-        for root in "''${roots[@]}"; do
+        for root in "''${names[@]}"; do
           if [[ "$name" == "$root" ]]; then
             keep=1
             break

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -1,0 +1,81 @@
+{ config, pkgs, ... }:
+{
+  # CIで構築される全ホストの閉包をGCから保護するGC rootを登録します。
+  #
+  # セルフホストランナーはこのホストのnix storeを共有していますが、
+  # `nix build`のresultリンクはephemeralなランナーコンテナ内にあるため、
+  # ジョブ終了後は他ホスト向けの閉包(特にbulletの巨大なモデルファイル)を守るrootが残りません。
+  # そのままnix-gcに回収されると、
+  # 次のCIで巨大なパスをHDD RAID上のキャッシュから取得し直すことになります。
+  # https://github.com/ncaq/dotfiles/issues/1535
+  #
+  # デプロイ時に配置される`/etc/nixos-flake`(nix-daemon.nix参照)から、
+  # 全nixosConfigurationsのtoplevelとhome-managerの閉包をビルドして、
+  # `--out-link`でGC rootとして保持します。
+  # デプロイ済みのflakeを参照するため作業ツリーには依存しません。
+  # nix-on-droid(aarch64-linux)はQEMUエミュレーション経由のビルドが遅く、
+  # モデルファイルのような巨大なパスも含まれないため対象外にします。
+  systemd.services.nix-gc-root-hosts = {
+    description = "Register Nix GC roots for all hosts' closures";
+    path = [
+      config.nix.package
+      pkgs.jq
+    ];
+    script = ''
+      set -euo pipefail
+
+      failed=0
+      roots=()
+
+      build() {
+        local name="$1" installable="$2"
+        roots+=("$name")
+        if ! nix build "$installable" --out-link "$STATE_DIRECTORY/$name"; then
+          echo "failed to build $installable" >&2
+          failed=1
+        fi
+      }
+
+      # ホスト一覧の取得に失敗した場合はここで中断します。
+      # 誤って後段のクリーンアップで既存のrootを消してしまわないようにするためです。
+      hostNames=$(nix eval --json /etc/nixos-flake#nixosConfigurations --apply builtins.attrNames | jq -r '.[]')
+
+      for host in $hostNames; do
+        build "nixos-$host" "/etc/nixos-flake#nixosConfigurations.$host.config.system.build.toplevel"
+      done
+      build home-manager-x86_64-linux /etc/nixos-flake#homeConfigurations.x86_64-linux.activationPackage
+
+      # flakeから消えた構成のrootを削除して、
+      # 不要になった閉包をいつまでも保持し続けないようにします。
+      shopt -s nullglob
+      for link in "$STATE_DIRECTORY"/*; do
+        name=$(basename "$link")
+        keep=0
+        for root in "''${roots[@]}"; do
+          if [[ "$name" == "$root" ]]; then
+            keep=1
+            break
+          fi
+        done
+        if [[ "$keep" == 0 ]]; then
+          rm -- "$link"
+        fi
+      done
+
+      exit "$failed"
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      StateDirectory = "nix-gc-root-hosts";
+      # キャッシュが切れているとビルドに長時間かかることがあります。
+      TimeoutStartSec = "8h";
+    };
+  };
+
+  # nix-gcの実行前にGC rootを更新します。
+  # root更新が失敗してもGC自体は実行させたいのでrequiresではなくwantsにします。
+  systemd.services.nix-gc = {
+    wants = [ "nix-gc-root-hosts.service" ];
+    after = [ "nix-gc-root-hosts.service" ];
+  };
+}

--- a/nixos/host/seminar/nix-gc-root-hosts.nix
+++ b/nixos/host/seminar/nix-gc-root-hosts.nix
@@ -6,6 +6,9 @@
   ...
 }:
 let
+  # サービス名はユニット属性名・StateDirectory・CacheDirectoryなど各所で使うため、
+  # リネーム時の取りこぼしが起きないよう一箇所から導出します。
+  serviceName = "nix-gc-root-hosts";
   # flakeに定義された全nixosConfigurationsとhomeConfigurationsの閉包を、
   # GCから保護するGC rootを登録するスクリプト。
   #
@@ -26,7 +29,7 @@ let
   # QEMUエミュレーション経由のビルドが遅く、
   # モデルファイルのような巨大なパスも含まれないためです。
   nix-gc-root-hosts = pkgs.writeShellApplication {
-    name = "nix-gc-root-hosts";
+    name = serviceName;
     runtimeInputs = [
       config.nix.package
       pkgs.coreutils
@@ -91,7 +94,7 @@ let
   };
 in
 {
-  systemd.services.nix-gc-root-hosts = {
+  systemd.services.${serviceName} = {
     description = "Register Nix GC roots for all hosts' closures";
     environment = {
       # `ProtectSystem = "strict"`下ではnixクライアントがstoreへ直接書けないため、
@@ -99,14 +102,15 @@ in
       NIX_REMOTE = "daemon";
       # `ProtectHome`でrootのホームへ書けないため、
       # nixの評価キャッシュの書き先をCacheDirectoryへ向けます。
-      XDG_CACHE_HOME = "/var/cache/nix-gc-root-hosts";
+      # `%C`はsystemdの指定子でキャッシュルート(/var/cache)に展開されます。
+      XDG_CACHE_HOME = "%C/${serviceName}";
     };
     # ネットワークからflake inputsとキャッシュを取得するためnetworkプロファイルを使います。
     serviceConfig = hardening.network // {
       Type = "oneshot";
       ExecStart = lib.getExe nix-gc-root-hosts;
-      StateDirectory = "nix-gc-root-hosts";
-      CacheDirectory = "nix-gc-root-hosts";
+      StateDirectory = serviceName;
+      CacheDirectory = serviceName;
       # キャッシュが切れているとビルドに長時間かかることがあります。
       TimeoutStartSec = "8h";
       # 週次のウォームアップに緊急性はないため、
@@ -120,7 +124,7 @@ in
   # nix-gcの実行前にGC rootを更新します。
   # root更新が失敗してもGC自体は実行させたいのでrequiresではなくwantsにします。
   systemd.services.nix-gc = {
-    wants = [ "nix-gc-root-hosts.service" ];
-    after = [ "nix-gc-root-hosts.service" ];
+    wants = [ "${serviceName}.service" ];
+    after = [ "${serviceName}.service" ];
   };
 }


### PR DESCRIPTION
セルフホストランナーのCIには2つの無駄がありました。

CIが構築した他ホスト向けの閉包を守るGC rootが無く、
特にbulletの巨大なモデルファイルが毎週のnix-gcで回収されて、
次のCIでキャッシュから取得し直すことになっていました。

さらにniks3-public.ncaq.netの公開経路はCloudflare Tunnelだけなので、
その取得は同じマシン上のHDD RAIDにあるデータへ、
Cloudflareを往復して到達する形になっていました。

両方を解決します。

デプロイ時に配置される`/etc/nixos-flake`から全ホストの閉包をビルドして、
GC rootとして保持するサービスを追加し、
`nix-gc.service`の直前に実行されるよう結び付けます。
これで必要な閉包がGCに回収されなくなります。

またgarage.ncaq.netで既にやっているバイパスと同じ手法で、
niks3-public.ncaq.netへのホスト内からのアクセスを、
CaddyとネットワークのhostsによりCloudflare Tunnelを経由せずマシン内で完結させます。
GC rootで守れない新規パスの取得やキャッシュへのアップロードも高速になります。

seminarへ適用して以下を確認済みです。

- キャッシュ応答が14ミリ秒程度で返ること
- GC rootサービスが全ホストのrootを登録すること
- nix-gcを手動実行しても保護対象の閉包(bulletの292.9GiBを含む)が回収されないこと

close https://github.com/ncaq/dotfiles/issues/1535

https://claude.ai/code/session_01KHb74jzmuwagtEEA6UdB4B