### PR TITLE
feat(ollama): RAGの埋め込みをOllamaエンジンへ移します

### DIFF
--- a/lib/ollama-model-names.nix
+++ b/lib/ollama-model-names.nix
@@ -1,7 +1,7 @@
 /**
   アクセラレータごとに、役割から実際のモデル名を引く表。
 
-  型: { cuda = { general, freedom }; cpu = { general, freedom }; }
+  型: { cuda = { general, freedom }; cpu = { general, freedom }; embedding; }
 
   NixOSモジュールからはこのファイルを直接importせず、
   `nixos/ollama/model.nix`がここから設定する`local.ollama.models`を参照すること。
@@ -75,4 +75,15 @@
     # ディスクとロード時間を消費するだけになる。
     freedom = [ ];
   };
+  # RAGの埋め込みに使うモデル。
+  # アクセラレータ別にしない理由は`nixos/ollama/option.nix`のオプションの説明にある。
+  #
+  # モデルの選定はblue-promptのKnowledge 10011チャンクと20問での実測に基づく。
+  # multilingual-e5-largeはtop3命中率0.70/MRR 0.605で、
+  # sentence-transformersのfp32とGGUFのq8_0で精度は変わらない。
+  # 量子化をq8_0にするのは、f16との精度差が無い一方で、
+  # 帯域で頭打ちになる6コアのseminarではq8_0の方が速いため。
+  # bge-m3などへの乗り換えの検討はblue-prompt#196で継続している。
+  # ref https://github.com/ncaq/blue-prompt/issues/171
+  embedding = [ "multilingual-e5-large:q8_0" ];
 }

--- a/nixos/host/seminar/open-webui/environment.nix
+++ b/nixos/host/seminar/open-webui/environment.nix
@@ -10,7 +10,7 @@
 # それは`blue-prompt.nix`のようにコンテナへ追従する同期の側の仕事になる。
 # 環境変数で書けるものをここで押さえておけば、
 # 状態を持つ同期に頼る範囲をその分だけ狭められる。
-{ config, ... }:
+{ lib, config, ... }:
 {
   local.openWebui.environment = {
     # nixpkgsのモジュールが`http://localhost:8080`を渡すため、
@@ -116,39 +116,53 @@
     # 新しい版が出ていると知らされても通知から動けることはない。
     #
     # 同じ効果は`OFFLINE_MODE`でも得られるが、そちらは使わない。
-    # あちらは`HF_HUB_OFFLINE`も立てるため、
-    # 後述の埋め込みモデルをHugging Faceから取得できなくなる。
+    # あちらは`HF_HUB_OFFLINE`も立てる。
+    # 埋め込みをOllamaへ移した今のコンテナはHugging Faceから何も取得しないが、
+    # コンテナ内で推論する設定へ戻した時に離れた場所で壊れて原因を探すことになるので、
+    # 止めたい挙動だけを狙えるこちらを使い続ける。
     ENABLE_VERSION_UPDATE_CHECK = "False";
+
+    # 埋め込みはコンテナ内のsentence-transformersではなくOllamaで行う。
+    #
+    # 接続先の`RAG_OLLAMA_BASE_URL`は未指定なら`OLLAMA_BASE_URL`を使うので、
+    # チャットと同じCaddyのフェイルオーバー(bullet優先、seminarへ退避)をそのまま通る。
+    # モデルはGGUFに`num_gpu 0`を焼き込んで登録しているため、
+    # bulletで受けてもGPUには載らず、デスクトップ用途とVRAMを取り合わない。
+    #
+    # 同じモデルならエンジンを変えても検索精度は変わらないことと、
+    # GGUFのCPU推論がtorchのfp32よりbulletで約2.5倍、seminarでも約1.8倍速いことは、
+    # blue-promptのKnowledge 10011チャンクと20問の実測で確認した。
+    # ref https://github.com/ncaq/blue-prompt/issues/171
+    RAG_EMBEDDING_ENGINE = "ollama";
 
     # 既定の`sentence-transformers/all-MiniLM-L6-v2`は英語専用の小型モデルで、
     # `blue-prompt.nix`が登録する日本語のKnowledgeをほとんど引けない。
+    # 上記の実測ではmultilingual-e5-largeがtop3命中率0.70/MRR 0.605で、
+    # 測った中のMRR首位はbge-m3の0.640だった。
+    # 差は20問では統計的に語れないため、
+    # 実測済みで現行と埋め込みが変わらないe5-largeを維持して、
+    # モデルの乗り換えはblue-prompt#196の決着に任せる。
     #
-    # 実際のKnowledgeの134ファイルを`CHUNK_SIZE`と`CHUNK_OVERLAP`の既定値で分割し、
-    # 日本語の質問を10問引かせて比較した結果は以下の通りだった。
-    # 並べたのは`RAG_TOP_K`の既定値である上位3件に正解が入った問題数とMRRである。
-    #
-    # - all-MiniLM-L6-v2: 5問, 0.314
-    # - multilingual-e5-small: 8問, 0.670
-    # - ruri-v3-70m: 8問, 0.768
-    # - multilingual-e5-large: 9問, 0.764
-    # - ruri-v3-310m: 9問, 0.858
-    #
-    # 日本語特化のruri-v3-310mが最も強いが、
-    # 他の言語の文書を入れる可能性と利用実績の多さを取ってe5-largeにする。
-    # 本格的な選定は別途行う。
-    RAG_EMBEDDING_MODEL = "intfloat/multilingual-e5-large";
+    # 名前の実体は`lib/ollama-model-names.nix`にあり、
+    # GGUFの登録は`nixos/ollama/model.nix`が行う。
+    RAG_EMBEDDING_MODEL = lib.head config.local.ollama.models.embedding;
 
     # e5系はクエリと文書を別のprefixで区別する前提で学習されている。
     # 付けないと質問と文書が同じ空間の同じ扱いになり、
     # 短い質問から長い文書を引く非対称な検索の精度が落ちる。
+    #
+    # Ollamaエンジンではprefixは本文の先頭へ文字列として連結される。
+    # `RAG_EMBEDDING_PREFIX_FIELD_NAME`は設定してはいけない。
+    # 設定するとprefixがリクエストJSONの別フィールドへ移るが、
+    # Ollamaの`/api/embed`に受け皿が無く未知フィールドとして黙って捨てられるため、
+    # prefixがどこにも付かないままエラーにもならない。
     RAG_EMBEDDING_QUERY_PREFIX = "query: ";
     RAG_EMBEDDING_CONTENT_PREFIX = "passage: ";
 
     # 既定値は1で、chunkを1件ずつ埋め込む。
-    # Knowledgeの取り込みはchunkの数だけモデルの呼び出しを繰り返すため、
-    # 行列演算をまとめられない分がそのまま待ち時間になる。
-    # コンテナのメモリ上限に対してe5-largeの重みは小さく、
-    # この程度のバッチなら同時に載せても余裕がある。
+    # Knowledgeの取り込みはchunkの数だけ呼び出しを繰り返すため、
+    # Ollamaエンジンでは1回の`/api/embed`へまとめて渡す件数がこれになる。
+    # バッチにできない分がそのまま往復と起動の待ち時間になる。
     RAG_EMBEDDING_BATCH_SIZE = "32";
 
     # ノートやカレンダーなどの組み込みツールを既定で渡さない。

--- a/nixos/ollama/model.nix
+++ b/nixos/ollama/model.nix
@@ -42,171 +42,204 @@ let
   # home-managerの設定もこれを読むため、実体は`lib/`に置いている。
   # 理由はそのファイルの先頭に書いてある。
   modelNames = import ../../lib/ollama-model-names.nix;
-  ggufModels = lib.optionalAttrs enableCuda {
-    # registryに無い量子化でQwen3.8-27Bを使うための自前ビルド。
-    # MTPのドラフトヘッドはQwen3.8の公式の重みに元から入っており、
-    # 対応したllama.cppで変換すれば`qwen35.nextn_predict_layers=1`として、
-    # 本体と同じGGUFの中に15テンソル約451MBで残る。
-    # Jackrongのリポジトリはそれを捨てずに量子化したもので、
-    # 素のQwen3.8に対する改変は入っていない。
-    #
-    # 供給元がOllama公式のregistryから個人のリポジトリへ移るため、
-    # 登録した結果が公式のQwen3.8-27Bと噛み合うことを一度確認した。
-    # `ollama show`が返す値は`Qwen/Qwen3.8-27B`の`config.json`と以下の通り一致する。
-    #
-    # - context lengthの262144が`max_position_embeddings`
-    # - embedding lengthの5120が`text_config.hidden_size`
-    # - 投影器のembedding lengthの1152が`vision_config.hidden_size`
-    # - 投影器のdimensionsの5120が`vision_config.out_hidden_size`
-    #
-    # capabilitiesにもtoolsとthinkingとvisionが揃い、
-    # 投影器はregistry版と同じclipの460.73Mパラメータとして認識される。
-    # `rev`と`hash`で固定しているので、
-    # 配布元が後から差し替えた場合はビルドが壊れて気付ける。
-    #
-    # unslothも同じ量子化を配っているが、
-    # あちらはMTPのドラフトヘッドを`MTP/mtp-*.gguf`として別ファイルに切り出している。
-    # 本体と一緒に`FROM`へ並べると`ollama create`は取り込みこそするものの、
-    # マニフェストに`model`のレイヤーが2つ並ぶ形になり、
-    # ollamaは最後の`model`レイヤーを本体だと解釈する。
-    # bulletではドラフトヘッドが後ろに来て、
-    # 1.28GiBのドラフトを本体としてロードしたllama-serverがsegmentation faultで落ちた。
-    # レイヤーの並びは`FROM`の順番では制御できず、
-    # Modelfileにドラフトを指定する構文も無いため、
-    # 別ファイルのドラフトヘッドは使えない。
-    #
-    # visionはregistry版がマニフェストの別レイヤーとして同梱しているだけなので、
-    # 本体のGGUFを取るだけでは付いてこず、clipの投影器を自分で足す必要がある。
-    # 投影器はunslothのF16を使う。
-    # registry版の投影器も888MiBでF16相当であり、
-    # Jackrongが置いているF32は1.72GiBと倍を占める割に得るものが無い。
-    #
-    # チャットテンプレートはそのままではコーディングエージェントからの入力を弾くので、
-    # `qwen3.8-chat-template.patch`を当てて緩和したものを登録する。
-    # 弾かれる入力と緩和の内容はそのパッチファイルの先頭に書いてある。
-    "qwen3.8-27b-mtp:q6_k" = {
-      sources = [
-        (patchGgufChatTemplate {
-          gguf = fetchHuggingFace {
-            owner = "Jackrong";
-            repo = "Qwen3.8-27B-MTP-GGUF";
-            rev = "422451108d80df4a55ebd66c3416af42a0ce0b0c";
-            file = "Qwen3.8-27B-MTP-Q6_K.gguf";
-            hash = "sha256-0PqUrycPPeQmll8fn29hQKrp9arZuIu0ZkUkknSNUm4=";
-          };
-          patch = ./qwen3.8-chat-template.patch;
-        })
-        (fetchHuggingFace {
-          owner = "unsloth";
-          repo = "Qwen3.8-27B-GGUF";
-          rev = "4ca720788d1e01f1bff70c033e0d0028fd02e502";
-          file = "mmproj-F16.gguf";
-          hash = "sha256-y7hBqe4GNrLsFy9buN8uqN/rAekP58YSZYHWYqC05D4=";
-        })
-      ];
-      parameters = qwenParameters;
-    };
-    # Qwen3.8-27Bをheretic(ARA: Arbitrary-Rank Ablation)で拒否挙動だけ除去したもの。
-    # 単一の拒否方向を引き算する従来のabliterationと違い重み行列を直接最適化するため、
-    # 配布元の計測ではKL divergenceが基のQwen3.8-27Bに対して0.0085と小さく、
-    # 拒否率は99/100から0-1/100まで落ちている。
-    # 素の知能を保ったまま規制だけ外れるので、
-    # 創作用に別途finetuneされたモデルとは性格が違い、
-    # 汎用の受け答えの延長で自由度が欲しい場合に効く。
-    # mtp版を選ぶのは汎用モデルと同じ理由で、
-    # MTPのドラフトヘッドを埋め込んだGGUFはGPUの投機的デコーディングで速度が上がる。
-    # `-multilingual`は配布元が新規のダウンロードに推奨している校正の系統で、
-    # importance matrixが20以上の言語とコードと推論とツール利用の構造を含む。
-    # 英語だけに低ビットの精度予算を寄せないので日本語で使うならこちらになる。
-    # 量子化はq6_kまで上げる。
-    # 配布元のREADMEは24GBのGPUではq6_kを「too tight」としているが、
-    # あれは32GBのGPUを前提にしていない表である。
-    # bulletでの実測(KVキャッシュq8_0, context 131072)では、
-    # q6_kが28.6GiBで100%GPUに載って109.8トークン/秒、
-    # VRAMの空きも2.7GiB残る。
-    # 一段上のq8_0は本体だけで26.63GiBあり、
-    # このcontextでは10GiB近いKVキャッシュと計算バッファを載せる余地が無い。
-    # revを2aff31aから進めたのは配布元がテンプレートを修復したためで、
-    # 古いGGUFはOllamaに`does not support thinking`と拒否されて、
-    # Qwen3.8の思考を使えていなかった。
-    # 言語モデル本体だけではvisionが付かないので、
-    # clipの投影器であるmmprojも一緒に渡す。
-    # 投影器は`ggml-org/Qwen3.8-27B-GGUF`にある公式のものと同一で、
-    # ARAは言語モデル側の層しか触っていないため素の投影器がそのまま噛み合う。
-    #
-    # チャットテンプレートは汎用モデルのものとバイト単位で同一なので、
-    # 同じ`qwen3.8-chat-template.patch`を当てる。
-    # ARAは重みしか触っておらずテンプレートは素のQwen3.8のままだからである。
-    # 今の呼び出し側であるOpen WebUIが弾かれる形を送っているわけではないが、
-    # reasoning effortを明示する経路があれば同じ500に当たる。
-    # 片方だけ緩和されている状態は、
-    # 役割を入れ替えた時に理由の分からない失敗として現れる。
-    "qwen3.8-27b-heretic-rvn:q6_k" = {
-      sources = [
-        (patchGgufChatTemplate {
-          gguf = fetchHuggingFace {
+  ggufModels =
+    lib.optionalAttrs enableCuda {
+      # registryに無い量子化でQwen3.8-27Bを使うための自前ビルド。
+      # MTPのドラフトヘッドはQwen3.8の公式の重みに元から入っており、
+      # 対応したllama.cppで変換すれば`qwen35.nextn_predict_layers=1`として、
+      # 本体と同じGGUFの中に15テンソル約451MBで残る。
+      # Jackrongのリポジトリはそれを捨てずに量子化したもので、
+      # 素のQwen3.8に対する改変は入っていない。
+      #
+      # 供給元がOllama公式のregistryから個人のリポジトリへ移るため、
+      # 登録した結果が公式のQwen3.8-27Bと噛み合うことを一度確認した。
+      # `ollama show`が返す値は`Qwen/Qwen3.8-27B`の`config.json`と以下の通り一致する。
+      #
+      # - context lengthの262144が`max_position_embeddings`
+      # - embedding lengthの5120が`text_config.hidden_size`
+      # - 投影器のembedding lengthの1152が`vision_config.hidden_size`
+      # - 投影器のdimensionsの5120が`vision_config.out_hidden_size`
+      #
+      # capabilitiesにもtoolsとthinkingとvisionが揃い、
+      # 投影器はregistry版と同じclipの460.73Mパラメータとして認識される。
+      # `rev`と`hash`で固定しているので、
+      # 配布元が後から差し替えた場合はビルドが壊れて気付ける。
+      #
+      # unslothも同じ量子化を配っているが、
+      # あちらはMTPのドラフトヘッドを`MTP/mtp-*.gguf`として別ファイルに切り出している。
+      # 本体と一緒に`FROM`へ並べると`ollama create`は取り込みこそするものの、
+      # マニフェストに`model`のレイヤーが2つ並ぶ形になり、
+      # ollamaは最後の`model`レイヤーを本体だと解釈する。
+      # bulletではドラフトヘッドが後ろに来て、
+      # 1.28GiBのドラフトを本体としてロードしたllama-serverがsegmentation faultで落ちた。
+      # レイヤーの並びは`FROM`の順番では制御できず、
+      # Modelfileにドラフトを指定する構文も無いため、
+      # 別ファイルのドラフトヘッドは使えない。
+      #
+      # visionはregistry版がマニフェストの別レイヤーとして同梱しているだけなので、
+      # 本体のGGUFを取るだけでは付いてこず、clipの投影器を自分で足す必要がある。
+      # 投影器はunslothのF16を使う。
+      # registry版の投影器も888MiBでF16相当であり、
+      # Jackrongが置いているF32は1.72GiBと倍を占める割に得るものが無い。
+      #
+      # チャットテンプレートはそのままではコーディングエージェントからの入力を弾くので、
+      # `qwen3.8-chat-template.patch`を当てて緩和したものを登録する。
+      # 弾かれる入力と緩和の内容はそのパッチファイルの先頭に書いてある。
+      "qwen3.8-27b-mtp:q6_k" = {
+        sources = [
+          (patchGgufChatTemplate {
+            gguf = fetchHuggingFace {
+              owner = "Jackrong";
+              repo = "Qwen3.8-27B-MTP-GGUF";
+              rev = "422451108d80df4a55ebd66c3416af42a0ce0b0c";
+              file = "Qwen3.8-27B-MTP-Q6_K.gguf";
+              hash = "sha256-0PqUrycPPeQmll8fn29hQKrp9arZuIu0ZkUkknSNUm4=";
+            };
+            patch = ./qwen3.8-chat-template.patch;
+          })
+          (fetchHuggingFace {
+            owner = "unsloth";
+            repo = "Qwen3.8-27B-GGUF";
+            rev = "4ca720788d1e01f1bff70c033e0d0028fd02e502";
+            file = "mmproj-F16.gguf";
+            hash = "sha256-y7hBqe4GNrLsFy9buN8uqN/rAekP58YSZYHWYqC05D4=";
+          })
+        ];
+        parameters = qwenParameters;
+      };
+      # Qwen3.8-27Bをheretic(ARA: Arbitrary-Rank Ablation)で拒否挙動だけ除去したもの。
+      # 単一の拒否方向を引き算する従来のabliterationと違い重み行列を直接最適化するため、
+      # 配布元の計測ではKL divergenceが基のQwen3.8-27Bに対して0.0085と小さく、
+      # 拒否率は99/100から0-1/100まで落ちている。
+      # 素の知能を保ったまま規制だけ外れるので、
+      # 創作用に別途finetuneされたモデルとは性格が違い、
+      # 汎用の受け答えの延長で自由度が欲しい場合に効く。
+      # mtp版を選ぶのは汎用モデルと同じ理由で、
+      # MTPのドラフトヘッドを埋め込んだGGUFはGPUの投機的デコーディングで速度が上がる。
+      # `-multilingual`は配布元が新規のダウンロードに推奨している校正の系統で、
+      # importance matrixが20以上の言語とコードと推論とツール利用の構造を含む。
+      # 英語だけに低ビットの精度予算を寄せないので日本語で使うならこちらになる。
+      # 量子化はq6_kまで上げる。
+      # 配布元のREADMEは24GBのGPUではq6_kを「too tight」としているが、
+      # あれは32GBのGPUを前提にしていない表である。
+      # bulletでの実測(KVキャッシュq8_0, context 131072)では、
+      # q6_kが28.6GiBで100%GPUに載って109.8トークン/秒、
+      # VRAMの空きも2.7GiB残る。
+      # 一段上のq8_0は本体だけで26.63GiBあり、
+      # このcontextでは10GiB近いKVキャッシュと計算バッファを載せる余地が無い。
+      # revを2aff31aから進めたのは配布元がテンプレートを修復したためで、
+      # 古いGGUFはOllamaに`does not support thinking`と拒否されて、
+      # Qwen3.8の思考を使えていなかった。
+      # 言語モデル本体だけではvisionが付かないので、
+      # clipの投影器であるmmprojも一緒に渡す。
+      # 投影器は`ggml-org/Qwen3.8-27B-GGUF`にある公式のものと同一で、
+      # ARAは言語モデル側の層しか触っていないため素の投影器がそのまま噛み合う。
+      #
+      # チャットテンプレートは汎用モデルのものとバイト単位で同一なので、
+      # 同じ`qwen3.8-chat-template.patch`を当てる。
+      # ARAは重みしか触っておらずテンプレートは素のQwen3.8のままだからである。
+      # 今の呼び出し側であるOpen WebUIが弾かれる形を送っているわけではないが、
+      # reasoning effortを明示する経路があれば同じ500に当たる。
+      # 片方だけ緩和されている状態は、
+      # 役割を入れ替えた時に理由の分からない失敗として現れる。
+      "qwen3.8-27b-heretic-rvn:q6_k" = {
+        sources = [
+          (patchGgufChatTemplate {
+            gguf = fetchHuggingFace {
+              owner = "0bserverx";
+              repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
+              rev = "20b94f0613b632b4848bbe3b1e05d9ee0c2b1608";
+              file = "RVN-Q6_K-multilingual-mtp.gguf";
+              hash = "sha256-E0TQdCXXPw0bjzYhORDq6P7CEGGxqQg1kn6EhSOPk6Q=";
+            };
+            patch = ./qwen3.8-chat-template.patch;
+          })
+          (fetchHuggingFace {
             owner = "0bserverx";
             repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
             rev = "20b94f0613b632b4848bbe3b1e05d9ee0c2b1608";
-            file = "RVN-Q6_K-multilingual-mtp.gguf";
-            hash = "sha256-E0TQdCXXPw0bjzYhORDq6P7CEGGxqQg1kn6EhSOPk6Q=";
-          };
-          patch = ./qwen3.8-chat-template.patch;
-        })
-        (fetchHuggingFace {
-          owner = "0bserverx";
-          repo = "Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF";
-          rev = "20b94f0613b632b4848bbe3b1e05d9ee0c2b1608";
-          file = "mmproj-Qwen3.8-27B-Q8_0.gguf";
-          hash = "sha256-LpaKavl8412JcYkLJXubftq/IK2RRQUB+lMWKhnuM+s=";
-        })
-      ];
-      parameters = qwenParameters;
-    };
-    # Mistral Small系は配布元の推奨がQwenと大きく違うので個別に書く。
-    # 配布元のREADMEがollamaとvLLMの実行例で使っている値をそのまま採る。
-    # 学習元のMistral-Small-3.1が低いtemperatureを勧めているためで、
-    # 配布元自身は「そうかもしれないが詳しくは未検証」と断っている。
-    # 創作用途には低すぎると感じたら上げて構わない。
-    "mistralprism-24b:q4_k_m" = {
-      sources = [
-        (fetchHuggingFace {
-          owner = "Aratako";
-          repo = "MistralPrism-24B-GGUF";
-          rev = "ef08191bef153caaa70e0720a8fcfa1cf11fb10b";
-          file = "MistralPrism-24B-Q4_K_M.gguf";
-          hash = "sha256-Tm9H9IXyhqSnPhzA0KZhwU8fNYWyK1XcdRKFGfB0Fdw=";
-        })
-      ];
-      parameters = {
-        min_p = 0.05;
-        temperature = 0.15;
-        top_k = 40;
-        top_p = 0.9;
+            file = "mmproj-Qwen3.8-27B-Q8_0.gguf";
+            hash = "sha256-LpaKavl8412JcYkLJXubftq/IK2RRQUB+lMWKhnuM+s=";
+          })
+        ];
+        parameters = qwenParameters;
+      };
+      # Mistral Small系は配布元の推奨がQwenと大きく違うので個別に書く。
+      # 配布元のREADMEがollamaとvLLMの実行例で使っている値をそのまま採る。
+      # 学習元のMistral-Small-3.1が低いtemperatureを勧めているためで、
+      # 配布元自身は「そうかもしれないが詳しくは未検証」と断っている。
+      # 創作用途には低すぎると感じたら上げて構わない。
+      "mistralprism-24b:q4_k_m" = {
+        sources = [
+          (fetchHuggingFace {
+            owner = "Aratako";
+            repo = "MistralPrism-24B-GGUF";
+            rev = "ef08191bef153caaa70e0720a8fcfa1cf11fb10b";
+            file = "MistralPrism-24B-Q4_K_M.gguf";
+            hash = "sha256-Tm9H9IXyhqSnPhzA0KZhwU8fNYWyK1XcdRKFGfB0Fdw=";
+          })
+        ];
+        parameters = {
+          min_p = 0.05;
+          temperature = 0.15;
+          top_k = 40;
+          top_p = 0.9;
+        };
+      };
+      # 配布元は`temperature = 1.0`と`min_p = 0.1`から始めることを勧めている。
+      # 他は好みで動かせという書き方なので、この2つだけ指定する。
+      "ms3.2-24b-magnum-diamond:q4_k_m" = {
+        sources = [
+          (fetchHuggingFace {
+            owner = "Doctor-Shotgun";
+            repo = "MS3.2-24B-Magnum-Diamond-GGUF";
+            rev = "7422a3599b749c9efa003c53f3165adc71e1f2aa";
+            file = "MS3.2-24B-Magnum-Diamond-Q4_K_M.gguf";
+            hash = "sha256-MLwAq6iPY52EsZwZ2bxVaHHQBGbDJuyc9U7F+Y6PVsQ=";
+          })
+        ];
+        parameters = {
+          min_p = 0.1;
+          temperature = 1.0;
+        };
+      };
+    }
+    // {
+      # RAGの埋め込み用モデル。CUDAの有無に関係なく全てのOllamaホストへ登録する。
+      # Open WebUIからの埋め込み要求はCaddyのフェイルオーバーがホストを選ぶため、
+      # どちらのホストでも同じモデルが引ける必要がある。
+      #
+      # registryのpullではなくGGUFから組むのは`num_gpu 0`を焼き込むためである。
+      # bulletは27Bのチャットモデルを載せると空きVRAMが約2.5GiBしかなく、
+      # 埋め込みモデルを同居させるとデスクトップ用途の描画が押し出されるので、
+      # 埋め込みはCPUに縛る。CPUでもGGUFはtorchのfp32より速い。
+      #
+      # このGGUFが正しい変換であることは、
+      # 精度の実測に使ったregistryのjeffh/intfloat-multilingual-e5-large:q8_0と、
+      # 同じ文書の埋め込みのコサイン一致度が平均・最小とも1.000000であることで確認した。
+      # ref https://github.com/ncaq/blue-prompt/issues/171
+      "multilingual-e5-large:q8_0" = {
+        sources = [
+          (fetchHuggingFace {
+            owner = "soichisumi";
+            repo = "multilingual-e5-large-Q8_0-GGUF";
+            rev = "aefacc2937c5710d215b9d20e1a02f0df0f79555";
+            file = "multilingual-e5-large-q8_0.gguf";
+            hash = "sha256-b8CGpD+p+adm7mZDEuzy8wH/JMifhmxkk25bTFCZs74=";
+          })
+        ];
+        parameters = {
+          num_gpu = 0;
+        };
       };
     };
-    # 配布元は`temperature = 1.0`と`min_p = 0.1`から始めることを勧めている。
-    # 他は好みで動かせという書き方なので、この2つだけ指定する。
-    "ms3.2-24b-magnum-diamond:q4_k_m" = {
-      sources = [
-        (fetchHuggingFace {
-          owner = "Doctor-Shotgun";
-          repo = "MS3.2-24B-Magnum-Diamond-GGUF";
-          rev = "7422a3599b749c9efa003c53f3165adc71e1f2aa";
-          file = "MS3.2-24B-Magnum-Diamond-Q4_K_M.gguf";
-          hash = "sha256-MLwAq6iPY52EsZwZ2bxVaHHQBGbDJuyc9U7F+Y6PVsQ=";
-        })
-      ];
-      parameters = {
-        min_p = 0.1;
-        temperature = 1.0;
-      };
-    };
-  };
   # 全てのアクセラレータの全ての役割に現れるモデル名。
-  declaredModels = lib.concatMap (models: models.general ++ models.freedom) (
-    lib.attrValues modelNames
-  );
+  declaredModels =
+    lib.concatMap (models: models.general ++ models.freedom) [
+      modelNames.cuda
+      modelNames.cpu
+    ]
+    ++ modelNames.embedding;
   # 役割のリストに載っていない`ggufModels`の定義。
   orphanGgufModels = lib.subtractLists declaredModels (lib.attrNames ggufModels);
 in

--- a/nixos/ollama/option.nix
+++ b/nixos/ollama/option.nix
@@ -89,6 +89,21 @@ in
             type = roleType;
             description = "CPUで推論するホストのモデル。";
           };
+
+          embedding = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            description = ''
+              RAGの埋め込みに使うモデル。
+
+              アクセラレータ別にしないのは、
+              Open WebUIの`RAG_EMBEDDING_MODEL`が1つの固定文字列で、
+              リクエストを受けるホストはCaddyのフェイルオーバーが実行時に決めるためである。
+              ホストごとにモデルが違うと、
+              フォールバックした瞬間にモデル不明で失敗するか、
+              埋め込みの空間がずれて検索が壊れる。
+              全ホストで同じ一覧を共有することでこの食い違いを型の上で塞ぐ。
+            '';
+          };
         };
       };
       readOnly = true;
@@ -124,10 +139,12 @@ in
       readOnly = true;
       default =
         with config.local.ollama;
-        lib.subtractLists (lib.attrNames ggufModels) (hostModels.general ++ hostModels.freedom);
+        lib.subtractLists (lib.attrNames ggufModels) (
+          hostModels.general ++ hostModels.freedom ++ models.embedding
+        );
       defaultText = lib.literalExpression ''
         lib.subtractLists (lib.attrNames ggufModels)
-          (hostModels.general ++ hostModels.freedom)
+          (hostModels.general ++ hostModels.freedom ++ models.embedding)
       '';
       description = ''
         Ollama registryからpullするモデル。


### PR DESCRIPTION
Open WebUIの埋め込みをコンテナ内のsentence-transformersから、
`RAG_EMBEDDING_ENGINE = "ollama"`へ切り替えます。
モデルは現行と同じmultilingual-e5-largeのq8_0です。

blue-promptのKnowledge 10011チャンクと20問の実測で、
以下を確認した上での切り替えです。

- 同じモデルならエンジン差は検索精度に効かない。
  torchのfp32とGGUFのq8_0でtop3命中率もMRRも変わらず、
  文書ベクトルのコサイン一致度は平均0.9996だった
- GGUFのCPU推論はtorchのfp32よりbulletで約2.5倍、seminarでも約1.8倍速い
- 量子化はq8_0にする。f16と精度が変わらない一方で、
  帯域で頭打ちになる6コアのseminarではq8_0の方が速い

埋め込みの役割は`models.embedding`としてcuda/cpuと独立に宣言します。
`RAG_EMBEDDING_MODEL`は1つの固定文字列で、
リクエストを受けるホストはCaddyのフェイルオーバーが実行時に決めるため、
ホストごとにモデルが違うと退避した瞬間に壊れます。
全ホストで同じ一覧を共有する形にして食い違いを型の上で塞ぎます。

GGUFはregistryのpullではなくHugging Faceからrev固定で取得して、
`PARAMETER num_gpu 0`を焼き込んで登録します。
bulletは27Bのチャットモデルを載せると空きVRAMが約2.5GiBしかなく、
埋め込みモデルを同居させるとデスクトップ用途の描画が押し出されるため、
埋め込みはCPUに縛ります。
このGGUFは精度の実測に使ったregistryのGGUFと、
同じ文書の埋め込みのコサイン一致度が平均・最小とも1.000000であることを確認済みです。

接続先は`RAG_OLLAMA_BASE_URL`が`OLLAMA_BASE_URL`へフォールバックするため、
チャットと同じbullet優先のフェイルオーバーをそのまま通ります。

適用と検証は両ホストで実施済みです。

- コンテナの再起動でモデルが両ホストへ登録される
- `/api/v1/retrieval/reset/db`からの同期し直しが46分8秒で272コレクションを登録し終える
- 同期中の埋め込みはbulletで100% CPUのまま処理され、GPUには載らない
- 検索クエリが正しい断片を0.2秒程度で返す

ref https://github.com/ncaq/blue-prompt/issues/171
ref https://github.com/ncaq/blue-prompt/issues/196