### PR TITLE
refactor: niks3とComfyUIの更新に合わせて宣言を実態へ揃えます

### DIFF
--- a/nixos/core/nix-daemon.nix
+++ b/nixos/core/nix-daemon.nix
@@ -12,11 +12,9 @@
       substituters = [
         "https://cache.nixos.org/"
         "https://niks3-public.ncaq.net/"
-        # niks3はnix-cache-infoにPriority 30をハードコードしており、
-        # niks3-publicと同値で優先順位が決まりません。
         # tailnet経由のniks3-privateの方が高速なため、
-        # `?priority`で明示的にpublicより高優先(数値が小さいほど高優先)にします。
-        "https://seminar.border-saurolophus.ts.net:8443/niks3/private/?priority=20"
+        # `services.niks3.priority`でniks3-publicより高優先にしています。
+        "https://seminar.border-saurolophus.ts.net:8443/niks3/private/"
         "https://ncaq.cachix.org/"
         "https://nix-community.cachix.org/"
       ];

--- a/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
+++ b/nixos/host/bullet/comfyui/workflow/anime-video-extend.nix
@@ -257,7 +257,8 @@ in
           ])
           (mkOutput "audio" "AUDIO" [ ])
           (mkOutput "fps" "FLOAT" [ ])
-          (mkOutput "bit_depth" "INT" [ ])
+          (mkOutput "bit_depth" "COMBO" [ ])
+          (mkOutput "color_space" "COMBO" [ ])
         ];
       })
       # batch_index -1は末尾からの参照。

--- a/nixos/host/seminar/niks3-private.nix
+++ b/nixos/host/seminar/niks3-private.nix
@@ -96,6 +96,10 @@ in
             cacheUrl = "https://seminar.border-saurolophus.ts.net:8443/niks3/private/";
             # readはTailscaleネットワーク認証、writeはAPIトークン認証。
             readProxy.enable = true;
+            # nix-cache-infoで広告する優先順位(数値が小さいほど高優先)。
+            # tailnet経由のこちらの方がniks3-public(デフォルトの30)より高速なため、
+            # クライアント側でsubstituterの順序に依存せず選ばれるようにします。
+            priority = 20;
           };
         };
       };

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -93,15 +93,28 @@ in
             apiTokenFile = "/run/niks3-public/api-token";
             signKeyFiles = [ "/run/niks3-public/sign-key" ];
             cacheUrl = "https://niks3-public.ncaq.net";
-            # publicバケットですがGarage S3 APIが匿名読み取りを未サポートのため、
-            # niks3のread proxy経由で配信しています。
-            # Garage v3.0で匿名アクセスが実装予定のようです。
-            # [Allow anonymous access on the S3 endpoint](https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/263)
-            # よって実装されたらS3直接読み取りを有効化して性能を改善する予定です。
-            # 互換性のためread proxyは残したままにするかもしれませんが。
-            # 今でもweb endpointを使えば匿名アクセスは可能かもしれませんが、
-            # 正規の方法で匿名アクセスが実装予定なのにそういったトリッキーなことはしたくありません。
-            readProxy.enable = true;
+            readProxy = {
+              # publicバケットですがGarage S3 APIが匿名読み取りを未サポートのため、
+              # niks3のread proxy経由で配信しています。
+              # Garage v3.0で匿名アクセスが実装予定のようです。
+              # [Allow anonymous access on the S3 endpoint](https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/263)
+              # よって実装されたらS3直接読み取りを有効化して性能を改善する予定です。
+              # 互換性のためread proxyは残したままにするかもしれませんが。
+              # 今でもweb endpointを使えば匿名アクセスは可能かもしれませんが、
+              # 正規の方法で匿名アクセスが実装予定なのにそういったトリッキーなことはしたくありません。
+              enable = true;
+              # NARの実バイトをniks3でストリーミングせず、
+              # presigned S3 URLへの307リダイレクトで返します。
+              # narinfoなどのメタデータは従来通りread proxyを経由します。
+              # publicバケットなので、
+              # presigned URLが第三者に渡っても隠すべき内容はありません。
+              # niks3-public.ncaq.netもgarage.ncaq.netも同じCloudflare Tunnel経由のため、
+              # リダイレクト分の往復が増える代わりにniks3のストリーミング処理が省けます。
+              # どちらが速いかは経路の性質上読めないので、
+              # 実際のsubstituteの速度を見て継続するか判断します。
+              # niks3-private側はtailnet直結が失われるため有効にしていません。
+              redirectTTL = "15m";
+            };
             oidc.providers.github = {
               issuer = "https://token.actions.githubusercontent.com";
               audience = "https://niks3-public.ncaq.net";

--- a/nixos/host/seminar/niks3-public.nix
+++ b/nixos/host/seminar/niks3-public.nix
@@ -93,28 +93,15 @@ in
             apiTokenFile = "/run/niks3-public/api-token";
             signKeyFiles = [ "/run/niks3-public/sign-key" ];
             cacheUrl = "https://niks3-public.ncaq.net";
-            readProxy = {
-              # publicバケットですがGarage S3 APIが匿名読み取りを未サポートのため、
-              # niks3のread proxy経由で配信しています。
-              # Garage v3.0で匿名アクセスが実装予定のようです。
-              # [Allow anonymous access on the S3 endpoint](https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/263)
-              # よって実装されたらS3直接読み取りを有効化して性能を改善する予定です。
-              # 互換性のためread proxyは残したままにするかもしれませんが。
-              # 今でもweb endpointを使えば匿名アクセスは可能かもしれませんが、
-              # 正規の方法で匿名アクセスが実装予定なのにそういったトリッキーなことはしたくありません。
-              enable = true;
-              # NARの実バイトをniks3でストリーミングせず、
-              # presigned S3 URLへの307リダイレクトで返します。
-              # narinfoなどのメタデータは従来通りread proxyを経由します。
-              # publicバケットなので、
-              # presigned URLが第三者に渡っても隠すべき内容はありません。
-              # niks3-public.ncaq.netもgarage.ncaq.netも同じCloudflare Tunnel経由のため、
-              # リダイレクト分の往復が増える代わりにniks3のストリーミング処理が省けます。
-              # どちらが速いかは経路の性質上読めないので、
-              # 実際のsubstituteの速度を見て継続するか判断します。
-              # niks3-private側はtailnet直結が失われるため有効にしていません。
-              redirectTTL = "15m";
-            };
+            # publicバケットですがGarage S3 APIが匿名読み取りを未サポートのため、
+            # niks3のread proxy経由で配信しています。
+            # Garage v3.0で匿名アクセスが実装予定のようです。
+            # [Allow anonymous access on the S3 endpoint](https://git.deuxfleurs.fr/Deuxfleurs/garage/issues/263)
+            # よって実装されたらS3直接読み取りを有効化して性能を改善する予定です。
+            # 互換性のためread proxyは残したままにするかもしれませんが。
+            # 今でもweb endpointを使えば匿名アクセスは可能かもしれませんが、
+            # 正規の方法で匿名アクセスが実装予定なのにそういったトリッキーなことはしたくありません。
+            readProxy.enable = true;
             oidc.providers.github = {
               issuer = "https://token.actions.githubusercontent.com";
               audience = "https://niks3-public.ncaq.net";


### PR DESCRIPTION
lock file maintenanceのレビューで指摘された、
依存の更新によって実態と食い違ったままになっている宣言を直します。

## キャッシュ優先順位をサーバ側で宣言する

substituterのURLに`?priority=20`を付けて、
クライアント側から優先順位を上書きする回避策をやめます。

この回避策はniks3がnix-cache-infoのPriorityを30に固定していた頃のものでした。
niks3 v1.9.0でサーバに`--cache-priority`と対応するNixOSオプションが入ったため、
前提が成立しなくなっています。
niks3-privateの`services.niks3.priority`で宣言する形にして、
宣言的ファーストの原則に揃えます。

tailnet経由のniks3-privateをniks3-publicより高優先にする意図自体は変わりません。

## GetVideoComponentsの出力宣言を合わせる

ComfyUI v0.34.0で`GetVideoComponents`の出力スキーマが変わり、
`bit_depth`が`io.Int.Output`から`io.Combo.Output`になった上で、
末尾に`color_space`が追加されています。

`anime-video-extend`のノード定義は出力4個で`bit_depth`を`INT`としたままでした。
未接続かつ末尾追加のため実行時に壊れる経路はありませんが、
将来`bit_depth`を接続する時に噛み合わないので今のうちに揃えます。

## read proxyのpresigned URLリダイレクトは採用しない

同じく指摘のあった`readProxy.redirectTTL`は、
実際に有効にして計測した結果を残した上で取り消しています。
このPRとしては差分ゼロです。

`niks3-public.ncaq.net`のNARはCloudflareのエッジにキャッシュされており、
オリジンのseminarまで届かずに配信されていました。
リダイレクトを有効にするとniks3は307と`cache-control: no-store`を返すため、
Cloudflareはこのレスポンスをキャッシュできません。
リダイレクト先のpresigned URLもクエリに署名が入って毎回変わるので、
そちらもキャッシュキーが一致しません。

bulletから120MB前後のNARを3種類3回ずつ取得した実測値です。

- CDNキャッシュあり(リダイレクトなし): 平均0.418秒、292.8MB/s
- CDNキャッシュを迂回してniks3がストリーミング: 平均1.637秒、72.3MB/s
- CDNキャッシュを迂回してpresigned URLへリダイレクト: 平均1.834秒、66.6MB/s

オリジンまで到達した場合の速度はほぼ互角で、
リダイレクトの方が往復が増える分わずかに遅い結果でした。
決定的なのはキャッシュの可否で、
同じURLへの2回目のアクセスがリダイレクト有効時は`cf-cache-status: MISS`のままなのに対し、
無効時は`HIT`になって約4倍の速度が出ます。

seminarのCPUはNARのストリーミング程度では逼迫していないため、
niks3の負荷を下げる代わりにCDNキャッシュを捨てる交換は割に合いません。

## 確認したこと

seminarとbulletの両方へ適用済みです。

- niks3-privateがPriority 20、niks3-publicがPriority 30をnix-cache-infoで広告すること
- bulletの`/etc/nix/nix.conf`のsubstituterからクエリが消えて素のURLになること
- 最終状態のniks3-publicが307ではなく200を返し、2回目のアクセスで`cf-cache-status: HIT`に戻ること

ref https://github.com/ncaq/dotfiles/pull/1549

https://claude.ai/code/session_01Fc3pZbmatNS7PYRJvTKrcp